### PR TITLE
Updated version numbers for Spring Data Arora SR3.

### DIFF
--- a/src/main/resources/project-metadata.yml
+++ b/src/main/resources/project-metadata.yml
@@ -77,9 +77,9 @@ projects:
       apiDocUrl: /spring-data/jpa/docs/{version}/api/
       supportedVersions:
         - 1.5.0.BUILD-SNAPSHOT
+        - 1.4.2.BUILD-SNAPSHOT
         - 1.4.1.RELEASE
-        - 1.3.5.BUILD-SNAPSHOT
-        - 1.3.4.RELEASE
+        - 1.3.5.RELEASE
 
     - id: spring-data-commons
       name: Spring Data Commons
@@ -89,9 +89,9 @@ projects:
       apiDocUrl: /spring-data/data-commons/docs/{version}/api/
       supportedVersions:
         - 1.7.0.BUILD-SNAPSHOT
+        - 1.6.2.BUILD-SNAPSHOT
         - 1.6.1.RELEASE
-        - 1.5.3.BUILD-SNAPSHOT
-        - 1.5.2.RELEASE
+        - 1.5.3.RELEASE
 
     - id: spring-data-jdbc-ext
       name: Spring Data JDBC Extensions
@@ -111,9 +111,9 @@ projects:
       apiDocUrl: /spring-data/data-mongo/docs/{version}/api/
       supportedVersions:
         - 1.4.0.BUILD-SNAPSHOT
+        - 1.3.2.BUILD-SNAPSHOT
         - 1.3.1.RELEASE
-        - 1.2.4.BUILD-SNAPSHOT
-        - 1.2.3.RELEASE
+        - 1.2.4.RELEASE
 
     - id: spring-data-neo4j
       name: Spring Data Neo4J
@@ -124,9 +124,9 @@ projects:
       apiDocUrl: /spring-data/data-neo4j/docs/{version}/api/
       supportedVersions:
         - 2.4.0.BUILD-SNAPSHOT
+        - 2.3.2.BUILD-SNAPSHOT
         - 2.3.1.RELEASE
-        - 2.2.3.BUILD-SNAPSHOT
-        - 2.2.2.RELEASE
+        - 2.2.3.RELEASE
 
     - id: spring-data-redis
       name: Spring Data Redis


### PR DESCRIPTION
Removed snapshot versions for Arora as SR3 is the last service release.
Added snapshots for upcoming Babbage service releases.
