### PR TITLE
Fix json mapping to get github username

### DIFF
--- a/sagan-common/src/main/java/sagan/team/support/DefaultTeamImporter.java
+++ b/sagan-common/src/main/java/sagan/team/support/DefaultTeamImporter.java
@@ -5,7 +5,6 @@ import sagan.support.github.GitHubClient;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -15,7 +14,7 @@ import org.springframework.social.github.api.GitHubUser;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Service
@@ -57,9 +56,8 @@ class DefaultTeamImporter implements TeamImporter {
     public String getNameForUser(String username) {
         String jsonResponse = gitHub.sendRequestForJson("/users/{user}", username);
         try {
-            Map<String, String> map = objectMapper.readValue(jsonResponse, new TypeReference<Map<String, String>>() {
-            });
-            return map.get("name");
+            JsonNode jsonNode = objectMapper.readTree(jsonResponse);
+            return jsonNode.get("name").asText();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/sagan-common/src/test-util/resources/fixtures/github/ghUserProfile-asmith.json
+++ b/sagan-common/src/test-util/resources/fixtures/github/ghUserProfile-asmith.json
@@ -17,5 +17,11 @@
   "following": 0,
   "html_url": "https://github.com/asmith",
   "created_at": "2008-01-14T04:33:35Z",
-  "type": "User"
+  "type": "User",
+  "plan": {
+      "name": "free",
+      "space": 307200,
+      "collaborators": 0,
+      "private_repos": 0
+  }
 }

--- a/sagan-common/src/test-util/resources/fixtures/github/ghUserProfile-jdoe.json
+++ b/sagan-common/src/test-util/resources/fixtures/github/ghUserProfile-jdoe.json
@@ -17,5 +17,11 @@
 "following": 0,
 "html_url": "https://github.com/jdoe",
 "created_at": "2008-01-14T04:33:35Z",
-"type": "User"
+"type": "User",
+"plan": {
+    "name": "free",
+    "space": 307200,
+    "collaborators": 0,
+    "private_repos": 0
+  }
 }


### PR DESCRIPTION
When I run "Import Team Member From Github" on admin page, it was throwing stacktrace:

```
2014-06-24 21:48:05.981 ERROR 5736 --- [nio-9090-exec-8] o.a.c.c.C.[.[.[/].[dispatcherServlet]    : Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception [Request processing failed; nested exception is java.lang.RuntimeException: com.fasterxml.jackson.databind.JsonMappingException: Can not deserialize instance of java.lang.String out of START_OBJECT token
 at [Source: java.io.StringReader@3741e5e; line: 1, column: 1247]] with root cause

com.fasterxml.jackson.databind.JsonMappingException: Can not deserialize instance of java.lang.String out of START_OBJECT token
 at [Source: java.io.StringReader@3741e5e; line: 1, column: 1247]
    at com.fasterxml.jackson.databind.JsonMappingException.from(JsonMappingException.java:164)
    ...
    at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:2105)
    at sagan.team.support.DefaultTeamImporter.getNameForUser(DefaultTeamImporter.java:60)
    at sagan.team.support.DefaultTeamImporter.importTeamMembers(DefaultTeamImporter.java:43)
    ...
```

This was because, the response from github API contains nested hash in `plan` field (for [authenticated user](https://developer.github.com/v3/users/#get-the-authenticated-user) only??):

```
> curl https://api.github.com/users/ttddyy -u $TOKEN:x-oauth-basic
{
  "login": "ttddyy",
  "name":"Tadaya Tsuyukubo"
  ...
  "plan": {
    "name": "free",
    "space": 307200,
    "collaborators": 0,
    "private_repos": 0
  }
}
```

This caused binding error from json to `Map<String, String>` because the value of "plan" is not a string.

I changed the json binding to only read the "name" field to avoid "plan" field type mismatch.

Thanks,
