### PR TITLE
Relax build-time dependency from JDK 8 => JDK 7

### DIFF
--- a/gradle/integTest.gradle
+++ b/gradle/integTest.gradle
@@ -28,6 +28,9 @@ task integTest(type: Test) {
 
     maxHeapSize = '1024m'
 
+    // prevent OutOfMemoryErrors with JDK<8
+    jvmArgs '-XX:MaxPermSize=128m'
+
     // ensure we don't overwrite default report directories used by 'test' task
     reports.html.destination = "${project.buildDir}/reports/integTest"
     reports.junitXml.destination = "${project.buildDir}/integTest-results"

--- a/sagan-common/src/main/java/sagan/search/service/InMemoryElasticSearchConfiguration.java
+++ b/sagan-common/src/main/java/sagan/search/service/InMemoryElasticSearchConfiguration.java
@@ -4,6 +4,7 @@ import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 
 import org.elasticsearch.client.Client;
+import org.elasticsearch.node.Node;
 import org.elasticsearch.node.NodeBuilder;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,11 +18,14 @@ public class InMemoryElasticSearchConfiguration {
     @Autowired
     private Client client;
 
+    private Node node;
+
     @Bean
     public Client elasticSearchClient() throws Exception {
-        NodeBuilder nodeBuilder = NodeBuilder.nodeBuilder().local(false);
+        NodeBuilder nodeBuilder = NodeBuilder.nodeBuilder().local(true);
         nodeBuilder.getSettings().put("network.host", "127.0.0.1");
-        Client client = nodeBuilder.node().client();
+        node = nodeBuilder.node();
+        Client client = node.client();
         return client;
     }
 
@@ -31,7 +35,8 @@ public class InMemoryElasticSearchConfiguration {
     }
 
     @PreDestroy
-    public void closeClient() throws Exception {
+    public void shutDownElasticSearch() throws Exception {
         client.close();
+        node.close();
     }
 }


### PR DESCRIPTION
I know it's new, and it's next, but not many people use it yet and it's a _significant_ burden to get it working in an IDE that I know a lot of people use. Can we please downgrade for a few months at least until the world is a bit more ready?
