### PR TITLE
Restrict GitHub OAuth Scope

### DIFF
--- a/src/main/java/io/spring/site/web/configuration/GitHubConfiguration.java
+++ b/src/main/java/io/spring/site/web/configuration/GitHubConfiguration.java
@@ -30,9 +30,7 @@ public class GitHubConfiguration {
 
 	@Bean
 	public GitHubConnectionFactory gitHubConnectionFactory() {
-		GitHubConnectionFactory factory = new GitHubConnectionFactory(githubClientId, githubClientSecret);
-		factory.setScope("user");
-		return factory;
+		return new GitHubConnectionFactory(githubClientId, githubClientSecret);
 	}
 
 	@Bean


### PR DESCRIPTION
- [x] @cbeams to revert OAuth scope change per https://github.com/spring-io/sagan/pull/30#issuecomment-30424336

---

Previously, the `spring.io` application required `user` scope when authenticating against GitHub.  This scope gives the application write access to a user's profile, followers, and private email addresses. As the application does not need this access (it only needs to do a simple username verification), this change reduces the scope to its lowest possible level.  The [`(no scope)` scope](http://developer.github.com/v3/oauth/#scopes) grants only read access to public data.

**Note**:  I'd be quite surprised if your testing uses a fake GitHub that is so sophisticated it replicates the real OAuth scope/permissions model.  Before this change goes live you should probably check this against a real GitHub instance to ensure that it doesn't break anything.

[#55290634]
