### PR TITLE
Use the latest version of NekoHTML (1.9.20)

### DIFF
--- a/sagan-site/build.gradle
+++ b/sagan-site/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     compile 'org.thymeleaf.extras:thymeleaf-extras-springsecurity3'
 
     // nekohtml is required for thymeleaf's LEGACYHTML5 mode
-    runtime 'net.sourceforge.nekohtml:nekohtml:1.9.15'
+    runtime 'net.sourceforge.nekohtml:nekohtml:1.9.20'
 
     // for use in generating blog atom feeds
     compile 'net.java.dev.rome:rome:1.0.0'

--- a/sagan-site/src/main/resources/templates/guides/index.html
+++ b/sagan-site/src/main/resources/templates/guides/index.html
@@ -18,7 +18,7 @@
         </span>
       </p>
 
-      <a name="gs"/>
+      <a name="gs"></a>
       <div class="row-fluid content-container--wrapper guides-section--container">
         <div class="content-container--header">
           <input type='text' id='doc_filter' style="color:#aaa;" onfocus="this.value=''; this.style.color='#000'; this.style.fontStyle='normal'; this.onfocus='';" autofocus value="Find a guide..." placeholder="Find a guide..." class="content-container--filter"/>
@@ -41,7 +41,7 @@
           <div data-filterable-container>
             <div class="content-section-title--container">
               <div class="pull-left icon icon-tutorial"></div>
-              <a name="tutorials"/>
+              <a name="tutorials"></a>
               <h3 class="content-section-title no-margin">Tutorials</h3>
               <p class="content-section-sub-title">Designed to be completed in 2-3 hours, these guides provide deeper, in-context explorations of enterprise application development topics, leaving you ready to implement real-world solutions.</p>
             </div>


### PR DESCRIPTION
1.9.20 is the version of NekoHTML that's included in Spring IO Platform.

Please see the commit comment for further details, including an explanation of the changes to the `<a>` tags in the Guides index page.
