### PR TITLE
Update manifest to use new buildpack

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -6,12 +6,11 @@ applications:
   host: sagan
   domain: cfapps.io
   path: target/springframework-site-0.0.1.SNAPSHOT.jar
-  command: chmod +x *.sh && ./main.sh --server.port=$PORT --spring.profiles.active=$SPRING_PROFILE
+  buildpack: https://github.com/cloudfoundry/java-buildpack
 - name: sagan-indexer
   memory: 2G
   instances: 1
   host: sagan-indexer
   domain: cfapps.io
   path: target/springframework-site-0.0.1.SNAPSHOT.jar
-  command: chmod +x *.sh && ./main.sh --server.port=$PORT --spring.profiles.active=$SPRING_PROFILE
-
+  buildpack: https://github.com/cloudfoundry/java-buildpack

--- a/src/main/resources/main.sh
+++ b/src/main/resources/main.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-# Use spring.profiles.active to switch between main site and indexer app, e.g.
-# --spring.profiles.active=indexer for indexer.  Site runs in default and site profiles.
-
-java -Xmx1260m -XX:MaxPermSize=512m -classpath "." org.springframework.boot.loader.JarLauncher $*


### PR DESCRIPTION
Previously the manifest for this application was configured such that
it used a custom command to start itself (based on Spring Boot).  This
change removes that custom command and substitutes in the new Java
buildpack which takes care of all of the things that command
previously did.  A byproduct of this is that as improvements are made
to the main buildpack they will automatically get included in future
pushes of the application.  An example of this is that now, if a New
Relic service is bound to the application, the application will
automatically be configured to use it.

A couple of notes about the commit:
1.  This commit points at a [buildpack fork](https://github.com/nebhale/sagan-java-buildpack).  This fork sets the `--server.port` argument when executing the application.  I'd like to transfer ownership of this fork to the springframework-meta organization (which would then require a change to the buildpack URL).
2.  This commit also does away with the setting of the `--spring.profiles.active=` argument, instead opting to use the Spring native support for  the `SPRING_PROFILES_ACTIVE` environment variable.  I have verified that this does indeed work, but the change will need to be made before the next push of the application.

[#54518830]
