### PR TITLE
Link to Pivotal Education courses in guides

### DIFF
--- a/sagan-client/src/app/main.js
+++ b/sagan-client/src/app/main.js
@@ -15,6 +15,7 @@ var initNewsletterSubscription = require('feature/newsletterSubscription/main');
 var initMap = require('feature/map/main');
 var initTimeAgo = require('feature/timeAgo/main');
 var initHideShowGuide = require('feature/hide-show-guide/main');
+var initCourseware = require('feature/courseware/main');
 
 var most = require('most');
 var $ = require('jquery');
@@ -37,7 +38,8 @@ var features = {
     'newsletter-subscription': initNewsletterSubscription,
     'map': initMap,
     'timeago': initTimeAgo,
-    'hide-show-guide': initHideShowGuide
+    'hide-show-guide': initHideShowGuide,
+    'courseware': initCourseware
 };
 
 initFeatures(features, document).each(function(features) {

--- a/sagan-client/src/feature/courseware/main.js
+++ b/sagan-client/src/feature/courseware/main.js
@@ -1,0 +1,30 @@
+var $ = require('jquery');
+var sidebarSelector = 'aside div.related_courseware';
+
+module.exports = function initCourseware() {
+
+    $(ready);
+
+    return {
+        destroy: destroy
+    };
+
+    function ready() {
+        $.getJSON( "https://pivotallms.biglms.com/api/courses", function( data ) {
+            if(data.length) {
+                var items = [];
+                items.push("<h3>Pivotal Academy</h3><ul>");
+                $.each(data, function(idx, arr) {
+                    arr.map(function(value){
+                        items.push("<li><a href='"+value.url+"'>"+value.name+"</a></li>");
+                    });
+                });
+                items.push("</ul>");
+                $(sidebarSelector).append(items.join(""));
+                $(sidebarSelector).parent().show();
+            }
+        });
+    }
+
+    function destroy() {}
+};

--- a/sagan-common/src/main/java/sagan/guides/support/AsciidoctorUtils.java
+++ b/sagan-common/src/main/java/sagan/guides/support/AsciidoctorUtils.java
@@ -104,6 +104,12 @@ public class AsciidoctorUtils {
 
         sidebar += "</div>\n</div>";
 
+        sidebar += "<div class='right-pane-widget--container' style='display:none'>\n<div class='related_courseware'>\n";
+
+        sidebar += "<h2><a name='courseware' class='anchor' href='#courseware'></a>Related Courseware</h2>\n";
+
+        sidebar += "</div>\n</div>";
+
         return sidebar;
     }
 

--- a/sagan-site/src/main/resources/templates/guides/gs/guide.html
+++ b/sagan-site/src/main/resources/templates/guides/gs/guide.html
@@ -6,7 +6,8 @@
   data-code-sidebar
   data-code-prettify
   data-hide-show-guide
-  data-sts-import>
+  data-sts-import
+  data-courseware>
   <head>
     <title th:inline="text">Getting Started &middot; [[${guide.title}]]</title>
     <link rel="stylesheet" type="text/css" th:href="@{/css/gsguide.css}"/>


### PR DESCRIPTION
This change adds Pivotal Education links in the sidebar.
Browsers will send an AJAX request to the LMS website and will get back
relevant courses (depending on the Referer URL).

Note: the same feature is also added on individual projects pages.