### PR TITLE
Unrecognized property value for spring.jpa.hibernate.ddl-auto

### DIFF
--- a/sagan-indexer/src/main/resources/application.yml
+++ b/sagan-indexer/src/main/resources/application.yml
@@ -23,7 +23,7 @@ spring:
     show_sql: false
     hibernate:
       namingstrategy: org.hibernate.cfg.EJB3NamingStrategy
-      ddl-auto: false
+      ddl-auto: none
 
 security:
   basic:


### PR DESCRIPTION
`spring.jpa.hibernate.ddl-auto=false` is not a valid value for that property and results in a WARNING in log:

`Unrecognized value for "hibernate.hbm2ddl.auto": false`

The correct should be:

spring.jpa.hibernate.ddl-auto=none
