### PR TITLE
Write git.properties from Gradle build to support reading the current commit from /info Actuator endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ target
 build
 bin
 dependency-reduced-pom.xml
-src/main/resources/git.properties
 Gemfile.lock
 .DS_Store
 atlassian-ide-plugin.xml

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ buildscript {
     dependencies {
         classpath "org.springframework.boot:spring-boot-gradle-plugin:${vSpringBoot}"
         classpath 'org.cloudfoundry:cf-gradle-plugin:1.0.2'
+        classpath 'org.ajoberstar:gradle-git:0.6.3'
     }
 }
 
@@ -65,3 +66,19 @@ subprojects {
     }
 }
 
+configure([ project(':sagan-site'), project(':sagan-indexer') ]) {
+    // Populate git commit and branch metadata at http://spring.io/info.
+    // See:
+    //   http://projects.spring.io/spring-boot/docs/spring-boot-actuator/docs/Features.html ("Info Endpoint")
+    //   http://ajoberstar.org/gradle-git/docs/groovydoc/org/ajoberstar/gradle/git/tasks/GitBranchList.html
+    //   https://github.com/ajoberstar/gradle-git
+    task gitProperties(type: org.ajoberstar.gradle.git.tasks.GitBranchList) << {
+        Properties p = new Properties()
+        p['git.branch'] = workingBranch.name
+        p['git.commit.id'] = workingBranch.commit.id
+        p['git.commit.time'] = "N/A"
+        p.store(new FileWriter(file("${sourceSets.main.output.resourcesDir}/git.properties")),
+            "Written by the `processResources` Gradle build task")
+    }
+    processResources.finalizedBy gitProperties
+}


### PR DESCRIPTION
Sagan’s Maven build used the git-commit-id-plugin to write `git.properties`, which is consumed by Spring Boot Actuator and exposed via the /info endpoint. This is extremely useful in determining what “version” of the app is in production, staging, etc. We don’t have it right now, because Gradle has no equivalent plugin (that I’m aware of). This means we’re "flying blind” with regard to knowing exactly which bits are deployed where.

One possible solutions may be integrating with JGit from within the Gradle build to emulate the git.properties file. This needs to be explored.
