### PR TITLE
Filter widget on /guides and /docs should be focused by default

### DIFF
--- a/sagan-site/src/main/resources/templates/docs/index.html
+++ b/sagan-site/src/main/resources/templates/docs/index.html
@@ -20,7 +20,7 @@
 
         <div class="row-fluid content-container--wrapper docs--body" >
             <div class="content-container--header">
-                <input type='text' id='doc_filter' style="color:#aaa;" onfocus="this.value=''; this.style.color='#000'; this.style.fontStyle='normal'; this.onfocus='';" value="Find a project..." placeholder="Find a project..." class="content-container--filter"/>
+                <input type='text' id='doc_filter' style="color:#aaa;" onfocus="this.value=''; this.style.color='#000'; this.style.fontStyle='normal'; this.onfocus='';" autofocus value="Find a project..." placeholder="Find a project..." class="content-container--filter"/>
             </div>
             <div data-filterable-container>
                 <div class="js-item-dropdown-widget--wrapper">

--- a/sagan-site/src/main/resources/templates/guides/index.html
+++ b/sagan-site/src/main/resources/templates/guides/index.html
@@ -19,7 +19,7 @@
       <a name="gs"/>
       <div class="row-fluid content-container--wrapper guides-section--container">
         <div class="content-container--header">
-          <input type='text' id='doc_filter' style="color:#aaa;" onfocus="this.value=''; this.style.color='#000'; this.style.fontStyle='normal'; this.onfocus='';" value="Find a guide..." placeholder="Find a guide..." class="content-container--filter"/>
+          <input type='text' id='doc_filter' style="color:#aaa;" onfocus="this.value=''; this.style.color='#000'; this.style.fontStyle='normal'; this.onfocus='';" autofocus value="Find a guide..." placeholder="Find a guide..." class="content-container--filter"/>
         </div>
         <div class="content-container--body">
           <div data-filterable-container>


### PR DESCRIPTION
In their original implementation, the filter input fields had focus on page load. Somehow this has been removed in the meantime. Let’s add it back in for user convenience.
