### PR TITLE
Enable dynamic class reloading with Spring Loaded

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ buildscript {
     dependencies {
         classpath "org.springframework.boot:spring-boot-gradle-plugin:1.0.2.RELEASE"
         classpath 'org.cloudfoundry:cf-gradle-plugin:1.0.2' // see deploy.gradle
+        classpath 'org.springframework:springloaded:1.2.0.RELEASE'
     }
 }
 


### PR DESCRIPTION
This pull request adds Spring Loaded to the buildscript classpath, as instructed in spring-projects/spring-boot@77bac876ce8e164b652b92ca8bc6ee705e92a4a5. With this change in place, an attempt to run `gradle bootRun` will fail as follows:

```
$ gradle :sagan-site:bootRun
[...]
:sagan-site:bootRun FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':sagan-site:bootRun'.
> The JVM must be started with -noverify for this agent to work. You can use JAVA_OPTS to add that flag.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

BUILD FAILED
```

Passing `-noverify` via JAVA_OPTS does not actually work as advertised above. Instead we use GRADLE_OPTS, e.g.:

```
GRADLE_OPTS=-noverify gradle :sagan-site:bootRun
```

And the app fails as follows:
```
> :sagan-site:bootRunobjc[7936]: Class JavaLaunchHelper is implemented in both /Library/Java/JavaVirtualMachines/jdk1.8.0.jdk/Contents/Home/bin/java and /Library/Java/JavaVirtualMachines/jdk1.8.0.jdk/Contents/Home/jre/lib/libinstrument.dylib. One of the two will be used. Which one is undefined.
:sagan-site:bootRun FAILED
```

Perhaps I've missed something simple, but if so, it doesn't appear to be documented.

/cc @dsyer, @aclement, @rstoyanchev, @bclozel, @joshlong

See spring-projects/spring-boot#183