### PR TITLE
Exclude Commons logging and Log4j from dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,13 @@ configure(javaProjects) {
         testCompile 'org.mockito:mockito-core'
     }
 
+    configurations {
+        // replaced with jcl-over-slf4j
+        all*.exclude group: 'commons-logging', module: 'commons-logging'
+        // replaced with log4j-over-slf4j
+        all*.exclude group: 'log4j', module: 'log4j'
+    }
+
     // Ensure that all Gradle-compiled classes are available to Eclipse's
     // classpath.
     eclipseClasspath.dependsOn testClasses


### PR DESCRIPTION
Sagan is set up with Logback as the logging framework, with Slf4j bridges from Commons logging, log4j and Java Util logging. Prior to this commit both log4j and Commons logging were included in the dependencies. Commons logging seem to get routed fine to Slf4j, but with libraries using Log4j or JBoss logger (used by Hibernate) it seem to be random due to class loading order (mostly not).

This commit exclude both Log4j and Commons logging from the dependencies.

Looking at the log related dependencies before and after this commit:

```
 ./gradlew :sagan-site:dependencies | egrep 'log|slf4j' |  sed -r 's/^.*---//' | sort | uniq                                                                                                                      
 ch.qos.logback:logback-classic:1.1.2
 ch.qos.logback:logback-core:1.1.2
 commons-logging:commons-logging:1.1.3
 log4j:log4j:1.2.14
 org.apache.tomcat.embed:tomcat-embed-logging-juli:7.0.52
 org.jboss.logging:jboss-logging:3.1.1.GA -> 3.1.3.GA
 org.jboss.logging:jboss-logging:3.1.3.GA
 org.jboss.logging:jboss-logging-annotations:1.2.0.Beta1
 org.slf4j:jcl-over-slf4j:1.7.6 -> 1.7.7 (*)
 org.slf4j:jcl-over-slf4j:1.7.7
 org.slf4j:jul-to-slf4j:1.7.7
 org.slf4j:log4j-over-slf4j:1.7.7
 org.slf4j:slf4j-api:1.6.1 -> 1.7.7
 org.slf4j:slf4j-api:1.7.5 -> 1.7.7
 org.slf4j:slf4j-api:1.7.6 -> 1.7.7
 org.slf4j:slf4j-api: -> 1.7.7
 org.slf4j:slf4j-api:1.7.7
```

```
 ch.qos.logback:logback-classic:1.1.2
 ch.qos.logback:logback-core:1.1.2
 org.apache.tomcat.embed:tomcat-embed-logging-juli:7.0.52
 org.jboss.logging:jboss-logging:3.1.1.GA -> 3.1.3.GA
 org.jboss.logging:jboss-logging:3.1.3.GA
 org.jboss.logging:jboss-logging-annotations:1.2.0.Beta1
 org.slf4j:jcl-over-slf4j:1.7.6 -> 1.7.7 (*)
 org.slf4j:jcl-over-slf4j:1.7.7
 org.slf4j:jul-to-slf4j:1.7.7
 org.slf4j:log4j-over-slf4j:1.7.7
 org.slf4j:slf4j-api:1.6.1 -> 1.7.7
 org.slf4j:slf4j-api:1.7.5 -> 1.7.7
 org.slf4j:slf4j-api:1.7.6 -> 1.7.7
 org.slf4j:slf4j-api: -> 1.7.7
 org.slf4j:slf4j-api:1.7.7
 org.springframework.boot:spring-boot-starter-logging:1.0.2.RELEASE
```

And then starting Sagan with the test class below:

``` java
package sagan;

import org.springframework.stereotype.Component;

import javax.annotation.PostConstruct;

@Component
public class LogTester {

    @PostConstruct
    public void doSomeLogging() {

        org.apache.commons.logging.Log commonsLogger = org.apache.commons.logging.LogFactory.getLog(LogTester.class);
        org.jboss.logging.Logger jbossLogger = org.jboss.logging.Logger.getLogger(LogTester.class);
        org.slf4j.Logger slf4jLogger = org.slf4j.LoggerFactory.getLogger(LogTester.class);
        org.apache.log4j.Logger log4jLogger = org.apache.log4j.LogManager.getLogger(LogTester.class);
        java.util.logging.Logger javaLogger = java.util.logging.Logger.getLogger(LogTester.class.getName());

        commonsLogger.error("**** Commons logging " + commonsLogger +  " ***");
        jbossLogger.error("*** JBoss logging " + jbossLogger + " ***");
        log4jLogger.error("*** log4j logging " + log4jLogger + " ***");
        slf4jLogger.error("*** slf4j logging " + slf4jLogger + " ***");
        javaLogger.severe("*** Java logging " + javaLogger + " ***");
    }
}
```

Log output before and after this commit:

```
2014-05-02 17:54:42.599  INFO 10233 --- [           main] sagan.SiteMain                           : Starting SiteMain on bep-laptop with PID 10233 (/home/bep/dev/sagan/sagan-site/build/classes/main started by bep in /home/bep/dev/sagan/sagan-site)
log4j:WARN No appenders could be found for logger (org.jboss.logging).
log4j:WARN Please initialize the log4j system properly.
2014-05-02 17:54:54.473  INFO 10233 --- [ost-startStop-1] b.a.s.AuthenticationManagerConfiguration : 

Using default password for application endpoints: c0a05245-058c-423c-9b81-9b98c77fc748


2014-05-02 17:54:55.820  WARN 10233 --- [           main] sagan.support.github.GitHubConfig        : GitHub API access will be rate-limited at 60 req/hour
2014-05-02 17:55:00.290 ERROR 10233 --- [           main] sagan.LogTester                          : **** Commons logging org.apache.commons.logging.impl.SLF4JLocationAwareLog@19f497aa ***
2014-05-02 17:55:00.291 ERROR 10233 --- [           main] sagan.LogTester                          : *** slf4j logging Logger[sagan.LogTester] ***
2014-05-02 17:55:00.293 ERROR 10233 --- [           main] sagan.LogTester                          : *** Java logging java.util.logging.Logger@9147ba2 ***
2014-05-02 17:55:01.606  INFO 10233 --- [           main] sagan.SiteMain                           : Started SiteMain in 19.466 seconds (JVM running for 20.344)
```

```
2014-05-02 18:05:56.804  INFO 10610 --- [           main] sagan.SiteMain                           : Starting SiteMain on bep-laptop with PID 10610 (/home/bep/dev/sagan/sagan-site/build/classes/main started by bep in /home/bep/dev/sagan/sagan-site)
2014-05-02 18:06:06.053  WARN 10610 --- [ost-startStop-1] org.hibernate.cfg.SettingsFactory        : Unrecognized value for "hibernate.hbm2ddl.auto": false
2014-05-02 18:06:08.835  INFO 10610 --- [ost-startStop-1] b.a.s.AuthenticationManagerConfiguration : 

Using default password for application endpoints: d955740d-8ea5-425a-abf0-9038ca31716d


2014-05-02 18:06:09.827  WARN 10610 --- [           main] sagan.support.github.GitHubConfig        : GitHub API access will be rate-limited at 60 req/hour
2014-05-02 18:06:14.304 ERROR 10610 --- [           main] sagan.LogTester                          : **** Commons logging org.apache.commons.logging.impl.SLF4JLocationAwareLog@4449a60b ***
2014-05-02 18:06:14.305 ERROR 10610 --- [           main] sagan.LogTester                          : *** JBoss logging org.jboss.logging.Slf4jLocationAwareLogger@da5d5e1 ***
2014-05-02 18:06:14.306 ERROR 10610 --- [           main] sagan.LogTester                          : *** log4j logging org.apache.log4j.Logger@7d7d8911 ***
2014-05-02 18:06:14.307 ERROR 10610 --- [           main] sagan.LogTester                          : *** slf4j logging Logger[sagan.LogTester] ***
2014-05-02 18:06:14.307 ERROR 10610 --- [           main] sagan.LogTester                          : *** Java logging java.util.logging.Logger@460eb276 ***
2014-05-02 18:06:15.557  INFO 10610 --- [           main] sagan.SiteMain                           : Started SiteMain in 19.354 seconds (JVM running for 20.411)
```

This is also the reason why configuration errors described in issue #365 are hard to spot.

I have signed the Individual Contributor BSD3 Agreement, confirmation number 56120140502092644.
