### PR TITLE
Notes extend into right sidebar

### DIFF
--- a/sagan-site/src/main/resources/static/css/fix-asciidoctor-styles.css
+++ b/sagan-site/src/main/resources/static/css/fix-asciidoctor-styles.css
@@ -28,7 +28,7 @@
     background-color: #EBF1E7;
     padding: 25px 20px;
     margin: 30px 0;
-    width: 100%;
+    width: auto;
 }
 
 .content--container .admonitionblock .content:before {


### PR DESCRIPTION
For example, see the note here: http://spring.io/guides/gs/rest-service/

The element extends to the right too far (notice the green background).  I made the rookie mistake of using left/right padding in combination with `width: 100%`.  The fix is easy: use `width: auto`.  PR coming shortly.
