### PR TITLE
Update Spring Security documentation location

### DIFF
--- a/src/main/resources/project-metadata.yml
+++ b/src/main/resources/project-metadata.yml
@@ -294,7 +294,7 @@ projects:
           refDocUrl: /spring-security/site/docs/{version}/reference/html/
           apiDocUrl: /spring-security/site/docs/{version}/apidocs/
         - name: 3.2.0.CI-SNAPSHOT
-          refDocUrl: /spring-security/site/docs/{version}/reference/html/
+          refDocUrl: /spring-security/site/docs/{version}/reference/html5/
           apiDocUrl: /spring-security/site/docs/{version}/apidocs/
 
     - id: spring-security-oauth


### PR DESCRIPTION
This updates the Spring Security documentation location to use the asciidoctor location
