### PR TITLE
Add jshint linting on all sagan-js src and test files

### DIFF
--- a/sagan-js/.jshintignore
+++ b/sagan-js/.jshintignore
@@ -1,0 +1,5 @@
+node_modules/
+.git/
+.idea/
+dev/lib
+build/

--- a/sagan-js/.jshintrc
+++ b/sagan-js/.jshintrc
@@ -1,0 +1,28 @@
+{
+	"browser": true,
+	"node": true,
+
+	"globals": {
+		"define": true
+	},
+
+	"boss": true,
+	"curly": true,
+	"eqnull": true,
+	"expr": true,
+	"globalstrict": false,
+	"laxbreak": true,
+	"newcap": true,
+	"noarg": true,
+	"noempty": true,
+	"nonew": true,
+	"quotmark": "single",
+	"strict": false,
+	"sub": true,
+	"trailing": true,
+	"undef": true,
+	"unused": true,
+
+	"maxdepth": 3,
+	"maxcomplexity": 5
+}

--- a/sagan-js/dev/run.js
+++ b/sagan-js/dev/run.js
@@ -1,3 +1,4 @@
+/*global curl,baseUrl*/
 (function (curl, baseUrl) {
 
     var cjsConfig = {
@@ -14,7 +15,7 @@
 
     curl(['app/main']).then(start, fail);
 
-    function start (main) {
+    function start (/*main*/) {
         // TODO: are there any startup tasks at this level?
         console.log('it runs!');
     }

--- a/sagan-js/package.json
+++ b/sagan-js/package.json
@@ -6,13 +6,14 @@
 	},
 	"devDependencies": {
 		"buster": "~0.7",
-		"bower": "~1"
+		"bower": "~1",
+    "jshint": "~2.1"
 	},
 	"directories": {
 		"test": "test"
 	},
 	"scripts": {
-		"test": "buster-test -e node",
+		"test": "jshint . && buster-test -e node",
 		"prepublish": "bower install"
 	}
 }

--- a/sagan-js/test/.jshintrc
+++ b/sagan-js/test/.jshintrc
@@ -1,0 +1,7 @@
+{
+    "globals": {
+        "describe": true,
+        "it": true,
+        "expect": true
+    }
+}


### PR DESCRIPTION
Fixed existing jshint warnings as well, so we're starting with a clean slate.  I used a slightly tweaked version of the jshintrc that we use in cujoJS, which I also updated to be friendly with the very latest jshint 2.1.x version.  The test subdir uses an additional jshintrc to further specialize the globals we've exposed for buster's `describe`-style test dsl.

[Finishes #58904152]
