### PR TITLE
Upgrade to Spring Boot M7 snapshot for startup speed improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
-    ext.vSpringBoot = '0.5.0.M6'
-    ext.vSpringCore = '4.0.0.RC1'
+    ext.vSpringBoot = '0.5.0.M7'
+    ext.vSpringCore = '4.0.0.RELEASE'
     ext.vSpringSec = '3.2.0.RC2'
     ext.vHttpClient = '4.3'
     ext.vJunit = '4.11'
@@ -44,6 +44,23 @@ subprojects {
         testCompile "junit:junit:${vJunit}"
         testCompile 'org.hamcrest:hamcrest-library:1.3'
         testCompile 'org.mockito:mockito-core:1.9.5'
+    }
+
+    configurations.all {
+        resolutionStrategy {
+            //failOnVersionConflict()
+
+            eachDependency { DependencyResolveDetails details ->
+                if (details.requested.group == 'org.springframework') {
+                    details.useVersion "${vSpringCore}"
+                }
+                if (details.requested.group == "org.apache.httpcomponents") {
+                    if (details.requested.name != "httpasyncclient") {
+                        details.useVersion "${vHttpClient}"
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/sagan-common/build.gradle
+++ b/sagan-common/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     // datasource and connection pool dependencies
     runtime 'org.postgresql:postgresql:9.2-1002-jdbc4'
     runtime 'com.h2database:h2:1.3.173'
-    compile 'org.apache.tomcat:tomcat-jdbc:7.0.42'
+    compile 'org.apache.tomcat:tomcat-jdbc:7.0.47'
 
     // for use in on-the-fly database setup and migrations
     compile 'com.googlecode.flyway:flyway-core:2.2.1'

--- a/sagan-site/build.gradle
+++ b/sagan-site/build.gradle
@@ -25,11 +25,12 @@ dependencies {
     // Thymeleaf is used as the template engine for serving HTML
     // NOTE: versions below are intended to be in sync with spring-boot-dependencies pom @ ${vSpringBoot}
     // e.g.: https://github.com/spring-projects/spring-boot/blob/v0.5.0.M6/spring-boot-dependencies/pom.xml
-    compile 'org.thymeleaf:thymeleaf-spring3:2.0.19'
-    compile 'org.thymeleaf:thymeleaf:2.0.19'
-    compile 'nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect:1.1.3'
+    compile 'org.thymeleaf:thymeleaf-spring3:2.1.2.RELEASE'
+    compile 'org.thymeleaf:thymeleaf-spring4:2.1.2.RELEASE'
+    compile 'org.thymeleaf:thymeleaf:2.1.2.RELEASE'
+    compile 'nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect:1.2'
     compile 'com.github.mxab.thymeleaf.extras:thymeleaf-extras-data-attribute:1.2'
-    compile 'org.thymeleaf.extras:thymeleaf-extras-springsecurity3:2.0.1'
+    compile 'org.thymeleaf.extras:thymeleaf-extras-springsecurity3:2.1.1.RELEASE'
 
     // nekohtml is required for thymeleaf's LEGACYHTML5 mode
     runtime 'net.sourceforge.nekohtml:nekohtml:1.9.15'


### PR DESCRIPTION
Running from within the IDE or via `gradle run` is typically more than twice as fast as running with `java -jar`. @philwebb, @dsyer, is this a known problem with Boot? Anything we might be doing to cause this?

```
$ ./gradlew :sagan-site:run
[…]
[…] Started ApplicationConfiguration in 7.019 seconds
```

vs.

```
$ ./gradlew build -x check  # build the jar
[…]
$ java -jar sagan-site/build/libs/sagan-site.jar
[…]
[…] Started ApplicationConfiguration in 16.567 seconds
```
