### PR TITLE
Project documentation not being indexed

### DIFF
--- a/sagan-common/src/main/java/sagan/projects/service/ProjectDataRepository.java
+++ b/sagan-common/src/main/java/sagan/projects/service/ProjectDataRepository.java
@@ -15,6 +15,6 @@ import java.util.List;
 public interface ProjectDataRepository extends JpaRepository<Project, String> {
     List<Project> findByCategory(String category);
 
-    @Query("SELECT p FROM Project p JOIN FETCH p.releaseList")
+    @Query("SELECT DISTINCT p FROM Project p JOIN FETCH p.releaseList")
     List<Project> findAllWithReleases(Sort sort);
 }

--- a/sagan-indexer/src/main/java/sagan/docs/search/ProjectDocumentationIndexer.java
+++ b/sagan-indexer/src/main/java/sagan/docs/search/ProjectDocumentationIndexer.java
@@ -51,18 +51,25 @@ public class ProjectDocumentationIndexer implements Indexer<Project> {
         searchService.removeOldProjectEntriesFromIndex(project.getId(), projectVersions);
 
         for (ProjectRelease version : project.getProjectReleases()) {
-            String apiDocUrl = version.getApiDocUrl().replace("/index.html","") + "/allclasses-frame.html";
-            ApiDocumentMapper apiDocumentMapper = new ApiDocumentMapper(project, version);
-            CrawledWebDocumentProcessor apiDocProcessor =
-                    new CrawledWebDocumentProcessor(searchService, apiDocumentMapper);
-            crawlerService.crawl(apiDocUrl, 1, apiDocProcessor);
+            if(version.getApiDocUrl().isEmpty()) {
+                String message =
+                        String.format("Unable to index API doc for projet id '%s' and version '%s' since API doc URL is empty",
+                                project.getId(), version.getVersion());
+                logger.warn(message);
+            } else {
+                String apiDocUrl = version.getApiDocUrl().replace("/index.html","") + "/allclasses-frame.html";
+                ApiDocumentMapper apiDocumentMapper = new ApiDocumentMapper(project, version);
+                CrawledWebDocumentProcessor apiDocProcessor =
+                        new CrawledWebDocumentProcessor(searchService, apiDocumentMapper);
+                crawlerService.crawl(apiDocUrl, 2, apiDocProcessor);
 
-            String refDocUrl = version.getRefDocUrl();
-            ReferenceDocumentSearchEntryMapper documentMapper =
-                    new ReferenceDocumentSearchEntryMapper(project, version);
-            CrawledWebDocumentProcessor refDocProcessor =
-                    new CrawledWebDocumentProcessor(searchService, documentMapper);
-            crawlerService.crawl(refDocUrl, 1, refDocProcessor);
+                String refDocUrl = version.getRefDocUrl();
+                ReferenceDocumentSearchEntryMapper documentMapper =
+                        new ReferenceDocumentSearchEntryMapper(project, version);
+                CrawledWebDocumentProcessor refDocProcessor =
+                        new CrawledWebDocumentProcessor(searchService, documentMapper);
+                crawlerService.crawl(refDocUrl, 1, refDocProcessor);
+            }
         }
     }
 

--- a/sagan-indexer/src/main/java/sagan/search/service/CrawlerService.java
+++ b/sagan-indexer/src/main/java/sagan/search/service/CrawlerService.java
@@ -40,7 +40,7 @@ public class CrawlerService {
 
     public void crawl(String url, int linkDepth, DocumentProcessor processor) {
         CrawlerConfiguration apiConfig =
-                new CrawlerConfiguration.Builder().setStartUrl(url).setMaxLevels(linkDepth).build();
+                new CrawlerConfiguration.Builder().setStartUrl(url).setMaxLevels(linkDepth).setVerifyUrls(false).build();
         DefaultCrawler crawler =
                 new DefaultCrawler(new ResponseFetcher(processor), Executors.newFixedThreadPool(10),
                         new CompositeURLParser(new FramePageURLParser(), new AhrefPageURLParser()));

--- a/sagan-indexer/src/test/java/sagan/docs/search/ProjectDocumentationIndexerTests.java
+++ b/sagan-indexer/src/test/java/sagan/docs/search/ProjectDocumentationIndexerTests.java
@@ -58,7 +58,7 @@ public class ProjectDocumentationIndexerTests {
     @Test
     public void apiDocsAreIndexed() throws Exception {
         service.indexItem(project);
-        int linkDepthLevel = 1;
+        int linkDepthLevel = 2;
         assertThatCrawlingIsDoneFor("http://api.example.com/3/allclasses-frame.html", linkDepthLevel);
         assertThatCrawlingIsDoneFor("http://api.example.com/2/allclasses-frame.html", linkDepthLevel);
         assertThatCrawlingIsDoneFor("http://api.example.com/1/allclasses-frame.html", linkDepthLevel);


### PR DESCRIPTION
I can't see any search hits from Spring Boot docs. The API docs are in the right place I think, as are the ref docs. In /metrics for the indexer I see quite a few errors and not many refreshes, so maybe it's not actually running at all? In the logs I see errors from a lot of missing API docs (and suspicious looking double slashes "//" in the middle of URLs), but nothing mentioning refdocs. Is there a problem with the crawler implementation (maybe it craps out if it gets a single bad link out of a possible several starting points)?
