### PR TITLE
Fix incorrect GPLv3 licensing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Everything regarding Sagan is tracked in [GitHub Issues](https://github.com/spri
 
 If you want to contribute code to the project, you'll need to be familiar with GitHub's notion of [pull requests] (they're awesome). See also the section below on `hub`.
 
-We also ask that you sign our [contributor license agreement](http://support.springsource.com/spring_gpl3_committer_signup). It's not too big a deal, just a form to fill out, but it'll get even smoother soon when issue [#121](https://github.com/spring-io/sagan/issues/121) is complete.
+We also ask that you sign our [contributor license agreement](http://support.springsource.com/spring_bsd3_committer_signup). It's not too big a deal, just a form to fill out, but it'll get even smoother soon when issue [#121](https://github.com/spring-io/sagan/issues/121) is complete.
 
 
 ## Coding conventions

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,27 @@
+Copyright (c) 2014, Pivotal Software, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+ * Neither the name of Pivotal Software, Inc. nor the
+   names of its contributors may be used to endorse or promote products
+   derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,58 +1,10 @@
-
-Copyright (c) 2013 Pivotal Software, Inc.
-
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-
-modification, are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice,
-
-this list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright
-
-notice, this list of conditions and the following disclaimer in the
-
-documentation and/or other materials provided with the distribution.
-
-3. Neither the name of Pivotal Software, Inc. nor the names of its
-
-contributors may be used to endorse or promote products derived from this
-
-software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-
-ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-
-LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-
-SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-
-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-
-CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-
-POSSIBILITY OF SUCH DAMAGE.
-
-
 =================================================================
 TABLE OF CONTENTS
 =================================================================
 
-spring.io ("sagan")
+spring.io ("Sagan")
 
-spring.io ("sagan") includes a number of subcomponents with separate copyright
+spring.io ("Sagan") includes a number of subcomponents with separate copyright
 notices and license terms.  The product that includes this file does not
 necessarily use all the open source subcomponents referred to below. Your
 use of the source code for the these subcomponents is subject to the terms and
@@ -4383,8 +4335,8 @@ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 THE POSSIBILITY OF SUCH DAMAGE.
 
-Copyright (c) 1999-2009, OW2 Consortium <http://www.ow2.org/>	
-		
+Copyright (c) 1999-2009, OW2 Consortium <http://www.ow2.org/>
+
 =======================================================================
 
 To the extent any open source subcomponents are licensed under the EPL and/or other
@@ -4718,8 +4670,8 @@ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 THE POSSIBILITY OF SUCH DAMAGE.
 
-Copyright (c) 1999-2009, OW2 Consortium <http://www.ow2.org/>	
-		
+Copyright (c) 1999-2009, OW2 Consortium <http://www.ow2.org/>
+
 =======================================================================
 
 To the extent any open source subcomponents are licensed under the EPL and/or other
@@ -4840,8 +4792,8 @@ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 THE POSSIBILITY OF SUCH DAMAGE.
 
-Copyright (c) 1999-2009, OW2 Consortium <http://www.ow2.org/>	
-		
+Copyright (c) 1999-2009, OW2 Consortium <http://www.ow2.org/>
+
 =======================================================================
 
 To the extent any open source subcomponents are licensed under the EPL and/or other
@@ -5456,8 +5408,8 @@ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 THE POSSIBILITY OF SUCH DAMAGE.
 
-Copyright (c) 1999-2009, OW2 Consortium <http://www.ow2.org/>	
-		
+Copyright (c) 1999-2009, OW2 Consortium <http://www.ow2.org/>
+
 =======================================================================
 
 To the extent any open source subcomponents are licensed under the EPL and/or other
@@ -8775,7 +8727,7 @@ COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL)Version 1.1
 
 1.2. "Contributor Version" means the combination of the Original Software, prior Modifications used by a Contributor (if any), and the Modifications made by that particular Contributor.
 
-1.3. "Covered SoftwareÆ?" means (a) the Original Software, or (b) Modifications, or (c) the combination of files containing Original Software with files containing Modifications, in each case including portions thereof.
+1.3. "Covered Softwareï¿½?" means (a) the Original Software, or (b) Modifications, or (c) the combination of files containing Original Software with files containing Modifications, in each case including portions thereof.
 
 1.4. "Executable" means the Covered Software in any form other than Source Code.
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ If you have any questions, feedback, or feature requests, don't hesitate to [add
 
 [Pull requests](http://help.github.com/send-pull-requests) are welcome; see the [contributor guidelines](CONTRIBUTING.md) for details.
 
-## Licensing
+## License
 
-The Sagan reference application is released under the GPLv3 license. See [LICENSE.txt](LICENSE.txt) for details.
+Sagan is released under the [BSD-3 license](LICENSE.md).
+
 
 [blog]: http://spring.io/blog
 [guides]: http://spring.io/guides


### PR DESCRIPTION
Sagan's readme incorrectly states that the project is GPLv3 licensed. Should have always read BSD-3.
- [x] Fix typo in README
- [x] Separate out LICENSE.txt into two files: LICENSE.txt and NOTICE.txt; the latter contains all license and copyright info about 3rd-party deps. The former just the text of the BSD-3.
