### PR TITLE
Search should not return unpublished entries

### DIFF
--- a/sagan-common/src/main/java/sagan/SearchClientConfig.java
+++ b/sagan-common/src/main/java/sagan/SearchClientConfig.java
@@ -2,6 +2,8 @@ package sagan;
 
 import java.util.LinkedHashSet;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -32,7 +34,8 @@ class SearchClientConfig {
         LinkedHashSet<String> servers = new LinkedHashSet<>();
         servers.add(endpoint);
         logger.info("**** Elastic Search endpoint: " + endpoint);
-        return new ClientConfig.Builder(servers).multiThreaded(true).build();
+        Gson gson = new GsonBuilder().setDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX").create();
+        return new ClientConfig.Builder(servers).multiThreaded(true).gson(gson).build();
     }
 
 }

--- a/sagan-site/src/it/java/sagan/search/support/SearchFacetsIntegrationTests.java
+++ b/sagan-site/src/it/java/sagan/search/support/SearchFacetsIntegrationTests.java
@@ -7,6 +7,7 @@ import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 
 import org.junit.After;
@@ -243,9 +244,9 @@ public class SearchFacetsIntegrationTests extends AbstractIntegrationTests {
     @Test
     public void unpublishedEntriesDoNotAppearInResultsOrFacets() throws ParseException {
         SearchEntry unpublishedPost = SearchEntryBuilder.entry()
-                .path("http://example.com/blog")
+                .path("http://example.com/anotherBlog")
                 .title("a title")
-                .publishAt("2100-12-01 12:32")
+                .publishAt(new Date(System.currentTimeMillis() + (24 * 60 * 60 * 1000)))
                 .facetPath("Blog")
                 .facetPath("Blog/Engineering").build();
 
@@ -257,6 +258,9 @@ public class SearchFacetsIntegrationTests extends AbstractIntegrationTests {
 
         List<SearchResult> results = searchResults.getPage().getContent();
         assertThat(results.size(), equalTo(2));
+
+        List<String> paths = results.stream().map(SearchResult::getPath).collect(toList());
+        assertThat(paths, hasItems(blog.getPath(), gettingStarted.getPath()));
 
         List<SearchFacet> facets = searchResults.getFacets();
         assertThat(facets.size(), equalTo(2));

--- a/sagan-site/src/main/resources/elasticsearch/mappings/apiDoc.json
+++ b/sagan-site/src/main/resources/elasticsearch/mappings/apiDoc.json
@@ -13,7 +13,7 @@
                 "analyzer": "partial_word"
             },
             "publishAt": {
-                "type": "string",
+                "type": "date",
                 "store": "yes"
             },
             "summary": {

--- a/sagan-site/src/main/resources/elasticsearch/mappings/site.json
+++ b/sagan-site/src/main/resources/elasticsearch/mappings/site.json
@@ -13,7 +13,7 @@
                 "analyzer": "partial_word"
             },
             "publishAt": {
-                "type": "string",
+                "type": "date",
                 "store": "yes"
             },
             "summary": {


### PR DESCRIPTION
There is a passing test for this, `SearchFacetsIntegrationTests#unpublishedEntriesDoNotAppearInResultsOrFacets`, but it was green for the wrong reason (duplicate path).

This commit applies several fixes to how the date `publishAt` is handled in search:

*  `publishAt` is set to `date` in the Elasticsearch mapping.
* A date format is provided to the `Gson` instance in the configured Jest client.
* Filter for unpublished entries are moved to a query filter. When applied as a post filter, the unpublished entries are correctly filtered out from the query result, but show up in the facets.

**NOTE:**  The search index must obviously be rebuilt if this fix is applied to the live system.