### PR TITLE
Wrong arch guessed in tools downloads

### DIFF
--- a/sagan-client/src/platform/os.js
+++ b/sagan-client/src/platform/os.js
@@ -50,6 +50,7 @@ function arch(environment) {
   }
 
   if (environment.userAgent.indexOf('Mac OS X') !== -1
+      || environment.userAgent.indexOf('WOW64') !== -1
       || environment.platform.indexOf('Win64') !== -1
       || environment.platform.indexOf('Linux x86_64') !== -1) {
     return '64';


### PR DESCRIPTION
See Ben's [comment on spring.io blog](https://spring.io/blog/2014/07/11/spring-tool-suite-and-groovy-grails-tool-suite-3-6-0-released#comment-1500477476) and this [SO question](https://stackoverflow.com/questions/19877924/what-is-the-list-of-possible-values-for-navigator-platform-as-of-today) on why 64-bit architecture isn't correctly advertised by browsers.
