### PR TITLE
Fix typo when reporting git branch for /info use

### DIFF
--- a/gradle/gitMetadata.gradle
+++ b/gradle/gitMetadata.gradle
@@ -13,7 +13,7 @@ buildscript {
  */
 task gitMetadata(type: org.ajoberstar.gradle.git.tasks.GitBranchList) << {
     ext {
-        branch = workingBranch?.name ?: "detatched HEAD"
+        branch = workingBranch?.name ?: "detached HEAD"
         commitId = workingBranch?.commit?.abbreviatedId ?: "unknown"
         commitTime =  workingBranch?.commit?.time ?
                 new Date(new Integer(workingBranch.commit.time).longValue()*1000L).format("yyyy-MM-dd HH:mm") : "unknown"


### PR DESCRIPTION
Thanks to Henning Hoefer's eagle-eyed observations at
https://vimeo.com/90956088#comment_11707853
