### PR TITLE
Upgrade to Spring Boot 1.0.0.RC2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,18 +1,17 @@
 buildscript {
-    ext.vSpringBoot = '0.5.0.M7'
-    ext.vSpringCore = '4.0.0.RELEASE'
-    ext.vSpringSec = '3.2.0.RC2'
+
     ext.vHttpClient = '4.3'
-    ext.vJunit = '4.11'
 
     repositories {
         maven { url 'http://repo.spring.io/libs-milestone' }
     }
+
     dependencies {
-        classpath "org.springframework.boot:spring-boot-gradle-plugin:${vSpringBoot}"
+        classpath "org.springframework.boot:spring-boot-gradle-plugin:1.0.0.RC2"
         classpath 'org.cloudfoundry:cf-gradle-plugin:1.0.2'
         classpath 'org.ajoberstar:gradle-git:0.6.3'
     }
+
 }
 
 apply plugin: 'eclipse'
@@ -32,6 +31,7 @@ subprojects {
     apply plugin: 'java'
     apply plugin: 'idea'
     apply plugin: 'eclipse'
+    apply plugin: 'spring-boot'
 
     targetCompatibility = 1.7
     sourceCompatibility = 1.7
@@ -42,28 +42,12 @@ subprojects {
     }
 
     dependencies {
-        compile 'org.slf4j:slf4j-api:1.7.5'
-        testCompile "junit:junit:${vJunit}"
-        testCompile 'org.hamcrest:hamcrest-library:1.3'
-        testCompile 'org.mockito:mockito-core:1.9.5'
+        compile 'org.slf4j:slf4j-api'
+        testCompile "junit:junit"
+        testCompile 'org.hamcrest:hamcrest-library'
+        testCompile 'org.mockito:mockito-core'
     }
 
-    configurations.all {
-        resolutionStrategy {
-            //failOnVersionConflict()
-
-            eachDependency { DependencyResolveDetails details ->
-                if (details.requested.group == 'org.springframework') {
-                    details.useVersion "${vSpringCore}"
-                }
-                if (details.requested.group == "org.apache.httpcomponents") {
-                    if (details.requested.name != "httpasyncclient") {
-                        details.useVersion "${vHttpClient}"
-                    }
-                }
-            }
-        }
-    }
 }
 
 configure([ project(':sagan-site'), project(':sagan-indexer') ]) {

--- a/sagan-client/build.gradle
+++ b/sagan-client/build.gradle
@@ -1,6 +1,8 @@
 import org.apache.tools.ant.taskdefs.condition.Os
 import org.gradle.api.tasks.Exec
 
+bootRepackage.enabled = false
+
 task cssmin(type: GruntTask) {
     gruntArgs = "cssmin"
 }

--- a/sagan-common/build.gradle
+++ b/sagan-common/build.gradle
@@ -1,3 +1,5 @@
+bootRepackage.enabled = false
+
 sourceSets {
     testUtil {
         java.srcDir 'src/test-util/java'
@@ -6,10 +8,10 @@ sourceSets {
 }
 
 dependencies {
-    compile "org.springframework:spring-context:${vSpringCore}"
-    compile "org.springframework.security:spring-security-core:${vSpringSec}"
+    compile "org.springframework:spring-context"
+    compile "org.springframework.security:spring-security-core"
     compile 'org.springframework.social:spring-social-github:1.0.0.M4'
-    compile "org.springframework.boot:spring-boot-starter-data-jpa:${vSpringBoot}"
+    compile "org.springframework.boot:spring-boot-starter-data-jpa"
 
     compile 'org.elasticsearch:elasticsearch:0.90.2'
     compile('io.searchbox:jest:0.0.4') {
@@ -19,8 +21,8 @@ dependencies {
 
     // datasource and connection pool dependencies
     runtime 'org.postgresql:postgresql:9.2-1002-jdbc4'
-    compile 'com.h2database:h2:1.3.173'
-    compile 'org.apache.tomcat:tomcat-jdbc:7.0.47'
+    compile 'com.h2database:h2'
+    compile 'org.apache.tomcat:tomcat-jdbc'
 
     // for use in on-the-fly database setup and migrations
     compile 'com.googlecode.flyway:flyway-core:2.2.1'
@@ -32,14 +34,14 @@ dependencies {
     }
 
     compile 'org.jsoup:jsoup:1.7.2'
-    compile 'org.yaml:snakeyaml:1.12'
-    compile 'joda-time:joda-time:2.3'
-    compile 'org.hibernate:hibernate-validator:4.3.1.Final'
+    compile 'org.yaml:snakeyaml'
+    compile 'joda-time:joda-time'
+    compile 'org.hibernate:hibernate-validator'
 
     // for use in rendering AsciiDoc-based guide content to HTML
     compile 'org.asciidoctor:asciidoctor-java-integration:0.1.4'
 
-    testUtilCompile "junit:junit:${vJunit}"
+    testUtilCompile "junit:junit"
     testUtilCompile sourceSets.main.output
     testUtilCompile configurations.compile
     testUtilRuntime configurations.runtime
@@ -48,7 +50,7 @@ dependencies {
     testCompile sourceSets.testUtil.output
 
     // for use of spring-test's MatcherAssertionErrors.*
-    testCompile "org.springframework:spring-test:${vSpringCore}"
+    testCompile "org.springframework:spring-test"
 }
 
 // Add test util source directories to IDEA .iml files

--- a/sagan-indexer/build.gradle
+++ b/sagan-indexer/build.gradle
@@ -17,19 +17,19 @@ springBoot {
 dependencies {
     compile project(':sagan-common')
 
-    compile "org.springframework.boot:spring-boot-starter-web:${vSpringBoot}"
-    compile "org.springframework.boot:spring-boot-starter-actuator:${vSpringBoot}"
-    compile "org.springframework.boot:spring-boot-starter-security:${vSpringBoot}"
+    compile "org.springframework.boot:spring-boot-starter-web"
+    compile "org.springframework.boot:spring-boot-starter-actuator"
+    compile "org.springframework.boot:spring-boot-starter-security"
 
     // for use in CrawlerService
-    compile "org.apache.httpcomponents:httpclient:${vHttpClient}"
+    compile "org.apache.httpcomponents:httpclient"
     compile('com.soulgalore:crawler:1.5.1') {
         exclude(module: 'guice')
         exclude(module: 'commons-logging')
     }
 
     // for use in mocking http interactions
-    testCompile "org.springframework:spring-test:${vSpringCore}"
+    testCompile "org.springframework:spring-test"
 
     // pick up common test utility classes
     testCompile project(':sagan-common').sourceSets.testUtil.output

--- a/sagan-indexer/src/it/java/sagan/app/indexer/AbstractIndexerIntegrationTests.java
+++ b/sagan-indexer/src/it/java/sagan/app/indexer/AbstractIndexerIntegrationTests.java
@@ -5,7 +5,7 @@ import sagan.util.SetSystemProperty;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 
-import org.springframework.boot.context.initializer.ConfigFileApplicationContextInitializer;
+import org.springframework.boot.test.ConfigFileApplicationContextInitializer;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;

--- a/sagan-indexer/src/main/java/sagan/app/indexer/ApplicationConfiguration.java
+++ b/sagan-indexer/src/main/java/sagan/app/indexer/ApplicationConfiguration.java
@@ -7,13 +7,14 @@ import java.util.concurrent.Executors;
 
 import org.simpleframework.xml.Serializer;
 import org.simpleframework.xml.core.Persister;
-
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.orm.jpa.EntityScan;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.support.ResourcePatternResolver;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
@@ -23,6 +24,8 @@ import org.springframework.web.client.RestTemplate;
 @Configuration
 @EnableScheduling
 @ComponentScan(basePackageClasses = sagan.Package.class)
+@EntityScan(basePackageClasses = sagan.Package.class)
+@EnableJpaRepositories(basePackageClasses = sagan.Package.class)
 public class ApplicationConfiguration {
 
     public static void main(String[] args) {

--- a/sagan-site/build.gradle
+++ b/sagan-site/build.gradle
@@ -21,20 +21,18 @@ springBoot {
 dependencies {
     compile project(':sagan-common')
 
-    compile "org.springframework.boot:spring-boot-starter-web:${vSpringBoot}"
-    compile "org.springframework.boot:spring-boot-starter-actuator:${vSpringBoot}"
-    compile "org.springframework.boot:spring-boot-starter-security:${vSpringBoot}"
-    compile "org.springframework.security:spring-security-acl:${vSpringSec}"
+    compile "org.springframework.boot:spring-boot-starter-web"
+	compile "org.apache.tomcat.embed:tomcat-embed-jasper" // until spring-boot #248 is fixed
+    compile "org.springframework.boot:spring-boot-starter-actuator"
+    compile "org.springframework.boot:spring-boot-starter-security"
+    compile "org.springframework.security:spring-security-acl"
 
     // Thymeleaf is used as the template engine for serving HTML
-    // NOTE: versions below are intended to be in sync with spring-boot-dependencies pom @ ${vSpringBoot}
-    // e.g.: https://github.com/spring-projects/spring-boot/blob/v0.5.0.M6/spring-boot-dependencies/pom.xml
-    compile 'org.thymeleaf:thymeleaf-spring3:2.1.2.RELEASE'
-    compile 'org.thymeleaf:thymeleaf-spring4:2.1.2.RELEASE'
-    compile 'org.thymeleaf:thymeleaf:2.1.2.RELEASE'
-    compile 'nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect:1.2'
+    compile 'org.thymeleaf:thymeleaf-spring4'
+    compile 'org.thymeleaf:thymeleaf'
+    compile 'nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect'
     compile 'com.github.mxab.thymeleaf.extras:thymeleaf-extras-data-attribute:1.3'
-    compile 'org.thymeleaf.extras:thymeleaf-extras-springsecurity3:2.1.1.RELEASE'
+    compile 'org.thymeleaf.extras:thymeleaf-extras-springsecurity3'
 
     // nekohtml is required for thymeleaf's LEGACYHTML5 mode
     runtime 'net.sourceforge.nekohtml:nekohtml:1.9.15'
@@ -53,7 +51,7 @@ dependencies {
     compile 'org.tuckey:urlrewritefilter:4.0.3'
 
     // for use in mocking http interactions
-    testCompile "org.springframework:spring-test:${vSpringCore}"
+    testCompile "org.springframework:spring-test"
 
     // pick up common test utility classes
     testCompile project(':sagan-common').sourceSets.testUtil.output

--- a/sagan-site/src/it/java/integration/AbstractIntegrationTests.java
+++ b/sagan-site/src/it/java/integration/AbstractIntegrationTests.java
@@ -7,7 +7,7 @@ import org.junit.Before;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.context.initializer.ConfigFileApplicationContextInitializer;
+import org.springframework.boot.test.ConfigFileApplicationContextInitializer;
 import org.springframework.cache.CacheManager;
 import org.springframework.security.web.FilterChainProxy;
 import org.springframework.test.context.ContextConfiguration;

--- a/sagan-site/src/it/java/integration/caching/CachedRestClientTests.java
+++ b/sagan-site/src/it/java/integration/caching/CachedRestClientTests.java
@@ -12,7 +12,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.context.initializer.ConfigFileApplicationContextInitializer;
+import org.springframework.boot.test.ConfigFileApplicationContextInitializer;
 import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -41,7 +41,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 /**
  * Integration tests ensuring that caching functionality works as expected in
  * {@link CachedRestClient}.
- * 
+ *
  * @author Pivotal Labs
  */
 @RunWith(SpringJUnit4ClassRunner.class)

--- a/sagan-site/src/it/java/integration/projects/ProjectsMetadataApiTests.java
+++ b/sagan-site/src/it/java/integration/projects/ProjectsMetadataApiTests.java
@@ -7,7 +7,7 @@ import java.util.regex.Pattern;
 
 import org.junit.Test;
 
-import org.springframework.boot.config.JacksonJsonParser;
+import org.springframework.boot.json.JacksonJsonParser;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 

--- a/sagan-site/src/main/java/sagan/app/site/ApplicationConfiguration.java
+++ b/sagan-site/src/main/java/sagan/app/site/ApplicationConfiguration.java
@@ -21,13 +21,13 @@ import org.h2.server.web.WebServlet;
 import org.simpleframework.xml.Serializer;
 import org.simpleframework.xml.core.Persister;
 import org.tuckey.web.filters.urlrewrite.UrlRewriteFilter;
-
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.context.embedded.FilterRegistrationBean;
 import org.springframework.boot.context.embedded.ServletRegistrationBean;
+import org.springframework.boot.orm.jpa.EntityScan;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.concurrent.ConcurrentMapCache;
@@ -36,6 +36,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.servlet.DispatcherServlet;
 
@@ -45,6 +46,8 @@ import com.google.common.cache.CacheBuilder;
 @Configuration
 @EnableCaching(proxyTargetClass = true)
 @ComponentScan(basePackageClasses = sagan.Package.class)
+@EntityScan(basePackageClasses = sagan.Package.class)
+@EnableJpaRepositories(basePackageClasses = sagan.Package.class)
 public class ApplicationConfiguration {
 
     public static final String REWRITE_FILTER_NAME = "rewriteFilter";


### PR DESCRIPTION
Upgrade to the latest stable release of Spring Boot with the following
changes:
- Remove explicit version numbers from `build.gradle` since the
  `spring-boot` plugin now provides sensible defaults.
- Update import declarations for upstream package reorganization.
- Add `@EnableJpaRepositories` and `@EntityScan` annotations to
  application configuration classes since `@PackageScan` is no longer
  used as a global package indicator by Boot.

Fixes #239
