### PR TITLE
Switch Spring doc link to htmlsingle

### DIFF
--- a/sagan-common/src/main/resources/project-metadata.yml
+++ b/sagan-common/src/main/resources/project-metadata.yml
@@ -207,7 +207,7 @@ projects:
     - id: spring-framework
       name: Spring Framework
       groupId: org.springframework
-      refDocUrl: /spring/docs/{version}/spring-framework-reference/html/
+      refDocUrl: /spring/docs/{version}/spring-framework-reference/htmlsingle/
       apiDocUrl: /spring/docs/{version}/javadoc-api/
       supportedVersions:
         - 4.0.0.BUILD-SNAPSHOT


### PR DESCRIPTION
This will update the link to point to the new asciidoc location which
does not support multi page html output. It will also ensure consistency
among the links for other Spring versions.
