### PR TITLE
old STS/GGTS versions should be available for download

### DIFF
--- a/sagan-common/src/main/java/sagan/tools/support/ToolSuiteXml.java
+++ b/sagan-common/src/main/java/sagan/tools/support/ToolSuiteXml.java
@@ -23,4 +23,12 @@ class ToolSuiteXml {
     public void setReleases(List<Release> releases) {
         this.releases = releases;
     }
+
+    public List<Release> getOthers() {
+        return others;
+    }
+
+    public void setOthers(List<Release> others) {
+        this.others = others;
+    }
 }

--- a/sagan-common/src/main/java/sagan/tools/support/ToolXmlConverter.java
+++ b/sagan-common/src/main/java/sagan/tools/support/ToolXmlConverter.java
@@ -3,6 +3,11 @@ package sagan.tools.support;
 import sagan.tools.Release;
 import sagan.tools.ToolSuiteDownloads;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
 class ToolXmlConverter {
 
     public ToolSuiteDownloads convert(ToolSuiteXml toolSuiteXml, String toolSuiteName, String shortName) {
@@ -18,4 +23,23 @@ class ToolXmlConverter {
 
         return state.build();
     }
+
+    public List<ToolSuiteDownloads> convertLegacy(ToolSuiteXml toolSuiteXml, String toolSuiteName, String shortName) {
+        List<ToolSuiteDownloads> downloadsList = new ArrayList<>();
+
+        toolSuiteXml.getOthers().stream()
+                .filter(r -> r.getName().startsWith(toolSuiteName))
+                .collect(Collectors.groupingBy( r -> r.getDownloads().get(0).getVersion()))
+                .forEach((version, releases) -> {
+                    ToolSuiteBuilder state = new ToolSuiteBuilder(shortName);
+                    for (Release release : releases) {
+                        state.setWhatsNew(release.getWhatsnew());
+                        release.getDownloads().forEach(state::addDownload);
+                    }
+                    downloadsList.add(state.build());
+                });
+        Collections.sort(downloadsList, (i, j) -> j.getReleaseName().compareTo(i.getReleaseName()));
+        return downloadsList;
+    }
+
 }

--- a/sagan-common/src/main/java/sagan/tools/support/ToolsService.java
+++ b/sagan-common/src/main/java/sagan/tools/support/ToolsService.java
@@ -8,6 +8,10 @@ import sagan.support.cache.CachedRestClient;
 import sagan.tools.EclipseDownloads;
 import sagan.tools.ToolSuiteDownloads;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
 @Service
 class ToolsService {
     private final ToolXmlConverter toolXmlConverter = new ToolXmlConverter();
@@ -30,6 +34,14 @@ class ToolsService {
         return getToolSuiteDownloads("Milestone Version - Spring Tool Suite", "STS");
     }
 
+    public Collection<ToolSuiteDownloads> getStsLegacyDownloads() throws Exception {
+        List<ToolSuiteDownloads> previousStsDownloads = new ArrayList<>();
+
+        previousStsDownloads.addAll(getLegacyToolSuiteDownloads("Spring Tool Suite", "STS"));
+        previousStsDownloads.addAll(getLegacyToolSuiteDownloads("Previous Version", "STS"));
+        return previousStsDownloads;
+    }
+
     public ToolSuiteDownloads getGgtsGaDownloads() throws Exception {
         return getToolSuiteDownloads("Groovy/Grails Tool Suite", "GGTS");
     }
@@ -44,6 +56,14 @@ class ToolsService {
                         String.class);
         ToolSuiteXml toolSuiteXml = serializer.readValue(responseXml, ToolSuiteXml.class);
         return toolXmlConverter.convert(toolSuiteXml, toolSuiteName, shortName);
+    }
+
+    private Collection<ToolSuiteDownloads> getLegacyToolSuiteDownloads(String toolSuiteName, String shortName) throws Exception {
+        String responseXml =
+                restClient.get(restTemplate, "http://dist.springsource.com/release/STS/index-new.xml",
+                        String.class);
+        ToolSuiteXml toolSuiteXml = serializer.readValue(responseXml, ToolSuiteXml.class);
+        return toolXmlConverter.convertLegacy(toolSuiteXml, toolSuiteName, shortName);
     }
 
     public EclipseDownloads getEclipseDownloads() throws Exception {

--- a/sagan-common/src/test/java/sagan/tools/support/ToolSuiteXmlParsingTests.java
+++ b/sagan-common/src/test/java/sagan/tools/support/ToolSuiteXmlParsingTests.java
@@ -17,10 +17,17 @@ public class ToolSuiteXmlParsingTests {
         XmlMapper serializer = new XmlMapper();
 
         ToolSuiteXml toolSuiteXml = serializer.readValue(responseXml, ToolSuiteXml.class);
+
         assertThat(toolSuiteXml.getReleases(), notNullValue());
         assertThat(toolSuiteXml.getReleases().size(), equalTo(4));
         Release release = toolSuiteXml.getReleases().get(0);
         assertThat(release.getDownloads().size(), equalTo(7));
         assertThat(release.getWhatsnew(), notNullValue());
+
+        assertThat(toolSuiteXml.getOthers(), notNullValue());
+        assertThat(toolSuiteXml.getOthers().size(), equalTo(43));
+        Release oldRelease = toolSuiteXml.getOthers().get(0);
+        assertThat(oldRelease.getDownloads().size(), equalTo(17));
+        assertThat(oldRelease.getWhatsnew(), notNullValue());
     }
 }

--- a/sagan-common/src/test/java/sagan/tools/support/ToolXmlConverter_SingleArchiveDownloadTests.java
+++ b/sagan-common/src/test/java/sagan/tools/support/ToolXmlConverter_SingleArchiveDownloadTests.java
@@ -55,7 +55,5 @@ public class ToolXmlConverter_SingleArchiveDownloadTests {
                 equalTo("http://dist.springsource.com/release/TOOLS/update/3.3.0.RELEASE/e4.3/springsource-tool-suite-3.3.0.RELEASE-e4.3-updatesite.zip"));
         assertThat(archive.getFileSize(), equalTo("172MB"));
         assertThat(archive.getFileName(), equalTo("springsource-tool-suite-3.3.0.RELEASE-e4.3-updatesite.zip"));
-        assertThat(archive.getFileName(), equalTo("springsource-tool-suite-3.3.0.RELEASE-e4.3-updatesite.zip"));
-        assertThat(archive.getFileName(), equalTo("springsource-tool-suite-3.3.0.RELEASE-e4.3-updatesite.zip"));
     }
 }

--- a/sagan-common/src/test/java/sagan/tools/support/ToolXmlConverter_SingleLegacyDownloadTests.java
+++ b/sagan-common/src/test/java/sagan/tools/support/ToolXmlConverter_SingleLegacyDownloadTests.java
@@ -1,0 +1,121 @@
+package sagan.tools.support;
+
+import org.junit.Before;
+import org.junit.Test;
+import sagan.tools.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+
+public class ToolXmlConverter_SingleLegacyDownloadTests {
+
+    private List<ToolSuiteDownloads> toolSuites;
+    private ToolXmlConverter toolXmlConverter;
+
+    @Before
+    public void setUp() throws Exception {
+        ToolSuiteXml toolSuiteXml = new ToolSuiteXml();
+        List<Release> releases = new ArrayList<>();
+        Release release = new Release();
+        List<Download> downloads = new ArrayList<>();
+
+        Download download = new Download();
+        download.setDescription("Mac OS X (Cocoa)");
+        download.setOs("mac");
+        download.setFile("release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-macosx-cocoa-installer.dmg");
+        download.setBucket("http://download.springsource.com/");
+        download.setEclipseVersion("4.3.2");
+        download.setSize("361MB");
+        download.setVersion("3.5.1.RELEASE");
+        downloads.add(download);
+        release.setDownloads(downloads);
+        release.setName("Spring Tool Suite 3.5.1.RELEASE - based on Eclipse Kepler 4.3.2");
+        releases.add(release);
+
+        release = new Release();
+        downloads = new ArrayList<>();
+        download = new Download();
+        download.setDescription("Mac OS X (Cocoa)");
+        download.setOs("mac");
+        download.setFile("release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-macosx-cocoa-installer.dmg");
+        download.setBucket("http://download.springsource.com/");
+        download.setEclipseVersion("3.8.2");
+        download.setSize("349MB");
+        download.setVersion("3.5.1.RELEASE");
+        downloads.add(download);
+        release.setDownloads(downloads);
+        release.setName("Spring Tool Suite 3.5.1.RELEASE - based on Eclipse Juno 3.8.2");
+        releases.add(release);
+
+        release = new Release();
+        downloads = new ArrayList<>();
+        download = new Download();
+        download.setDescription("Mac OS X (Cocoa)");
+        download.setOs("mac");
+        download.setFile("release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-macosx-cocoa-installer.dmg");
+        download.setBucket("http://download.springsource.com/");
+        download.setEclipseVersion("4.3.2");
+        download.setSize("361MB");
+        download.setVersion("3.5.0.RELEASE");
+        downloads.add(download);
+        release.setDownloads(downloads);
+        release.setName("Spring Tool Suite 3.5.0.RELEASE - based on Eclipse Kepler 4.3.2");
+        releases.add(release);
+
+        toolSuiteXml.setOthers(releases);
+
+        toolXmlConverter = new ToolXmlConverter();
+        toolSuites = toolXmlConverter.convertLegacy(toolSuiteXml, "Spring Tool Suite", "STS");
+    }
+
+    @Test
+    public void addsAReleaseName() throws Exception {
+        assertThat(toolSuites.stream().map(ToolSuiteDownloads::getReleaseName).collect(Collectors.toList()),
+                contains("3.5.1.RELEASE", "3.5.0.RELEASE"));
+    }
+
+    @Test
+    public void addsAPlatform() throws Exception {
+        ToolSuiteDownloads toolSuite = toolSuites.get(0);
+        assertThat(toolSuite.getPlatformList().size(), equalTo(3));
+        assertThat(toolSuite.getPlatformList().get(1).getName(), equalTo("Mac"));
+    }
+
+    @Test
+    public void addsAnEclipseVersionToThePlatform() throws Exception {
+        ToolSuiteDownloads toolSuite = toolSuites.get(0);
+        ToolSuitePlatform platform = toolSuite.getPlatformList().get(1);
+        assertThat(platform.getEclipseVersions().size(), equalTo(2));
+        assertThat(platform.getEclipseVersions().get(0).getName(), equalTo("4.3.2"));
+        assertThat(platform.getEclipseVersions().get(1).getName(), equalTo("3.8.2"));
+    }
+
+    @Test
+    public void addsAnArchitectureToTheEclipseVersion() throws Exception {
+        ToolSuiteDownloads toolSuite = toolSuites.get(0);
+        ToolSuitePlatform platform = toolSuite.getPlatformList().get(1);
+        EclipseVersion eclipseVersion = platform.getEclipseVersions().get(0);
+        assertThat(eclipseVersion.getArchitectures().size(), equalTo(1));
+        assertThat(eclipseVersion.getArchitectures().get(0).getName(), equalTo("Mac OS X (Cocoa)"));
+    }
+
+    @Test
+    public void addsADownloadLinkTheArchitecture() throws Exception {
+        ToolSuiteDownloads toolSuite = toolSuites.get(0);
+        ToolSuitePlatform platform = toolSuite.getPlatformList().get(1);
+        EclipseVersion eclipseVersion = platform.getEclipseVersions().get(0);
+        Architecture architecture = eclipseVersion.getArchitectures().get(0);
+
+        assertThat(architecture.getDownloadLinks().size(), equalTo(1));
+        assertThat(
+                architecture.getDownloadLinks().get(0).getUrl(),
+                equalTo("http://download.springsource.com/release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-macosx-cocoa-installer.dmg"));
+        assertThat(architecture.getDownloadLinks().get(0).getOs(), equalTo("mac"));
+        assertThat(architecture.getDownloadLinks().get(0).getArchitecture(), equalTo("32"));
+    }
+}

--- a/sagan-site/src/it/java/sagan/tools/support/ToolsPagesTests.java
+++ b/sagan-site/src/it/java/sagan/tools/support/ToolsPagesTests.java
@@ -14,6 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.web.client.RestTemplate;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -107,6 +108,27 @@ public class ToolsPagesTests extends AbstractIntegrationTests {
                         containsString("spring-tool-suite"),
                         containsString("win32.zip"))));
 
+    }
+
+    @Test
+    public void showsLegacyStsGaDownloads() throws Exception {
+        MvcResult mvcResult = mockMvc.perform(get("/tools/sts/legacy"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith("text/html"))
+                .andReturn();
+
+        Document document = Jsoup.parse(mvcResult.getResponse().getContentAsString());
+        assertThat(document.select("h1").text(), equalTo("Previous Spring Tool Suite™ Downloads"));
+        assertThat(document.select(".ga--release h2.tool-versions--version").text(), allOf(containsString("STS"),
+                containsString("RELEASE")));
+        assertThat(document.select(".platform h3").text(), containsString("Windows"));
+
+        assertThat(document.select(".ga--release .item--dropdown a").first().attr("href"), allOf(
+                containsString("http://download.springsource.com/release/STS/"),
+                containsString("spring-tool-suite"),
+                containsString("win32-installer.exe")));
+
+        assertThat(document.select(".ga--release").size(), equalTo(24));
     }
 
     @Test

--- a/sagan-site/src/main/java/sagan/tools/support/ToolsController.java
+++ b/sagan-site/src/main/java/sagan/tools/support/ToolsController.java
@@ -5,13 +5,16 @@ import sagan.tools.EclipsePlatform;
 import sagan.tools.ToolSuiteDownloads;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.RequestMapping;
+import sagan.tools.UpdateSiteArchive;
 
 import static org.springframework.web.bind.annotation.RequestMethod.*;
 
@@ -67,6 +70,13 @@ class ToolsController {
         model.addAttribute("milestoneRelease", milestoneDownloads);
         model.addAttribute("updateSiteArchives", stsDownloads.getArchives());
         return "tools/sts/all";
+    }
+
+    @RequestMapping(value = "/sts/legacy", method = { GET, HEAD })
+    public String legacyStsDownloads(Model model) throws Exception {
+        Collection<ToolSuiteDownloads> stsDownloads = toolsService.getStsLegacyDownloads();
+        model.addAttribute("legacyReleases", stsDownloads);
+        return "tools/sts/legacy";
     }
 
     @RequestMapping(value = "/ggts", method = { GET, HEAD })

--- a/sagan-site/src/main/resources/templates/tools/sts/all.html
+++ b/sagan-site/src/main/resources/templates/tools/sts/all.html
@@ -18,7 +18,8 @@
       <div class="content--title">Tools</div>
         <h1 class="tools--title">Spring Tool Suite&trade; Downloads</h1>
         <p class="tools--description">Use one of the links below to download an all-in-one
-            distribution for your platform.</p>
+            distribution for your platform.<br> Or check the list of
+            <a href="legacy.html" th:href="@{/tools/sts/legacy}" class="all-versions">previous Spring Tool Suite&trade; versions</a>.</p>
 
           <section class='ga--release' layout:include="tools/_tools_versions :: tools-versions" th:with="release=${gaRelease}"></section>
           <section class='milestone--release' layout:include="tools/_tools_versions :: tools-versions" th:with="release=${milestoneRelease}" th:if="${milestoneRelease.hasPlatforms()}"></section>

--- a/sagan-site/src/main/resources/templates/tools/sts/legacy.html
+++ b/sagan-site/src/main/resources/templates/tools/sts/legacy.html
@@ -1,0 +1,30 @@
+<html   xmlns:th="http://www.thymeleaf.org"
+        xmlns:layout="http://www.ultraq.net.nz/web/thymeleaf/layout"
+        layout:decorator="layout"
+        data-info-popups>
+<head>
+    <title>Download STS</title>
+    <!-- http://opengraphprotocol.org/ -->
+    <meta property="og:title" content="Spring Tool Suite&trade; (STS) Download page" />
+    <meta property="og:image" th:content="@{/img/spring-by-pivotal.png}" />
+    <meta property="og:description" content="Use one of the links below to download an all-in-one distribution for your
+    platform. Choose either a native installer or simple archive, they contain equivalent functionality" />
+</head>
+<body>
+<div layout:fragment="header-container"></div>
+<div layout:fragment="content">
+  <div class="main-body--wrapper">
+    <div class="tools--wrapper">
+      <div class="content--title">Tools</div>
+        <h1 class="tools--title">Previous Spring Tool Suite&trade; Downloads</h1>
+        <p class="tools--description">Use one of the links below to download an all-in-one
+            distribution for your platform.</p>
+        <th:block th:each="legacyRelease : ${legacyReleases}">
+            <section class='ga--release' layout:include="tools/_tools_versions :: tools-versions" th:with="release=${legacyRelease}"></section>
+        </th:block>
+      </div>
+    </div>
+  </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
We are constantly getting questions where to find older versions of STS/GGTS for download. This was available on the old website, but hasn't been ported over to the new STS/GGTS download pages. I think we need to bring this back now, since too many people are asking for this.

