### PR TITLE
Add optional war build triggered with -Pwar ( See #419 )

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,8 @@ configure(rootProject) {
 
 configure(javaProjects) {
     apply plugin: 'java'
+    if ( project.hasProperty('war') )
+      apply plugin: 'war'
 
     targetCompatibility = vJavaLang
     sourceCompatibility = vJavaLang

--- a/sagan-common/src/main/java/sagan/support/StaticPagePathFinder.java
+++ b/sagan-common/src/main/java/sagan/support/StaticPagePathFinder.java
@@ -49,7 +49,8 @@ public class StaticPagePathFinder {
     }
 
     private String relativeFilePath(String basePath, Resource resource) throws IOException {
-        return resource.getURL().getPath().substring(basePath.length()).replace(".html", "");
+        String path = resource.getURL().getPath().substring(basePath.length()).replace(".html", "");
+        return path.startsWith("/") ? path : "/" + path;
     }
 
     private String buildRequestMapping(String filePath) {

--- a/sagan-indexer/build.gradle
+++ b/sagan-indexer/build.gradle
@@ -3,8 +3,18 @@ springBoot.mainClass = 'sagan.IndexerMain'
 
 dependencies {
     compile project(':sagan-common')
-
-    compile "org.springframework.boot:spring-boot-starter-web"
+    
+    if ( project.hasProperty('war') ) { 
+      compile("org.springframework.boot:spring-boot-starter-web") {
+        exclude(module: 'tomcat-embed-core')
+        exclude(module: 'tomcat-embed-logging-juli')
+      }
+      providedRuntime 'org.apache.tomcat.embed:tomcat-embed-core'
+      providedCompile 'org.apache.tomcat.embed:tomcat-embed-jasper'
+      providedRuntime 'org.apache.tomcat.embed:tomcat-embed-logging-juli'
+		} else {
+      compile("org.springframework.boot:spring-boot-starter-web")
+		}
     compile "org.springframework.boot:spring-boot-starter-actuator"
     compile "org.springframework.boot:spring-boot-starter-security"
 

--- a/sagan-indexer/src/main/java/sagan/IndexerWebXml.java
+++ b/sagan-indexer/src/main/java/sagan/IndexerWebXml.java
@@ -1,0 +1,14 @@
+package sagan;
+
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.context.web.SpringBootServletInitializer;
+
+public class IndexerWebXml extends SpringBootServletInitializer {
+
+    @Override
+    protected SpringApplicationBuilder configure(SpringApplicationBuilder application) {
+        SpringApplicationBuilder sources = application.sources(IndexerConfig.class);
+        return sources;
+    }
+
+}

--- a/sagan-site/build.gradle
+++ b/sagan-site/build.gradle
@@ -14,7 +14,17 @@ dependencies {
     compile project(':sagan-common')
     compile project(':sagan-client')
 
-    compile "org.springframework.boot:spring-boot-starter-web"
+    if ( project.hasProperty('war') ) { 
+      compile("org.springframework.boot:spring-boot-starter-web") {
+        exclude(module: 'tomcat-embed-core')
+        exclude(module: 'tomcat-embed-logging-juli')
+      }
+      providedRuntime 'org.apache.tomcat.embed:tomcat-embed-core'
+      providedCompile 'org.apache.tomcat.embed:tomcat-embed-jasper'	// until spring-boot #248 is fixed
+      providedRuntime 'org.apache.tomcat.embed:tomcat-embed-logging-juli'
+    } else {
+      compile("org.springframework.boot:spring-boot-starter-web")
+    }
     compile "org.springframework.boot:spring-boot-starter-actuator"
     compile "org.springframework.boot:spring-boot-starter-security"
     compile "org.springframework.security:spring-security-acl"

--- a/sagan-site/src/main/java/sagan/SiteWebXml.java
+++ b/sagan-site/src/main/java/sagan/SiteWebXml.java
@@ -1,0 +1,14 @@
+package sagan;
+
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.context.web.SpringBootServletInitializer;
+
+public class SiteWebXml extends SpringBootServletInitializer {
+
+    @Override
+    protected SpringApplicationBuilder configure(SpringApplicationBuilder application) {
+        SpringApplicationBuilder sources = application.sources(SiteConfig.class);
+        return sources;
+    }
+
+}


### PR DESCRIPTION
I wanted to test deploying Sagan as a WAR to tomcat. To do this I added an option to the build.gradle, where if the gradle property -Pwar=true is specified, then the following command would build a WAR rather than a JAR file.

```
./gradlew :sagan-site:clean :sagan-site:build -x check -Pwar=true
```

If -Pwar is not present, then the Jar will be built as normal.

StaticPagePathFinder was also modified as when converting to a war the leading '/' was being trimmed from Resource Url paths. Tested this in tomcat on both Linux Centos & Windows 7.

A gradle property seemed like the best way to make the WAR optional. Let me know if it should be done a different way.

Also, ran into an error when trying to convert issue 419 to a pull request. 

```
C:\...\sagan>hub pull-request -i 419
...
Error creating pull request: Unprocessable Entity (HTTP 422)
Invalid value for "issue": "419"
```

Not sure what I am missing, so I am submitting the pull request manually through Github.
