### PR TITLE
Upgrade to Spring Boot 1.0.0.RC3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "org.springframework.boot:spring-boot-gradle-plugin:1.0.0.RC2"
+        classpath "org.springframework.boot:spring-boot-gradle-plugin:1.0.0.RC3"
         classpath 'org.cloudfoundry:cf-gradle-plugin:1.0.2'
         classpath 'org.ajoberstar:gradle-git:0.6.3'
     }


### PR DESCRIPTION
RC3 was rushed to fix a [regression](https://github.com/spring-projects/spring-boot/issues/346). Should be a simple upgrade.
