### PR TITLE
Add config to allow non-spring-member sign-in

### DIFF
--- a/sagan-common/src/main/java/sagan/team/support/DefaultTeamImporter.java
+++ b/sagan-common/src/main/java/sagan/team/support/DefaultTeamImporter.java
@@ -7,6 +7,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
@@ -14,12 +17,15 @@ import org.springframework.social.github.api.GitHub;
 import org.springframework.social.github.api.GitHubUser;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestClientException;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Service
 class DefaultTeamImporter implements TeamImporter {
+
+    private static final Log logger = LogFactory.getLog(DefaultTeamImporter.class);
 
     private final TeamService teamService;
     private final GitHubClient gitHub;
@@ -49,9 +55,14 @@ class DefaultTeamImporter implements TeamImporter {
 
     private GitHubUser[] getGitHubUsers(GitHub gitHub) {
         String membersUrl = GitHubClient.API_URL_BASE + "/teams/{teamId}/members";
-        ResponseEntity<GitHubUser[]> entity =
-                gitHub.restOperations().getForEntity(membersUrl, GitHubUser[].class, gitHubTeamId);
-        return entity.getBody();
+        try {
+            ResponseEntity<GitHubUser[]> entity =
+                    gitHub.restOperations().getForEntity(membersUrl, GitHubUser[].class, gitHubTeamId);
+            return entity.getBody();
+        } catch (RestClientException e) {
+            logger.warn("Failed to retrieve team members. reason=" + e.getMessage());
+            return new GitHubUser[] { };
+        }
     }
 
     public String getNameForUser(String username) {

--- a/sagan-site/src/main/resources/application.yml
+++ b/sagan-site/src/main/resources/application.yml
@@ -56,6 +56,8 @@ github:
   # See http://developer.github.com/v3/orgs/teams/#list-teams
   team:
     id: ${GITHUB_TEAM_ID:482984}
+    # Allow non spring team member to become admin
+    non_member_admin: false
 
   # GitHub OAuth application credentials for use when logging into administrative
   # console at /admin. Default 'id' and 'secret' values apply only when running


### PR DESCRIPTION
While I'm exploring sagan app, I needed to work around the admin access since I'm not a spring team member.
I just thought it would be nice to have a configuration that can toggle non spring member sign-in, especially for outside developers who want to develop sagan.  
This is good for local dev.
Since sagan is a web site for spring, it may not make sense to have this feature though...
