### PR TITLE
Correct GS titles, promote head

### DIFF
--- a/doc/getting-started-guides/macros.md
+++ b/doc/getting-started-guides/macros.md
@@ -47,7 +47,7 @@ In this section you set up a basic build script and then create a simple applica
 
 > **Note:** If you are new to Android projects, before you proceed, refer to [Installing the Android Development Environment](../gs-android/README.md) to help you configure your development environment. 
 
-You can use any build system you like when building apps with Spring, but the code you need to work with [Maven](https://maven.apache.org) and [Gradle](http://gradle.org) is included here. If you're not familiar with either, refer to [Building Java Projects with Maven](../gs-maven-android/README.md) or [Building Java Projects with Gradle](../gs-gradle-android/README.md).
+You can use any build system you like when building apps with Spring, but the code you need to work with [Maven](https://maven.apache.org) and [Gradle](http://gradle.org) is included here. If you're not familiar with either, refer to [Building Android Projects with Maven](../gs-maven-android/README.md) or [Building Android Projects with Gradle](../gs-gradle-android/README.md).
  
 </#macro>
 


### PR DESCRIPTION
@Roy
-In build_system_intro and android_build_system intro,
corrected names of Maven, Gradle, and Android GS guides.
-In build_an_executable_jar, promoted heading level. Looking at this head in gs-consuming-rest, it looks like it should be higher level, or can be; i.e. it doesn't have to be a subhead of  "Create a main class."  Weird to have only one low-level head below a higher level head.
