### PR TITLE
Support -Pspace=<...> vs. -Pproduction / -Pstaging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
     - secure: "Z1OEibV0KFLukQT+goeCwassBwrcgB9gLdjG9iAI1EE3nVivjRK/kGXb4k1vWvfj2Si4O2KuVo6RZwAqzPCCJpdk0QYwHzKBxDvJCHHDV284On/2Wu+i7xXt53WVs25Xs2+GV2NzyUhexPKo6PvaRemPxfYH0kkPn01W/NO/ow4="
     - secure: "HLVX8ge6FAvgqxTcHX8mIEkSYC9fbK4pfCdJykGjK2AGeiInh8bJgJw4Pe0lEaJPJq8WngTxgvT80zWtALkUw+32Zs4Q20jUFuBAlWR2CcfmkT2ZM04E8UnGfan8ky/D2JUbfQrH2pX5o/MQ+goT1aOhHUImhCGEPuYPWteTQWo="
 
-script: ./gradlew deploy -Pproduction
+script: ./gradlew deploy
 
 notifications:
   hipchat:

--- a/gradle/deploy.gradle
+++ b/gradle/deploy.gradle
@@ -3,11 +3,15 @@ gradle.rootProject.allprojects { project ->
     checkTasks.addAll(project.tasks.findAll { it.name == 'build' })
 }
 
+def final TARGET_SPACE = 'space'
+def final PRODUCTION_SPACE = 'production'
+def final STAGING_SPACE = 'staging'
+
 def siteProject = project(':sagan-site')
 def indexerProject = project(':sagan-indexer')
 
 task deploy(dependsOn: [ build, rootProject.gitMetadata ]) {
-    description = 'Deploys the project to a Cloud Foundry space (specified with -P<spacename>)'
+    description = 'Deploys the project to a Cloud Foundry space (specified with -Pspace=<targetspace>)'
     mustRunAfter checkTasks
 
     // Gather information about the build environment. Is it a Travis CI build?
@@ -16,10 +20,22 @@ task deploy(dependsOn: [ build, rootProject.gitMetadata ]) {
     def isPullRequest = Boolean.valueOf(System.getenv().get("TRAVIS_PULL_REQUEST"))
     def isTravisBuild = travisBranch != null
 
+    // User may specify an explicit target space any time, e.g. ./gradlew deploy -Pspace=production
+    // Otherwise, target space will be determined by branch name (assuming we are in a Travis CI build).
+    // If no branch is matched, no space is set, and deployment will be skipped entirely.
+    if (!project.hasProperty(TARGET_SPACE) && travisBranch != null) {
+        if (travisBranch =~ '^master$') {
+            project.ext.setProperty(TARGET_SPACE, PRODUCTION_SPACE)
+        }
+        else if (travisBranch =~ '^stage-.*') {
+            project.ext.setProperty(TARGET_SPACE, STAGING_SPACE)
+        }
+    }
+
     // Always proceed with deployment if it is a local build. If we're on Travis CI, only
     // deploy if the secure environment vars are available (i.e. this is not a pull request
     // from a fork) and we're on a branch intended for production deployment.
-    if (!isTravisBuild || (isTravisBuild && !isPullRequest && hasSecureEnv && travisBranch == "master")) {
+    if (!isTravisBuild || (isTravisBuild && !isPullRequest && hasSecureEnv && project.hasProperty(TARGET_SPACE))) {
         dependsOn 'cf-login'
 
         // the site gets blue-green deployment
@@ -140,9 +156,9 @@ gradle.taskGraph.whenReady {
 // cf-push and cf-swap-deployed. Using both forms of specifying routes gives control over which routes are decorated and
 // which routes are undecorated.
 
-if (project.hasProperty('staging')) {
+if (project.hasProperty(TARGET_SPACE)) {
     cloudfoundry {
-        space = 'staging'
+        space = project.getProperty(TARGET_SPACE)
         host = "$application-${space}"
 
         env << [
@@ -155,7 +171,7 @@ if (project.hasProperty('staging')) {
             'sagan-db' {
                 label = 'elephantsql'
                 provider = 'elephantsql'
-                plan = 'hippo'
+                plan = (space == PRODUCTION_SPACE ? 'panda' : 'hippo')
                 version = 'n/a'
             }
             'newrelic' {
@@ -169,41 +185,9 @@ if (project.hasProperty('staging')) {
 
     if (project.name == siteProject.name) {
         cloudfoundry {
-            uris = [ "${space}.spring.io" ]
+            uris = (space == PRODUCTION_SPACE ? [ "spring.io", "www.spring.io" ] : [ "${space}.spring.io" ])
         }
     }
 }
 
-if (project.hasProperty('production')) {
-    cloudfoundry {
-        space = 'production'
-        host = "$application-${space}"
 
-        env << [
-            SPRING_PROFILES_ACTIVE: "${space}",
-            NEW_RELIC_APP_NAME: "sagan-blue;sagan",
-            ELASTICSEARCH_INDEX: "sagan-${space}"
-        ]
-
-        services {
-            'sagan-db' {
-                label = 'elephantsql'
-                provider = 'elephantsql'
-                plan = 'panda'
-                version = 'n/a'
-            }
-            'newrelic' {
-                label = 'newrelic'
-                provider = 'newrelic'
-                plan = 'standard'
-                version = 'n/a'
-            }
-        }
-    }
-
-    if (project.name == siteProject.name) {
-        cloudfoundry {
-            uris = [ "spring.io", "www.spring.io" ]
-        }
-    }
-}


### PR DESCRIPTION
Prior to this commit, deployment required specifying

```
./gradlew deploy -Pproduction # OR
./gradlew deploy -Pstaging
```

This worked fine, but required unnecessarily complex conditional logic in
deploy.gradle. This change refactors this logic such that -Pspace is required
and the value is treated as the target space. 'production' is treated as a
reserved value and gets special treatment, e.g.:
- 'panda' database instead of default 'hippo'
- 'spring.io' and 'www.spring.io' URIs are mapped, instead of the default '${space}.spring.io'

If the value of the space property is anything other than 'production', then
the defaults mentioned above apply instead.

If the space property is not present and the build is running on Travis CI,
the implementation now looks to the name of the current git branch to
determine the target space. This allows us to push changes to master in order
to deploy to production, and to push branches named stage-foo, stage-bar, etc
to deploy to staging.

See also #331
