### PR TITLE
Add redirect for spring.io/gplus

### DIFF
--- a/sagan-site/src/it/java/integration/rewrite/RewriteTests.java
+++ b/sagan-site/src/it/java/integration/rewrite/RewriteTests.java
@@ -119,6 +119,11 @@ public class RewriteTests {
         validateTemporaryRedirect("http://spring.io/tools/ggts/welcome", "http://grails.org/products/ggts/welcome");
     }
 
+    @Test
+    public void gplusIsRedirected() throws Exception {
+        validateTemporaryRedirect("http://spring.io/gplus", "https://plus.google.com/+springframework/");
+    }
+
     private void validateTemporaryRedirect(String requestedUrl, String redirectedUrl) throws IOException,
             ServletException, URISyntaxException {
         validateRedirect(requestedUrl, redirectedUrl, 302);

--- a/sagan-site/src/main/resources/urlrewrite.xml
+++ b/sagan-site/src/main/resources/urlrewrite.xml
@@ -73,4 +73,10 @@
         <from>^/tools/ggts/welcome</from>
         <to type="temporary-redirect" last="true">http://grails.org/products/ggts/welcome</to>
     </rule>
+    <rule>
+        <name>Google Plus</name>
+        <note>https://github.com/spring-io/sagan/issues/125</note>
+        <from>^/gplus$</from>
+        <to type="temporary-redirect" last="true">https://plus.google.com/+springframework/</to>
+    </rule>
 </urlrewrite>


### PR DESCRIPTION
via @phumphrey:

Please add a 302 redirect for http://spring.io/gplus to https://plus.google.com/+springframework/
