### PR TITLE
Fix tests when default Locale is not "US"

### DIFF
--- a/sagan-common/src/main/java/sagan/team/service/GeoLocationFormatter.java
+++ b/sagan-common/src/main/java/sagan/team/service/GeoLocationFormatter.java
@@ -28,6 +28,6 @@ public class GeoLocationFormatter implements Formatter<GeoLocation> {
 
     @Override
     public String print(GeoLocation location, Locale locale) {
-        return String.format("%f,%f", location.getLatitude(), location.getLongitude());
+        return String.format(Locale.US, "%f,%f", location.getLatitude(), location.getLongitude());
     }
 }

--- a/sagan-site/src/test/java/sagan/blog/view/PostViewTests.java
+++ b/sagan-site/src/test/java/sagan/blog/view/PostViewTests.java
@@ -1,11 +1,13 @@
 package sagan.blog.view;
 
+import org.junit.After;
 import sagan.blog.Post;
 import sagan.blog.PostBuilder;
 import sagan.util.DateTestUtils;
 import sagan.util.service.DateService;
 
 import java.text.ParseException;
+import java.util.Locale;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -22,12 +24,21 @@ public class PostViewTests {
     @Mock
     private DateService dateService;
 
+    private Locale defaultLocale;
+
     private Post post;
     private PostView postView;
 
     @Before
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
+        defaultLocale = Locale.getDefault();
+        Locale.setDefault(Locale.US);
+    }
+
+    @After
+    public void tearDown() {
+        Locale.setDefault(defaultLocale);
     }
 
     @Test

--- a/sagan-site/src/test/java/sagan/blog/web/BlogControllerTests.java
+++ b/sagan-site/src/test/java/sagan/blog/web/BlogControllerTests.java
@@ -1,11 +1,13 @@
 package sagan.blog.web;
 
+import org.junit.After;
 import sagan.blog.Post;
 import sagan.blog.service.BlogService;
 import sagan.blog.view.PostViewFactory;
 import sagan.util.service.DateService;
 
 import java.util.Collections;
+import java.util.Locale;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -30,6 +32,8 @@ public class BlogControllerTests {
     private BlogService blogService;
     private BlogController blogController;
 
+    private Locale defaultLocale;
+
     private ExtendedModelMap model = new ExtendedModelMap();
 
     @Before
@@ -43,6 +47,14 @@ public class BlogControllerTests {
                 page);
 
         blogController = new BlogController(blogService, postViewFactory);
+
+        defaultLocale = Locale.getDefault();
+        Locale.setDefault(Locale.US);
+    }
+
+    @After
+    public void tearDown() {
+        Locale.setDefault(defaultLocale);
     }
 
     @Test


### PR DESCRIPTION
- [x] GeoLocationFormatter.print uses a "." decimal separator (can be "," for other languages). Maybe we should enforce "." here since all-commas GPS coordinates may not be valid.
- [x] PostViewTests.formattedPublishDateForPublishedPosts date in test is hard-coded in english.
- [x] BlogControllerTests dates in tests are hard-coded in english.

---

This issue tracks problems related to failing tests / code updates due to the premise that the default JVM Locale is en/us. Possible fixes: update tests to use locale formatting when checking against values, or update formatters to enforce a proper format.
Asking users to change globally their Locale is not ideal, since it's strictly tied to the OS Locale.
