### PR TITLE
Fix Reactor tagline on the platform page

### DIFF
--- a/sagan-site/src/main/resources/templates/pages/platform.html
+++ b/sagan-site/src/main/resources/templates/pages/platform.html
@@ -97,7 +97,7 @@
           <a href="https://github.com/reactor/reactor" class="project--container project--container--link">
             <img class="project--logo small" src="/img/platform-reactor.png">
             <div class="project--title">Reactor</div>
-            <p class="project--description">A foundation for reactive fastdata applications on the JVM.</p>
+            <p class="project--description">A foundation for reactive applications on the JVM.</p>
           </a>
         </div>
         <p>The popular Groovy dynamic language is supported as an integral part of the Spring IO platform. Groovy integrates seamlessly with your existing classes and libraries and works especially well with IO Execution DSRs such as Boot and Grails.</p>


### PR DESCRIPTION
Current tagline for Reactor in the platform page is:

> A powerful and highly customizable authentication and access-control framework

Should be:

> A foundation for reactive fastdata applications on the JVM
