### PR TITLE
Fix PermGen errors when running locally

### DIFF
--- a/sagan-site/build.gradle
+++ b/sagan-site/build.gradle
@@ -5,6 +5,10 @@ apply from: '../gradle/deploy.gradle'
 
 mainClassName = 'sagan.app.site.ApplicationConfiguration'
 
+// Avoid PermGen errors during JRuby/Asciidoctor guide processing on JDK 7 with `gradle :sagan-site:run`
+// http://www.gradle.org/docs/1.7/release-notes#specify-default-jvm-arguments-for-the-application-plugin
+applicationDefaultJvmArgs = [ "-XX:MaxPermSize=128M" ]
+
 run {
     systemProperties System.properties
 }
@@ -12,12 +16,6 @@ run {
 springBoot {
     backupSource = false
     mainClass = mainClassName
-}
-
-// configure the CreateStartScripts task provided by the 'application' plugin
-// http://www.gradle.org/docs/current/dsl/org.gradle.api.tasks.application.CreateStartScripts.html
-startScripts {
-    defaultJvmOpts += "-XX:MaxPermSize=128M"
 }
 
 dependencies {


### PR DESCRIPTION
- [x] @cbeams to look at `gradle run` doc.
- [x] @philwebb/@dsyer to respond to https://github.com/spring-io/sagan/issues/250#issuecomment-34473097 (2/7)

---

@dsyer, @philwebb, I'm getting PermGen space errors when running locally with

```
gradle :sagan-site:run
```

The reasons for this likely have to do with JRuby and dynamic class generation when downloading GS guides, but that's beside the point. What I want to do is increase MaxPermSize, and I cannot figure out how to do so with Boot.

Have looked at the [spring-boot-gradle-plugin docs](http://projects.spring.io/spring-boot/docs/spring-boot-tools/spring-boot-gradle-plugin/README.html) and dug into the [source for the `run` plugin](https://github.com/spring-projects/spring-boot/blob/master/spring-boot-tools/spring-boot-gradle-plugin/src/main/groovy/org/springframework/boot/gradle/task/RunApp.java) to no avail thus far.

Help!
