### PR TITLE
Order projects alphabetically on the docs page?

### DIFF
--- a/sagan-site/src/main/java/sagan/docs/support/DocsController.java
+++ b/sagan-site/src/main/java/sagan/docs/support/DocsController.java
@@ -37,6 +37,7 @@ class DocsController {
     private List<Project> nonAggregatorsForCategory(String category) {
         return service.getProjectsForCategory(category).stream()
                 .filter(project -> !project.isAggregator())
+                .sorted((p1, p2) -> p1.getId().compareToIgnoreCase(p2.getId()))
                 .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
I realise that there's a search box, but if the projects were listed alphabetically I'd be able to locate the project I was looking for more quickly than by typing in a search
