### PR TITLE
Support blog comments using Disqus

### DIFF
--- a/sagan-site/src/main/resources/templates/blog/_full_post.html
+++ b/sagan-site/src/main/resources/templates/blog/_full_post.html
@@ -29,18 +29,22 @@
         </div>
         <article class="blog--post" th:utext="*{renderedContent}">Blog content</article>
     </div>
-    <div class="blog-comments--wrapper">
-      <div class="blog-comments--container desktop-only">
-        <div class="blog-comments--header">
-          Have feedback? Let the team know at <a th:href="@{'https://twitter.com/intent/tweet?text=@springcentral&related=springcentral&url=http://spring.io'+${post.path}}">@springcentral</a>. We read every mention.
-        </div>
-      </div>
-      <div class="mobile-only">
-        <p><a th:href="@{/blog}">
-          <i class="icon-chevron-left"></i>
-          Back
-        </a></p>
-      </div>
+    <div id="disqus_thread"></div>
+    <script type="text/javascript">
+      var disqus_shortname = 'spring-io';
+      (function() {
+        var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+        dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+        (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+      })();
+    </script>
+    <noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
+    <a href="http://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>
+    <div class="mobile-only">
+      <p><a th:href="@{/blog}">
+        <i class="icon-chevron-left"></i>
+        Back
+      </a></p>
     </div>
   </div>
   </body>


### PR DESCRIPTION
Per consensus in #128 and on internal mailing lists, add comments to the blog using Disqus.

Per [best practices for staging sites](http://help.disqus.com/customer/portal/articles/1053796) (great doc):
- [x] re-register under sagan-ops@gopivotal such that the account is 'portable'
- [x] register two shortnames: one for staging, one for prod
- [x] whitelist their respective domains
- [x] expose discus_shortname through profiles
- [x] see what happens when there are no comments on localhost (perhaps instruct folks how they can add this themselves.).

Next steps:
- [x] comment count in index page (see #338)
