### PR TITLE
Make "Spring Team" id configurable

### DIFF
--- a/sagan-common/src/main/java/sagan/team/support/DefaultTeamImporter.java
+++ b/sagan-common/src/main/java/sagan/team/support/DefaultTeamImporter.java
@@ -1,5 +1,6 @@
 package sagan.team.support;
 
+import org.springframework.beans.factory.annotation.Value;
 import sagan.support.github.GitHubClient;
 
 import java.io.IOException;
@@ -20,16 +21,17 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @Service
 class DefaultTeamImporter implements TeamImporter {
 
-    private static final String SPRING_TEAM_MEMBERS_ID = "482984";
-
     private final TeamService teamService;
     private final GitHubClient gitHub;
+    private final String gitHubTeamId;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Autowired
-    public DefaultTeamImporter(TeamService teamService, GitHubClient gitHub) {
+    public DefaultTeamImporter(TeamService teamService, GitHubClient gitHub,
+                               @Value("${github.team.id}") String gitHubTeamId) {
         this.teamService = teamService;
         this.gitHub = gitHub;
+        this.gitHubTeamId = gitHubTeamId;
     }
 
     @Transactional
@@ -48,7 +50,7 @@ class DefaultTeamImporter implements TeamImporter {
     private GitHubUser[] getGitHubUsers(GitHub gitHub) {
         String membersUrl = GitHubClient.API_URL_BASE + "/teams/{teamId}/members";
         ResponseEntity<GitHubUser[]> entity =
-                gitHub.restOperations().getForEntity(membersUrl, GitHubUser[].class, SPRING_TEAM_MEMBERS_ID);
+                gitHub.restOperations().getForEntity(membersUrl, GitHubUser[].class, gitHubTeamId);
         return entity.getBody();
     }
 

--- a/sagan-common/src/main/java/sagan/team/support/SignInService.java
+++ b/sagan-common/src/main/java/sagan/team/support/SignInService.java
@@ -1,5 +1,6 @@
 package sagan.team.support;
 
+import org.springframework.beans.factory.annotation.Value;
 import sagan.team.MemberProfile;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,13 +13,14 @@ import org.springframework.stereotype.Service;
 @Service
 public class SignInService {
 
-    private static final String SPRING_TEAM_MEMBERS_ID = "482984";
     private static final String IS_MEMBER_URL = "https://api.github.com/teams/{team}/members/{user}";
     private final TeamService teamService;
+    private final String gitHubTeamId;
 
     @Autowired
-    public SignInService(TeamService teamService) {
+    public SignInService(TeamService teamService, @Value("${github.team.id}") String gitHubTeamId) {
         this.teamService = teamService;
+        this.gitHubTeamId = gitHubTeamId;
     }
 
     public MemberProfile getOrCreateMemberProfile(Long githubId, GitHub gitHub) {
@@ -30,7 +32,7 @@ public class SignInService {
 
     public boolean isSpringMember(String userId, GitHub gitHub) {
         ResponseEntity<Void> response =
-                gitHub.restOperations().getForEntity(IS_MEMBER_URL, Void.class, SPRING_TEAM_MEMBERS_ID, userId);
+                gitHub.restOperations().getForEntity(IS_MEMBER_URL, Void.class, gitHubTeamId, userId);
         return response.getStatusCode() == HttpStatus.NO_CONTENT;
     }
 }

--- a/sagan-common/src/test/java/sagan/team/support/SignInServiceTests.java
+++ b/sagan-common/src/test/java/sagan/team/support/SignInServiceTests.java
@@ -40,7 +40,7 @@ public class SignInServiceTests {
 
     @Before
     public void setup() {
-        signInService = new SignInService(teamService);
+        signInService = new SignInService(teamService, "482984");
     }
 
     @Test

--- a/sagan-indexer/src/main/resources/application.yml
+++ b/sagan-indexer/src/main/resources/application.yml
@@ -46,6 +46,8 @@ elasticsearch:
 # for the sagan-site application. This arrangement should be refactored so that keeping these
 # entries here on the indexer side is no longer required.
 github:
+  team:
+    id: n/a
   client:
     id: n/a
     secret: n/a

--- a/sagan-site/src/main/resources/application.yml
+++ b/sagan-site/src/main/resources/application.yml
@@ -50,6 +50,13 @@ security:
 
 github:
 
+  # Credentials are based on users belonging to a particular GitHub team,
+  # by requesting the GitHub API (see github.client configuration keys).
+  # This key can be found in the list of teams in your organization
+  # See http://developer.github.com/v3/orgs/teams/#list-teams
+  team:
+    id: ${GITHUB_TEAM_ID:482984}
+
   # GitHub OAuth application credentials for use when logging into administrative
   # console at /admin. Default 'id' and 'secret' values apply only when running
   # locally, i.e. at http://localhost:8080. Production values must be overridden


### PR DESCRIPTION
- [x] Remove hardcoded GitHub team from SignInService, TeamImporter, etc
- [x] Read GitHub team to user for authorization out of environment
- [ ] Update wiki to reflect configurability
