### PR TITLE
Fix accidental zoom interactions on team map

### DIFF
--- a/src/main/resources/static/js/application.js
+++ b/src/main/resources/static/js/application.js
@@ -118,7 +118,7 @@ $(function () {
       $(".viewport").height(deviceHeight).addClass("constrained");
     }
   }, false);
-  
+
   $(".js-open-nav-drawer").click(function() {
     $(".navigation-drawer--container").addClass("js-open");
     $(".mobile-nav, .body--container, .homepage--body").addClass("js-slide-right");
@@ -132,7 +132,7 @@ $(function () {
       $(".viewport").removeClass("constrained");
     });
   });
-  
+
   var initializeFacetSearchWidget = function () {
     var searchFacet = $(".search-facets");
     if (!searchFacet.length) {
@@ -166,12 +166,12 @@ $(function () {
           function firstCheckbox(context) {
             context.siblings(".facet--wrapper").find("input[type='checkbox']").first().prop('checked', false);
           }
-          // UNCHECKES HIGHEST PARENT 
+          // UNCHECKES HIGHEST PARENT
           firstCheckbox($(this).parents(".sub-facet--list"));
 
           // UNCHECKS CLOSEST PARENT
           firstCheckbox($(this).closest(".sub-facet--list"));
-          
+
           // UNCHECKS ALL CHILDRED
           $(this).parents(".facet--wrapper").siblings(".sub-facet--list, .facet-section--header").find("input[type='checkbox']").prop('checked', false);
 
@@ -195,12 +195,12 @@ $(function () {
       });
 
 
-      
+
       if ($(".projects-facet input[type='checkbox']:checked").length) {
         $(".facet-section--header").removeClass("js-close");
         $(".projects-facet .sub-facet--list").first().removeClass("js-close");
       }
-      
+
       $(".facets--clear-filters").click(function() {
         $(".facet--wrapper input[type='checkbox']:checked").prop('checked', false);
         $(".sub-facet--list, .facet-section--header").addClass("js-close");
@@ -208,13 +208,6 @@ $(function () {
     }
   }
   initializeFacetSearchWidget();
-
-  $(".js-team-map--wrapper").mouseenter(function() {
-    $(".js-team-map--container").fadeOut("100");
-    $(".js-team-map--wrapper").mouseleave(function() {
-      $(".js-team-map--container").fadeIn("100");
-    });
-  });
 });
 
 

--- a/src/main/resources/static/js/team.js
+++ b/src/main/resources/static/js/team.js
@@ -1,7 +1,10 @@
 window.Spring = window.Spring || {};
 
 Spring.CreateMap = function () {
-    var map = L.map('map').setView([51.505, -0.09], 2);
+    var map = L.map('map', {
+        scrollWheelZoom: false,
+        touchZoom: false
+    }).setView([51.505, -0.09], 2);
     L.tileLayer('http://{s}.tile.cloudmade.com/dc6ad76c483d4e5c92152aa34375ec28/1/256/{z}/{x}/{y}.png', {
         attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery © <a href="http://cloudmade.com">CloudMade</a>',
         maxZoom: 18
@@ -27,5 +30,16 @@ Spring.CreateMap = function () {
         var latLng = new L.LatLng(teamLocations[0].latitude, teamLocations[0].longitude);
         map.setView(latLng, 5);
     }
+
+    $(".js-team-map--wrapper").click(function() {
+        map.scrollWheelZoom.enable();
+        map.touchZoom.enable();
+        $(".js-team-map--container").fadeOut("100");
+        $(".js-team-map--wrapper").mouseleave(function() {
+            map.scrollWheelZoom.disable();
+            map.touchZoom.disable();
+            $(".js-team-map--container").fadeIn("100");
+        });
+      });
 
 };


### PR DESCRIPTION
Update the team map so that zoom interactions only occur when the map
has been clicked. This change also updates the 'The Spring Team' banner
text so that it disappears on click, rather than on focus change.
