### PR TITLE
Resolves #275: Have guides use project metadata to make sidebar links

### DIFF
--- a/sagan-common/src/main/java/sagan/guides/support/GettingStartedGuides.java
+++ b/sagan-common/src/main/java/sagan/guides/support/GettingStartedGuides.java
@@ -10,6 +10,8 @@ import sagan.guides.GettingStartedGuide;
 import sagan.guides.Guide;
 import sagan.guides.GuideMetadata;
 import sagan.guides.ImageProvider;
+import sagan.projects.Project;
+import sagan.projects.service.ProjectMetadataService;
 import sagan.util.ResourceNotFoundException;
 import sagan.util.service.github.Readme;
 
@@ -49,9 +51,12 @@ public class GettingStartedGuides extends GitHubBackedGuideRepository
 
     private final SetMultimap<String, String> tagMultimap = LinkedHashMultimap.create();
 
+    private final ProjectMetadataService projectMetadataService;
+
     @Autowired
-    public GettingStartedGuides(GuideOrganization org) {
+    public GettingStartedGuides(GuideOrganization org, ProjectMetadataService projectMetadataService) {
         super(org);
+        this.projectMetadataService = projectMetadataService;
     }
 
     @Override
@@ -123,7 +128,10 @@ public class GettingStartedGuides extends GitHubBackedGuideRepository
                     "<ul>\n";
 
             for (String project : asciidocGuide.getProjects()) {
-                sidebar += "<li><a href='http://projects.spring.io/" + project + "'>" + WordUtils.capitalize(project.replaceAll("-", " ")) + "</a></li>\n";
+
+                Project springIoProject = projectMetadataService.getProject(project);
+                sidebar += "<li><a href='" + springIoProject.getSiteUrl() + "'>" + springIoProject.getName()
+                        + "</a></li>\n";
             }
             sidebar += "</ul>\n";
         }

--- a/sagan-common/src/test/java/sagan/guides/support/GettingStartedGuidesTests.java
+++ b/sagan-common/src/test/java/sagan/guides/support/GettingStartedGuidesTests.java
@@ -2,6 +2,7 @@ package sagan.guides.support;
 
 import sagan.guides.GettingStartedGuide;
 import sagan.guides.Guide;
+import sagan.projects.service.ProjectMetadataService;
 import sagan.util.ResourceNotFoundException;
 import sagan.util.service.github.Readme;
 
@@ -27,6 +28,7 @@ import static org.mockito.MockitoAnnotations.initMocks;
  * Unit tests for {@link GettingStartedGuides}.
  * 
  * @author Chris Beams
+ * @author Greg Turnquist
  */
 public class GettingStartedGuidesTests {
 
@@ -42,6 +44,9 @@ public class GettingStartedGuidesTests {
     private GuideOrganization org;
 
     @Mock
+    private ProjectMetadataService projectMetadataService;
+
+    @Mock
     private Guide gsRestService;
 
     private GettingStartedGuides gsGuides;
@@ -52,7 +57,7 @@ public class GettingStartedGuidesTests {
         initMocks(this);
         given(org.getName()).willReturn("mock-org");
 
-        gsGuides = new GettingStartedGuides(org);
+        gsGuides = new GettingStartedGuides(org, projectMetadataService);
         readme.setName("README.md");
 
         given(gsRestService.getRepoName()).willReturn(GUIDE_REPO_NAME);


### PR DESCRIPTION
Currently, the sidebar links for projects wrangle the YAML front matter to project a link to the project page and name. This patch uses the ProjectMetadataService to instead use a proper site URL and name.

Tested by running the app, adding a new project for Grails/http://grails.org. Then I had a forked copy of gs-accessing-data-gorm with "grails" in the YAML projects. It worked great at rendering both Spring Boot and Grails in the sidebar.

All automated tests passed. The sidebar tests currently only test that the `AsciidocGuide` contains the tag data and does NOT actually inspect the rendered HTML, so I didn't augment those test suites.

NOTE: This adds technical debt (see #223) which should eventually be cleaned up to better separate logic and views.
