### PR TITLE
Fix remaining issues with Gradle deployment tasks.

### DIFF
--- a/gradle/deploy.gradle
+++ b/gradle/deploy.gradle
@@ -3,15 +3,19 @@ gradle.rootProject.allprojects { project ->
     checkTasks.addAll(project.tasks.findAll { it.name == 'build' })
 }
 
+def siteProject = project(':sagan-site')
+def indexerProject = project(':sagan-indexer')
+
 task deploy(dependsOn: 'build') {
     description = 'Deploys the project to a Cloud Foundry space (specified with -P<spacename>)'
     mustRunAfter checkTasks
 
-    if (project.name == 'sagan-site') {
+    if (project.name == siteProject.name)
         dependsOn 'cf-deploy', 'cf-swap-deployed'
-    } else {
+    else if (project.name == indexerProject.name)
         dependsOn 'cf-push'
-    }
+    else
+        throw new IllegalArgumentException('Unknown project ${project.name}')
 }
 
 def saganEnvScript = file("${System.getProperty("user.home")}/.gradle/sagan-env.gradle")
@@ -36,7 +40,7 @@ cloudfoundry {
     variants = ['-blue', '-green']
 }
 
-if (project.name == 'sagan-site') {
+if (project.name == siteProject.name) {
     cloudfoundry {
         application = 'sagan' // instead of 'sagan-site'
     }
@@ -56,7 +60,7 @@ if (project.hasProperty('adminPassword') && project.hasProperty('elasticsearchEn
         ]
     }
 
-    if (project.name == 'sagan-site') {
+    if (project.name == siteProject.name) {
         cloudfoundry {
             env << [
                 GITHUB_CLIENT_ID: githubClientId,
@@ -100,7 +104,7 @@ if (project.hasProperty('staging')) {
         }
     }
 
-    if (project.name == 'sagan-site') {
+    if (project.name == siteProject.name) {
         cloudfoundry {
             uris = [ "${space}.spring.io" ]
         }
@@ -134,7 +138,7 @@ if (project.hasProperty('production')) {
         }
     }
 
-    if (project.name == 'sagan-site') {
+    if (project.name == siteProject.name) {
         cloudfoundry {
             uris = [ "spring.io", "www.spring.io" ]
         }


### PR DESCRIPTION
Fixes remaining issues from #147: 

> - I consistently get duplicate messages about applying environment settings when running gradle deploy...

I removed the `println` statement from the build script. Because of how the `deploy.gradle` file is used by both sub-projects, any console output from that build script will be shown twice. 

> - running gradle deploy from the root of the project causes sagan-indexer to build and deploy before sagan-site.

I fixed this by re-working the dependency declarations in the task rule. I'm not exactly sure why it wasn't working before, but it is now. 

> - per comments above, it sounds like there's still work to do to ensure that the build fails fast if any deployment step fails—and that in any case, mapping/unmapping does not occur unless the push was successful.

Also fixed with the above changes. `finalizedBy` ensures that the named task gets run after all other tasks, either on success or failure (similar to Java's `finally`). That's obviously not what we want. Plain old `dependsOn` does what we want. 

Also, 

> - I forgot about the gradle cf-login step and was confronted with OAuth login errors when I tried to run gradle deploy out of the gate. This is probably a matter for documentation, but a little nicer error message there would be good if it's not a hassle.

You should get an error like the following when you run a CF plugin task without being logged in: 

```
* What went wrong:
Execution failed for task ':sagan-site:cf-deploy'.
> Can not authenticate to target http://api.run.pivotal.io. Configure a username and password, or use the login task.
```

If you were seeing a different error, I need to see what it was so I can figure out where it as coming from. 
