### PR TITLE
Add basic buster setup for node-based JavaScript unit tests.

### DIFF
--- a/sagan-js/package.json
+++ b/sagan-js/package.json
@@ -5,14 +5,14 @@
 		"cram": "~0"
 	},
 	"devDependencies": {
-		"buster": "~0.6",
+		"buster": "~0.7",
 		"bower": "~1"
 	},
 	"directories": {
 		"test": "test"
 	},
 	"scripts": {
-		"test": "buster test -e node",
+		"test": "buster-test -e node",
 		"prepublish": "bower install"
 	}
 }

--- a/sagan-js/test/README.md
+++ b/sagan-js/test/README.md
@@ -1,0 +1,13 @@
+# JavaScript Tests
+
+This directory contains JavaScript unit tests and functional scenario tests, both of which are driven by the [Buster.JS](http://busterjs.org) testing framework.  The functional tests also require a [Selenium](http://www.seleniumhq.org) server.
+
+## Unit tests
+
+Tests live in the `unit` directory in a parallel structure to the sources (which are in src/main/resources/static for now).  Run the unit tests from the *root dir* of the project:
+
+`npm test`
+
+## Functional Scenario Tests
+
+*Coming Soon*

--- a/sagan-js/test/buster-spec-expose.js
+++ b/sagan-js/test/buster-spec-expose.js
@@ -1,0 +1,5 @@
+(function(global) {
+  var buster = require('buster');
+  buster.spec.expose();
+  global.expect = buster.expect;
+}(typeof window === 'undefined' && typeof global !== 'undefined' ? global : this));

--- a/sagan-js/test/buster.js
+++ b/sagan-js/test/buster.js
@@ -1,0 +1,13 @@
+/**
+ * Buster.JS configuration for JavaScript unit and
+ * functional scenario tests.
+ */
+
+require('./buster-spec-expose');
+
+// Basic unit test configuration for tests that can run
+// in node (i.e. no DOM requirements)
+exports.unit = {
+	environment: 'node',
+	tests: ['unit/*-spec.js', 'unit/**/*-spec.js']
+};

--- a/sagan-js/test/unit/example-spec.js
+++ b/sagan-js/test/unit/example-spec.js
@@ -1,0 +1,33 @@
+/**
+ * A couple of version simple buster describe/expect-style
+ * tests, one sync, one async.  Async tests may also return
+ * a promise that fulfills to indicate success, or rejects
+ * to indicate failure.  When using promises, DO NOT accept
+ * the `done` parameter to the it() callback.
+ */
+
+describe('example test', function() {
+	describe('when expectations are met', function() {
+		it('passes', function() {
+			expect(true).toBeTrue();
+		});
+	});
+
+	describe('when test is async', function() {
+		describe('and expectations are met', function() {
+			it('passes using done()', function(done) {
+				setTimeout(function() {
+					expect(true).toBeTrue();
+					done();
+				});
+			});
+
+			// Example of using a promise instead of done()
+			// it('passes returning a promise', function(/* DO NOT use done */) {
+				// Do some testing
+				// and eventually:
+				// return promise;
+			// });
+		});
+	});
+});


### PR DESCRIPTION
This adds a simple buster config, an npm test command to point to the
right spot to run buster, and a simple example unit test to show
how to write tests using buster's describe/expect style.  I created
a simple helper that exposes the basic spec style dsl globally,
including expect().  We'll have to decide whether we want to stick
to that path (globalizing the spec dsl) or not.

[Finishes #58337924]
