### PR TITLE
Fix table style in blog posts

### DIFF
--- a/sagan-client/src/css/blog.css
+++ b/sagan-client/src/css/blog.css
@@ -167,6 +167,7 @@
 */
 .blog--container .blog--post table {
     width: 100%;
+    margin: 30px 0;
 }
 
 .blog--container .blog--post td,
@@ -179,6 +180,9 @@
 
 .blog--container .blog--post th {
     text-align: left;
+    text-transform: uppercase;
+    border-bottom: 1px solid #ccc;
+    font-family: "Montserrat", sans-serif;
 }
 
 .blog--container .blog--post td {


### PR DESCRIPTION
CSS stylesheets currently don't add a margin at the bottom of tables in post content (like it does for code dovs and paragraphs).
