### PR TITLE
Add AsciiDoc support for getting started guides

### DIFF
--- a/sagan-common/build.gradle
+++ b/sagan-common/build.gradle
@@ -36,6 +36,10 @@ dependencies {
     compile 'joda-time:joda-time:2.3'
     compile 'org.hibernate:hibernate-validator:4.3.1.Final'
 
+    // AsciiDoc compilation in-house, since GitHub doesn't provide a service
+    compile 'org.asciidoctor:asciidoctor-java-integration:0.1.4'
+    compile 'org.apache.ivy:ivy:2.3.0'
+
     testUtilCompile "junit:junit:${vJunit}"
     testUtilCompile sourceSets.main.output
     testUtilCompile configurations.compile

--- a/sagan-common/src/main/java/sagan/guides/service/UnderstandingGuidesService.java
+++ b/sagan-common/src/main/java/sagan/guides/service/UnderstandingGuidesService.java
@@ -30,7 +30,7 @@ public class UnderstandingGuidesService {
 
     private String getContent(String subject) {
         try {
-            return this.gitHubService.getRawFileAsHtml(String.format(CONTENT_PATH, subject.toLowerCase()));
+            return this.gitHubService.getMarkdownFileAsHtml(String.format(CONTENT_PATH, subject.toLowerCase()));
         } catch (RestClientException e) {
             String msg = String.format("No getting started guide found for '%s'", subject);
             throw new UnderstandingGuideNotFoundException(msg, e);
@@ -39,7 +39,7 @@ public class UnderstandingGuidesService {
 
     private String getSidebar(String subject) {
         try {
-            return this.gitHubService.getRawFileAsHtml(String.format(SIDEBAR_PATH, subject.toLowerCase()));
+            return this.gitHubService.getMarkdownFileAsHtml(String.format(SIDEBAR_PATH, subject.toLowerCase()));
         } catch (RestClientException e) {
             return "";
         }

--- a/sagan-common/src/main/java/sagan/util/service/github/DownloadConverter.java
+++ b/sagan-common/src/main/java/sagan/util/service/github/DownloadConverter.java
@@ -1,0 +1,44 @@
+package sagan.util.service.github;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpOutputMessage;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.http.converter.HttpMessageNotWritableException;
+import org.springframework.util.StreamUtils;
+
+public class DownloadConverter implements HttpMessageConverter<byte[]> {
+
+    public List<MediaType> getSupportedMediaTypes() {
+        return Collections
+                .singletonList(new MediaType("application", "vnd.github.v3.raw"));
+    }
+
+    @Override
+    public byte[] read(Class<? extends byte[]> clazz, HttpInputMessage inputMessage)
+            throws IOException, HttpMessageNotReadableException {
+        return StreamUtils.copyToByteArray(inputMessage.getBody());
+    }
+
+    @Override
+    public boolean canRead(Class<?> clazz, MediaType mediaType) {
+        return byte[].class.equals(clazz);
+    }
+
+    @Override
+    public boolean canWrite(Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    public void write(byte[] download, MediaType contentType,
+                      HttpOutputMessage outputMessage) throws IOException,
+            HttpMessageNotWritableException {
+        throw new UnsupportedOperationException("can't write");
+    }
+}

--- a/sagan-common/src/main/java/sagan/util/service/github/GitHubConfiguration.java
+++ b/sagan-common/src/main/java/sagan/util/service/github/GitHubConfiguration.java
@@ -48,6 +48,7 @@ public class GitHubConfiguration {
             List<HttpMessageConverter<?>> converters = new ArrayList<>();
             converters.add(new JsonStringConverter());
             converters.add(new MarkdownHtmlConverter());
+            converters.add(new DownloadConverter());
             converters.add(new StringHttpMessageConverter(Charset.forName("UTF-8")));
             return converters;
         }

--- a/sagan-common/src/main/java/sagan/util/service/github/GitHubRestClient.java
+++ b/sagan-common/src/main/java/sagan/util/service/github/GitHubRestClient.java
@@ -23,6 +23,11 @@ public class GitHubRestClient {
         return cachedRestClient.get(gitHub.restOperations(), url, String.class);
     }
 
+    public byte[] sendRequestForDownload(String path, Object... uriVariables) {
+        String url = resolveUrl(path, uriVariables);
+        return cachedRestClient.get(gitHub.restOperations(), url, byte[].class);
+    }
+
     public String sendRequestForHtml(String path, Object... uriVariables) {
         String url = resolveUrl(path, uriVariables);
         MarkdownHtml markdownHtml = cachedRestClient.get(gitHub.restOperations(), url, MarkdownHtml.class);

--- a/sagan-common/src/main/java/sagan/util/service/github/Readme.java
+++ b/sagan-common/src/main/java/sagan/util/service/github/Readme.java
@@ -1,0 +1,16 @@
+package sagan.util.service.github;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Readme {
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/sagan-common/src/test-util/resources/fixtures/github/gs-rest-service-readme.json
+++ b/sagan-common/src/test-util/resources/fixtures/github/gs-rest-service-readme.json
@@ -1,0 +1,17 @@
+{
+    "type": "file",
+    "encoding": "base64",
+    "size": 5362,
+    "name": "README.md",
+    "path": "README.md",
+    "content": "encoded content ...",
+    "sha": "3d21ec53a331a6f037a91c368710b99387d012c1",
+    "url": "https://api.github.com/repos/pengwynn/octokit/contents/README.md",
+    "git_url": "https://api.github.com/repos/pengwynn/octokit/git/blobs/3d21ec53a331a6f037a91c368710b99387d012c1",
+    "html_url": "https://github.com/pengwynn/octokit/blob/master/README.md",
+    "_links": {
+        "git": "https://api.github.com/repos/pengwynn/octokit/git/blobs/3d21ec53a331a6f037a91c368710b99387d012c1",
+        "self": "https://api.github.com/repos/pengwynn/octokit/contents/README.md",
+        "html": "https://github.com/pengwynn/octokit/blob/master/README.md"
+    }
+}

--- a/sagan-common/src/test/java/sagan/guides/service/UnderstandingGuidesServiceTests.java
+++ b/sagan-common/src/test/java/sagan/guides/service/UnderstandingGuidesServiceTests.java
@@ -42,8 +42,8 @@ public class UnderstandingGuidesServiceTests {
 
     @Test
     public void testGetsContentForGuide() throws Exception {
-        given(gitHubService.getRawFileAsHtml(matches(".*foo.*README.*"))).willReturn("Understanding: foo!");
-        given(gitHubService.getRawFileAsHtml(matches(".*rest.*README.*"))).willReturn("Understanding: rest");
+        given(gitHubService.getMarkdownFileAsHtml(matches(".*foo.*README.*"))).willReturn("Understanding: foo!");
+        given(gitHubService.getMarkdownFileAsHtml(matches(".*rest.*README.*"))).willReturn("Understanding: rest");
 
         List<UnderstandingGuide> guides = understandingGuidesService.getGuides();
 
@@ -53,8 +53,8 @@ public class UnderstandingGuidesServiceTests {
 
     @Test
     public void testGetsSidebarForGuide() throws Exception {
-        given(gitHubService.getRawFileAsHtml(matches(".*foo.*SIDEBAR.*"))).willReturn("foo sidebar");
-        given(gitHubService.getRawFileAsHtml(matches(".*rest.*SIDEBAR.*"))).willReturn("rest sidebar");
+        given(gitHubService.getMarkdownFileAsHtml(matches(".*foo.*SIDEBAR.*"))).willReturn("foo sidebar");
+        given(gitHubService.getMarkdownFileAsHtml(matches(".*rest.*SIDEBAR.*"))).willReturn("rest sidebar");
 
         List<UnderstandingGuide> guides = understandingGuidesService.getGuides();
 

--- a/sagan-common/src/test/java/sagan/util/service/github/GitHubServiceTests.java
+++ b/sagan-common/src/test/java/sagan/util/service/github/GitHubServiceTests.java
@@ -33,7 +33,7 @@ public class GitHubServiceTests {
     public void getRawFileAsHtml_fetchesRenderedHtmlFromGitHub() throws Exception {
         given(gitHubRestClient.sendRequestForHtml("/path/to/html")).willReturn("<h1>Something</h1>");
 
-        assertThat(service.getRawFileAsHtml("/path/to/html"), equalTo("<h1>Something</h1>"));
+        assertThat(service.getMarkdownFileAsHtml("/path/to/html"), equalTo("<h1>Something</h1>"));
     }
 
     @Test

--- a/sagan-site/src/it/java/integration/guides/GettingStartedGuidesTests.java
+++ b/sagan-site/src/it/java/integration/guides/GettingStartedGuidesTests.java
@@ -20,8 +20,10 @@ public class GettingStartedGuidesTests extends AbstractIntegrationTests {
     @Test
     public void showGuide() throws Exception {
         String gsRestServiceRepo = FixtureLoader.load("/fixtures/github/gs-rest-service-repo.json");
+        String gsRestServiceReadme = FixtureLoader.load("/fixtures/github/gs-rest-service-readme.json");
         stubRestClient.putResponse("/repos/spring-guides/gs-rest-service", gsRestServiceRepo);
 
+        stubRestClient.putResponse("/repos/spring-guides/gs-rest-service/readme", gsRestServiceReadme);
         stubRestClient.putResponse("/repos/spring-guides/gs-rest-service/contents/README.md",
                 "guide body");
         stubRestClient.putResponse("/repos/spring-guides/gs-rest-service/contents/SIDEBAR.md",

--- a/sagan-site/src/main/java/sagan/app/site/ApplicationConfiguration.java
+++ b/sagan-site/src/main/java/sagan/app/site/ApplicationConfiguration.java
@@ -136,12 +136,14 @@ public class ApplicationConfiguration {
 
     @Bean
     public CacheManager cacheManager(@Value("${cache.network.timetolive:300}") Long cacheNetworkTimeToLive,
-                                     @Value("${cache.database.timetolive:60}") Long cacheDatabaseTimeToLive) {
+                                     @Value("${cache.database.timetolive:60}") Long cacheDatabaseTimeToLive,
+                                     @Value("${cache.guide.timetolive:300}") Long cacheGuideTimeToLive) {
         SimpleCacheManager cacheManager = new SimpleCacheManager();
 
         List<ConcurrentMapCache> cacheList = new ArrayList<>();
         cacheList.add(createConcurrentMapCache(cacheNetworkTimeToLive, "cache.network", -1));
         cacheList.add(createConcurrentMapCache(cacheDatabaseTimeToLive, "cache.database", 50));
+        cacheList.add(createConcurrentMapCache(cacheGuideTimeToLive, "cache.guide", 100));
         cacheManager.setCaches(cacheList);
         return cacheManager;
     }


### PR DESCRIPTION
- GSGs can be either **README.md** or **README.asc**
- sagan uses GitHub to identify which format is accepted. Right now, **.asc** trumps **.md**
- Added `cache.guides` cache to support caching guides
- Checked formatting to confirm support for given styles.
- Used http://github.com/gregturn/gs-rest-service to verify functionality
- Altered existing tests to support the extra REST call needed to find the format
- Ran ./gradlew test and ./gradlew check and got 100% passage.
