### PR TITLE
date picker widget on sagan admin not working 

### DIFF
--- a/sagan-client/src/feature/formWidgets/main.js
+++ b/sagan-client/src/feature/formWidgets/main.js
@@ -1,5 +1,9 @@
 var $ = require('jquery');
 
+// This implicitly makes $.fn.datetimepicker available
+// Unfortunate, but it's the jquery way.
+require('bootstrap-datetimepicker');
+
 /**
  * The composition plan for pages that use the data-form-widgets feature
  * attribute for decorating forms with jQuery plugins.

--- a/sagan-site/src/main/resources/templates/admin/blog/_post_form.html
+++ b/sagan-site/src/main/resources/templates/admin/blog/_post_form.html
@@ -1,8 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:th="http://www.thymeleaf.org"
-      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
-      data-form-widgets>
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout">
 <body>
 
     <form layout:fragment="post-form">

--- a/sagan-site/src/main/resources/templates/admin/blog/edit.html
+++ b/sagan-site/src/main/resources/templates/admin/blog/edit.html
@@ -1,6 +1,7 @@
 <html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
       xmlns:th="http://www.thymeleaf.org"
-      layout:decorator="layout">
+      layout:decorator="layout"
+      data-form-widgets>
 <head>
     <title th:inline="text">Edit &middot; [[${post.title}]]</title>
 </head>

--- a/sagan-site/src/main/resources/templates/admin/blog/new.html
+++ b/sagan-site/src/main/resources/templates/admin/blog/new.html
@@ -1,6 +1,7 @@
 <html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
       xmlns:th="http://www.thymeleaf.org"
-      layout:decorator="layout">
+      layout:decorator="layout"
+      data-form-widgets>
 <head>
     <title>Add New Post</title>
 </head>


### PR DESCRIPTION
when posting a new blog entry, the date picker no longer works for choosing future posts, in Chrome or FF 26
