### PR TITLE
Add min-height so table doesn't break when downloads only have 1 row

### DIFF
--- a/sagan-client/src/css/tools.css
+++ b/sagan-client/src/css/tools.css
@@ -302,6 +302,7 @@
   margin: 40px 0 33px;
   width: 232px;
   padding: 0 10px;
+  min-height: 182px;
 }
 .tool-versions--wrapper .tool-versions--container .platform:last-child {
   border-right: none;


### PR DESCRIPTION
This is in preparation for a change that @martinlippert will be making to add another download table that only requires one of versions.

It may spread things out just a bit too far vertically for the smallest layout width.  If that's a problem, I can look into adding an adjustment for that media query.
