### PR TITLE
CSS fix for /platform page on Firefox

### DIFF
--- a/src/main/resources/static/css/main.css
+++ b/src/main/resources/static/css/main.css
@@ -1390,6 +1390,11 @@ form.lpeRegForm .mktInput {
   width: 24.153%;
   margin: 40px 1% 40px 0;
 }
+@-moz-document url-prefix() {
+  .platform-project .project--container {
+    width: 22%;
+  }
+}
 .platform-project .project--container:last-child {
   margin-right: 0;
 }


### PR DESCRIPTION
- Project containers were wrapping to next row
