### PR TITLE
code-snippet copy button covers content in top-right corner

### DIFF
--- a/sagan-client/src/css/fix-asciidoctor-styles.css
+++ b/sagan-client/src/css/fix-asciidoctor-styles.css
@@ -51,4 +51,12 @@
 .content--container .listingblock .copy-button {
     position: absolute;
     right: 0;
+    display:none;
+}
+
+.content--container .has-copy-button:hover .copy-button,
+.content--container .listingblock:hover .copy-button,
+.content--container .has-copy-button .zeroclipboard-is-hover,
+.content--container .listingblock .zeroclipboard-is-hover {
+    display:block;
 }


### PR DESCRIPTION
When the first line of a code snippet extends the full length of the block (i.e. is the longest line in the snippet), the copy button hides the code in the top-right corner.

See http://spring.io/guides/gs/accessing-data-rest/ for several examples ([Ctrl+F] -X PATCH)

Perhaps the copy button can display only on mouse-over of the snippet, or perhaps display outside the snippet block.

Browser: Chrome Version 33.0.1750.154
