### PR TITLE
add links to multipage html references

### DIFF
--- a/sagan-common/src/main/java/sagan/projects/ProjectRelease.java
+++ b/sagan-common/src/main/java/sagan/projects/ProjectRelease.java
@@ -35,6 +35,7 @@ public class ProjectRelease implements Comparable<ProjectRelease> {
     private ReleaseStatus releaseStatus;
     private boolean isCurrent;
     private String refDocUrl;
+    private String refDocMultiUrl;
     private String apiDocUrl;
     private String groupId;
     private String artifactId;
@@ -45,11 +46,12 @@ public class ProjectRelease implements Comparable<ProjectRelease> {
     }
 
     public ProjectRelease(String versionName, ReleaseStatus releaseStatus, boolean isCurrent, String refDocUrl,
-                          String apiDocUrl, String groupId, String artifactId) {
+                          String refDocMultiUrl, String apiDocUrl, String groupId, String artifactId) {
         setVersion(versionName);
         this.releaseStatus = releaseStatus;
         this.isCurrent = isCurrent;
         this.refDocUrl = refDocUrl;
+        this.refDocMultiUrl = refDocMultiUrl;
         this.apiDocUrl = apiDocUrl;
         this.groupId = groupId;
         this.artifactId = artifactId;
@@ -104,6 +106,14 @@ public class ProjectRelease implements Comparable<ProjectRelease> {
         return !refDocUrl.isEmpty();
     }
 
+    public String getRefDocMultiUrl() {
+        return refDocMultiUrl;
+    }
+
+    public boolean hasRefDocMultiUrl() {
+        return !refDocMultiUrl.isEmpty();
+    }
+
     public String getApiDocUrl() {
         return apiDocUrl;
     }
@@ -140,6 +150,10 @@ public class ProjectRelease implements Comparable<ProjectRelease> {
 
     public void setRefDocUrl(String refDocUrl) {
         this.refDocUrl = refDocUrl;
+    }
+
+    public void setRefDocMultiUrl(String refDocMultiUrl) {
+        this.refDocMultiUrl = refDocMultiUrl;
     }
 
     public void setApiDocUrl(String apiDocUrl) {
@@ -186,7 +200,8 @@ public class ProjectRelease implements Comparable<ProjectRelease> {
     @Override
     public String toString() {
         return "ProjectRelease{" + "versionName='" + versionName + '\'' + ", release=" + releaseStatus
-                + ", refDocUrl='" + refDocUrl + '\'' + ", apiDocUrl='" + apiDocUrl + '\'' + '}';
+                + ", refDocUrl='" + refDocUrl + '\'' + ", refDocMultiUrl='" + refDocMultiUrl + '\''
+                + ", apiDocUrl='" + apiDocUrl + '\'' + '}';
     }
 
 }

--- a/sagan-common/src/main/resources/db/migration/V5__add_refdocmulti.sql
+++ b/sagan-common/src/main/resources/db/migration/V5__add_refdocmulti.sql
@@ -1,0 +1,1 @@
+alter table project_releaselist add refDocMultiUrl character varying(255);

--- a/sagan-common/src/test-util/java/sagan/projects/ProjectReleaseBuilder.java
+++ b/sagan-common/src/test-util/java/sagan/projects/ProjectReleaseBuilder.java
@@ -4,6 +4,7 @@ public class ProjectReleaseBuilder {
     private String versionName = "";
     private ProjectRelease.ReleaseStatus releaseStatus = ProjectRelease.ReleaseStatus.GENERAL_AVAILABILITY;
     private boolean current = false;
+    private String refDocMultiUrl = "";
     private String refDocUrl = "";
     private String apiDocUrl = "";
     private String groupId = "";
@@ -29,6 +30,11 @@ public class ProjectReleaseBuilder {
         return this;
     }
 
+    public ProjectReleaseBuilder refDocMultiUrl(String refDocMultiUrl) {
+        this.refDocMultiUrl = refDocMultiUrl;
+        return this;
+    }
+
     public ProjectReleaseBuilder apiDocUrl(String apiDocUrl) {
         this.apiDocUrl = apiDocUrl;
         return this;
@@ -45,6 +51,6 @@ public class ProjectReleaseBuilder {
     }
 
     public ProjectRelease build() {
-        return new ProjectRelease(versionName, releaseStatus, current, refDocUrl, apiDocUrl, groupId, artifactId);
+        return new ProjectRelease(versionName, releaseStatus, current, refDocUrl, refDocMultiUrl, apiDocUrl, groupId, artifactId);
     }
 }

--- a/sagan-indexer/src/main/java/sagan/docs/support/ProjectDocumentationIndexer.java
+++ b/sagan-indexer/src/main/java/sagan/docs/support/ProjectDocumentationIndexer.java
@@ -69,6 +69,8 @@ public class ProjectDocumentationIndexer implements Indexer<Project> {
                 CrawledWebDocumentProcessor refDocProcessor =
                         new CrawledWebDocumentProcessor(searchService, documentMapper);
                 crawlerService.crawl(refDocUrl, 1, refDocProcessor);
+
+                // TODO: want to index multi page ref docs??
             }
         }
     }

--- a/sagan-indexer/src/test/java/sagan/docs/support/ProjectDocumentationIndexerTests.java
+++ b/sagan-indexer/src/test/java/sagan/docs/support/ProjectDocumentationIndexerTests.java
@@ -27,10 +27,13 @@ public class ProjectDocumentationIndexerTests {
 
     private List<ProjectRelease> documentationList = Arrays.asList(
             new ProjectRelease("3", GENERAL_AVAILABILITY, true, "http://reference.example.com/3",
-                    "http://api.example.com/3", "com.example", "example-framework"),
-            new ProjectRelease("2", SNAPSHOT, false, "http://reference.example.com/2", "http://api.example.com/2",
+                    "http://referencemulti.example.com/3", "http://api.example.com/3",
                     "com.example", "example-framework"),
-            new ProjectRelease("1", SNAPSHOT, false, "http://reference.example.com/1", "http://api.example.com/1",
+            new ProjectRelease("2", SNAPSHOT, false, "http://reference.example.com/2",
+                    "http://referencemulti.example.com/2", "http://api.example.com/2",
+                    "com.example", "example-framework"),
+            new ProjectRelease("1", SNAPSHOT, false, "http://reference.example.com/1",
+                    "http://referencemulti.example.com/1", "http://api.example.com/1",
                     "com.example", "example-framework")
             );
 
@@ -53,6 +56,20 @@ public class ProjectDocumentationIndexerTests {
         assertThatCrawlingIsDoneFor("http://reference.example.com/3", linkDepthLevel);
         assertThatCrawlingIsDoneFor("http://reference.example.com/2", linkDepthLevel);
         assertThatCrawlingIsDoneFor("http://reference.example.com/1", linkDepthLevel);
+    }
+
+    @Test
+    public void multipageReferenceDocsAreNOTIndexed() throws Exception {
+        service.indexItem(project);
+        int linkDepthLevel = 1;
+
+        // check multipages are NOT indexed
+        verify(crawlerService, never()).crawl(
+                eq("http://referencemulti.example.com/3"), eq(linkDepthLevel), any(CrawledWebDocumentProcessor.class));
+        verify(crawlerService, never()).crawl(
+                eq("http://referencemulti.example.com/2"), eq(linkDepthLevel), any(CrawledWebDocumentProcessor.class));
+        verify(crawlerService, never()).crawl(
+                eq("http://referencemulti.example.com/1"), eq(linkDepthLevel), any(CrawledWebDocumentProcessor.class));
     }
 
     @Test

--- a/sagan-site/src/main/java/sagan/projects/support/ProjectAdminController.java
+++ b/sagan-site/src/main/java/sagan/projects/support/ProjectAdminController.java
@@ -57,6 +57,7 @@ class ProjectAdminController {
                 ProjectRelease.ReleaseStatus.SNAPSHOT,
                 false,
                 "http://docs.spring.io/spring-new/docs/{version}/spring-new/htmlsingle/",
+                "http://docs.spring.io/spring-new/docs/{version}/spring-new/html/",
                 "http://docs.spring.io/spring-new/docs/{version}/javadoc-api/",
                 "org.springframework.new",
                 "spring-new");
@@ -93,6 +94,7 @@ class ProjectAdminController {
             String version = release.getVersion();
             release.setApiDocUrl(release.getApiDocUrl().replaceAll(version, VERSION_PLACEHOLDER));
             release.setRefDocUrl(release.getRefDocUrl().replaceAll(version, VERSION_PLACEHOLDER));
+            release.setRefDocMultiUrl(release.getRefDocMultiUrl().replaceAll(version, VERSION_PLACEHOLDER));
         }
 
         List<ProjectRelease> releases = project.getProjectReleases();
@@ -117,6 +119,7 @@ class ProjectAdminController {
             String version = release.getVersion();
             release.setApiDocUrl(release.getApiDocUrl().replaceAll(VERSION_PATTERN, version));
             release.setRefDocUrl(release.getRefDocUrl().replaceAll(VERSION_PATTERN, version));
+            release.setRefDocMultiUrl(release.getRefDocMultiUrl().replaceAll(VERSION_PATTERN, version));
 
         }
         service.save(project);

--- a/sagan-site/src/main/resources/templates/admin/project/edit.html
+++ b/sagan-site/src/main/resources/templates/admin/project/edit.html
@@ -45,6 +45,7 @@
                         <td>Version</td>
                         <td>Current</td>
                         <td>Reference URL</td>
+                        <td>Reference URL (Multipage)</td>
                         <td>API URL</td>
                     </tr>
                   </thead>
@@ -55,6 +56,7 @@
                           <td><input type="text" th:field="*{projectReleases[__${releaseStat.index}__].version}" /></td>
                           <td><input type="checkbox" th:field="*{projectReleases[__${releaseStat.index}__].current}" value="true"/></td>
                           <td><input type="text" th:field="*{projectReleases[__${releaseStat.index}__].refDocUrl}" /></td>
+                          <td><input type="text" th:field="*{projectReleases[__${releaseStat.index}__].refDocMultiUrl}" /></td>
                           <td><input type="text" th:field="*{projectReleases[__${releaseStat.index}__].apiDocUrl}" /></td>
                       </tr>
                       <tr th:with="size=${project.projectReleases.size()}">
@@ -63,6 +65,7 @@
                           <td><input type="text" th:field="*{projectReleases[__${size}__].version}" /></td>
                           <td><input type="checkbox" th:field="*{projectReleases[__${size}__].current}" value="true"/></td>
                           <td><input type="text" th:field="*{projectReleases[__${size}__].refDocUrl}" /></td>
+                          <td><input type="text" th:field="*{projectReleases[__${size}__].refDocMultiUrl}" /></td>
                           <td><input type="text" th:field="*{projectReleases[__${size}__].apiDocUrl}" /></td>
                       </tr>
                   </tbody>


### PR DESCRIPTION
Currently on spring.io, all links to the reference docs are poingting to  htmlsingle pages.

When I read spring references, I prefer multipage html than single html. So, it would be nice if spring.io has links to multipage references.

---

This commit is backend changes only(DB column and model class).

How to represent these links in UI needs to be considered.
- admin page
- docs page
- project page
