### PR TITLE
cf-gradle-plugin does not set environment variables as expected

### DIFF
--- a/gradle/deploy.gradle
+++ b/gradle/deploy.gradle
@@ -47,26 +47,61 @@ if (project.name == siteProject.name) {
 }
 
 // These deployment properties can be set on the command line with "-P" options, in "gradle.properties",
-// or in "~/.gradle/sagan-env.gradle".
+// or in "~/.gradle/sagan-env.gradle". All are required if the respective 'cf-login' / 'deploy' tasks
+// have been invoked.
 
-if (project.hasProperty('adminPassword') && project.hasProperty('elasticsearchEndpoint') &&
-    project.hasProperty('githubClientId') && project.hasProperty('githubClientSecret') &&
-    project.hasProperty('webhookAccessToken')) {
+def reqLoginVars = [ 'cf.username', 'cf.password' ]
 
-    cloudfoundry {
-        env << [
-            ADMIN_PASSWORD: adminPassword,
-            ELASTICSEARCH_ENDPOINT: elasticsearchEndpoint,
-        ]
+def reqDeployVars = [
+    'adminPassword', 'elasticsearchEndpoint', 'githubClientId',
+    'githubClientSecret', 'webhookAccessToken'
+]
+
+gradle.taskGraph.whenReady {
+    if (gradle.taskGraph.allTasks.collect { it.name.endsWith(":cf-login") }.size() > 0) {
+        def missingVars = []
+        reqLoginVars.each { var ->
+            if (!project.hasProperty(var)) {
+                missingVars << var
+            }
+        }
+        if (missingVars.size() > 0) {
+            throw new InvalidUserDataException(
+                "Missing required variable(s) for the 'cf-login' task: ${missingVars}. " +
+                "Specify them with -Pkey=value or in ${saganEnvScript}");
+        }
     }
 
-    if (project.name == siteProject.name) {
+    if (gradle.taskGraph.hasTask(":${siteProject.name}:${deploy.name}")
+          || gradle.taskGraph.hasTask(":${indexerProject.name}:${deploy.name}")) {
+        def missingVars = []
+        reqDeployVars.each { var ->
+            if (!project.hasProperty(var)) {
+                missingVars << var
+            }
+        }
+        if (missingVars.size() > 0) {
+            throw new InvalidUserDataException(
+                "Missing required variable(s) for the 'deploy' task: ${missingVars}. " +
+                "Specify them with -Pkey=value or in ${saganEnvScript}");
+        }
+
+        // All required env vars are present. Populate the cloudfoundry environment with them.
         cloudfoundry {
             env << [
-                GITHUB_CLIENT_ID: githubClientId,
-                GITHUB_CLIENT_SECRET: githubClientSecret,
-                WEBHOOK_ACCESS_TOKEN: webhookAccessToken
+                ADMIN_PASSWORD: adminPassword,
+                ELASTICSEARCH_ENDPOINT: elasticsearchEndpoint,
             ]
+        }
+
+        if (project.name == siteProject.name) {
+            cloudfoundry {
+                env << [
+                    GITHUB_CLIENT_ID: githubClientId,
+                    GITHUB_CLIENT_SECRET: githubClientSecret,
+                    WEBHOOK_ACCESS_TOKEN: webhookAccessToken
+                ]
+            }
         }
     }
 }


### PR DESCRIPTION
Related to #147 #260, @olivergierke has just discovered that attempting to log in at http://spring.io/admin fails because the app redirects the user to http://localhost:8080/?error=redirect_uri_mismatch, instead of the correct OAuth callback URL.

On investigation, this is because certain environment variables are missing:

```
$ gcf env sagan-green
Getting env variables for app sagan-green in org spring.io / space production as cbeams@vmware.com...
OK

SPRING_PROFILES_ACTIVE: production
NEW_RELIC_APP_NAME: sagan-blue;sagan
ELASTICSEARCH_INDEX: sagan-production
```

This list **should** include all of the following:

```
ADMIN_PASSWORD: redacted
ELASTICSEARCH_ENDPOINT: redacted
GITHUB_CLIENT_ID: redacted
GITHUB_CLIENT_SECRET: redacted
WEBHOOK_ACCESS_TOKEN: redacted
SPRING_PROFILES_ACTIVE: staging
NEW_RELIC_APP_NAME: sagan-blue;sagan
ELASTICSEARCH_INDEX: sagan-staging
```

@scottfrederick and I discussed the new gradle-cf-plugin's ability to ensure env vars are correctly set up, and [this functionality has been implemented](https://github.com/spring-io/sagan/pull/147#issuecomment-34275231), but it appears not to be working.

I have put a `println` statement at the end of `gradle/deploy.gradle` to inspect the state of the `cloudfoundry.env`, and it does appear to be populated with all the environment variables, yet they are not actually being set as expected.

@scottfrederick can you please take a look? I am manually populating the env vars in the meantime.
