### PR TITLE
declare inputs and outputs for npmInstall gradle task

### DIFF
--- a/sagan-client/build.gradle
+++ b/sagan-client/build.gradle
@@ -17,6 +17,8 @@ jar {
 task npmInstall(type:Exec) {
     logging.captureStandardOutput LogLevel.INFO
     logging.captureStandardError LogLevel.INFO
+    inputs.files "package.json", "bower.json"
+    outputs.dir "node_modules"
     commandLine 'npm', 'install'
 }
 


### PR DESCRIPTION
sagan-client has `npmInstall` and `npmBuild` tasks, that run npm tasks.
Those tasks should take advantage of the [inputs and outputs Gradle feature](http://www.gradle.org/docs/current/userguide/more_about_tasks.html#sec:task_inputs_outputs) for faster execution.
