### PR TITLE
Move asciidoctor factory up to being a field that is constructed once

### DIFF
--- a/sagan-common/src/main/java/sagan/guides/support/GuideOrganization.java
+++ b/sagan-common/src/main/java/sagan/guides/support/GuideOrganization.java
@@ -34,6 +34,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * Repository representing the GitHub organization for guide repositories.
  * 
  * @author Chris Beams
+ * @author Greg Turnquist
  */
 @Component
 class GuideOrganization {
@@ -44,6 +45,7 @@ class GuideOrganization {
     private final GitHubClient gitHub;
     private final String name;
     private final ObjectMapper objectMapper = new ObjectMapper();
+    private final Asciidoctor asciidoctor = Asciidoctor.Factory.create();
 
     @Autowired
     public GuideOrganization(@Value("${github.org.name:spring-guides}") String name, GitHubClient gitHub) {
@@ -100,7 +102,6 @@ class GuideOrganization {
             }
 
             // Process the unzipped guide through asciidoctor, rendering HTML content
-            Asciidoctor asciidoctor = Asciidoctor.Factory.create();
             Attributes attributes = new Attributes();
             attributes.setAllowUriRead(true);
             content = asciidoctor.renderFile(


### PR DESCRIPTION
Every time a guide is rendered, it causes another asciidoctor factory to get created. This is too expensive. According to http://discuss.asciidoctor.org/Java-thread-safety-and-other-server-questions-td976.html#a1051, it appears that the factory is thread safe.
