### PR TITLE
Add liquibase SLF4J bridge

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,6 +186,11 @@
             <artifactId>liquibase-core</artifactId>
             <version>3.0.2</version>
         </dependency>
+        <dependency>
+            <groupId>com.mattbertolini</groupId>
+            <artifactId>liquibase-slf4j</artifactId>
+            <version>1.1.0</version>
+        </dependency>
 
     </dependencies>
 


### PR DESCRIPTION
Add a bridge between liquibase and SLF4J to ensure liquibase log
output is handled via Spring Boot.
