### PR TITLE
Cannot run site with `java -jar` due to asciidoctorj error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,8 +37,8 @@ subprojects {
     sourceCompatibility = 1.7
 
     repositories {
+        maven { url 'http://dl.bintray.com/lordofthejars/maven' }
         maven { url 'http://repo.spring.io/libs-milestone' }
-        mavenLocal()
     }
 
     dependencies {

--- a/sagan-common/build.gradle
+++ b/sagan-common/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     compile 'org.hibernate:hibernate-validator'
 
     // for use in rendering AsciiDoc-based guide content to HTML
-    compile 'org.asciidoctor:asciidoctorj:1.5.0-SNAPSHOT'
+    compile 'org.asciidoctor:asciidoctor-java-integration:1.5.0.preview1'
 
     testUtilCompile "junit:junit"
     testUtilCompile sourceSets.main.output


### PR DESCRIPTION
- [ ] @lordofthejars (2/13) to respond to https://github.com/spring-io/sagan/pull/191#issuecomment-34979293
- [x] @gregturn to work with @lordofthejars per https://github.com/spring-io/sagan/issues/191#issuecomment-31614365
- [x] @gregturn to determine why Asciidoctor factory creation fails, i.e. what is the stack trace we’re seeing in https://github.com/spring-io/sagan/issues/191#issuecomment-30402519 all about?
- [ ] Remove the _**Note**_ from the [run the site locally](https://github.com/spring-io/sagan/wiki/Run-the-site-locally) wiki page when this issue is fixed.

---

Changes introduced with commit d83e63ff0aea4a7302dade5e46558454d73259e5 cause the following exception on startup with `java -jar sagan-site/build/libs/sagan-site.jar`: 

```
org.jruby.exceptions.RaiseException: (LoadError) no such file to load -- asciidoctor
```

See https://gist.github.com/anonymous/7925440 for complete stack trace.
