### PR TITLE
Run site and indexer apps on JDK 8 buildpack

### DIFF
--- a/gradle/deploy.gradle
+++ b/gradle/deploy.gradle
@@ -68,6 +68,7 @@ cloudfoundry {
     domain = 'cfapps.io'
     memory = 2048
     healthCheckTimeout = 180
+    buildpack = 'https://github.com/spring-io/java-buildpack'
 }
 
 if (project.name == siteProject.name) {


### PR DESCRIPTION
@cbeams wrote:

> Hey @nebhale,
> 
> I'd like to deploy an app to CF using JDK 8 language features.
> 
> If I understand correctly, per
> 
>   https://github.com/cloudfoundry/java-buildpack/blob/master/docs/jre-openjdk.md
> 
> I'm supposed to:
> - fork the buildpack repo at https://github.com/cloudfoundry/java-buildpack
> - edit config/openjdk.yml and set
>   version: 1.8.0_+
> - point to my fork of the buildpack in my application's manifest, e.g.
>   buildpack: https://github.com/spring-io/java-buildpack
> 
> If this is the way it works, that's fine, and I'll go for it, but it would of course be good to know if there's actually an easier way to specify that I'd like to use a different JDK version.
> 
> Thanks!
> 
> P.S.: I saw somewhere in the docs that you're including JDKs based on OpenJDK milestones, e.g. M7, M8, etc. The Spring Framework team, however, has been dealing with specific ea builds, e.g. b88, b108, etc. Looking at http://openjdk.java.net/projects/jdk8/milestones, M7 is based on b94, but M8 isn't quite out yet. I believe that the Framework is being built against b108 now, which is the very latest, and is also what I have installed on my local box. is there a way to get this build in the mix with the buildpack? Thanks.

@nebhale responded:

> > If this is the way it works, that's fine, and I'll go for it, but it would of course be good to know if there's actually an easier way to specify that I'd like to use a different JDK version.
> 
> Yup, that's the answer. We've chosen this as we don't expect many people to do this sort of configuration and know that it's more difficult than it might otherwise be. That being said, I'm interested in know how you get on with this design as we don't have anyone really using it yet.
> 
> > P.S.: I saw somewhere in the docs that you're including JDKs based on OpenJDK milestones, e.g. M7, M8, etc. The Spring Framework team, however, has been dealing with specific ea builds, e.g. b88, b108, etc. Looking at http://openjdk.java.net/projects/jdk8/milestones, M7 is based on b94, but M8 isn't quite out yet. I believe that the Framework is being built against b108 now, which is the very latest, and is also what I have installed on my local box. is there a way to get this build in the mix with the buildpack? Thanks.
> 
> We've gone with M8 based on this [announcement](http://mreinhold.org/blog/jdk8-preview). In practice, that milestones page has lagged by a couple of weeks which is why you don't see the M8 there yet. We've built M8 off of b106 which is listed as the [DP](https://jdk8.java.net/archive/8-b106.html). If you guys really want b108, I'll build it up just let me know if 106 isn't going to work for you.
