### PR TITLE
Fixes invalid value for ddl-auto in sagan-site

### DIFF
--- a/sagan-site/src/main/resources/application.yml
+++ b/sagan-site/src/main/resources/application.yml
@@ -26,7 +26,7 @@ spring:
     show_sql: false
     hibernate:
       namingstrategy: org.hibernate.cfg.EJB3NamingStrategy
-      ddl-auto: false
+      ddl-auto: none
 
 security:
   basic:


### PR DESCRIPTION
Change spring.jpa.hibernate.ddl-auto from 'false' (invalid) to 'none' in sagan-site. This was previously fixed in sagan-indexer (see #365), but missed this one.
