### PR TITLE
Use ‘dist.’ vs ‘download.’ S3 bucket for tools XML

### DIFF
--- a/sagan-common/src/main/java/sagan/tools/service/ToolsService.java
+++ b/sagan-common/src/main/java/sagan/tools/service/ToolsService.java
@@ -54,7 +54,7 @@ public class ToolsService {
 
     public EclipseDownloads getEclipseDownloads() throws Exception {
         String responseXml =
-                restClient.get(restTemplate, "http://download.springsource.com/release/STS/eclipse.xml",
+                restClient.get(restTemplate, "http://dist.springsource.com/release/STS/eclipse.xml",
                         String.class);
         EclipseXml eclipseXml = serializer.read(EclipseXml.class, responseXml);
         return new EclipseDownloadsXmlConverter().convert(eclipseXml);


### PR DESCRIPTION
As originally requested by @martinlippert:

> Use dist.springsource.com bucket instead of download.springsource.com for tools XML to avoid unnecessary CDN caching.
