### PR TITLE
Log Elastic Search failures

### DIFF
--- a/sagan-common/src/main/java/sagan/search/support/SearchService.java
+++ b/sagan-common/src/main/java/sagan/search/support/SearchService.java
@@ -91,6 +91,9 @@ public class SearchService {
         try {
             JestResult result = jestClient.execute(action);
             logger.debug(result.getJsonString());
+            if(!result.isSucceeded()) {
+                logger.warn("Failed to execute Elastic Search action: " + result.getErrorMessage());
+            }
             return result;
         } catch (Exception e) {
             throw new SearchException(e);


### PR DESCRIPTION
It may be sensible to fail softly when actions against Elastic Search fails for some reason, but not as soft as the current solution. Jest reports errors through `result.isSucceeded()` and `result.getErrorMessage()` (mapping errors and other).

This commit add WARN logging when `result.isSucceeded()` is `false` to make it easier to detect error situations.
