### PR TITLE
minor copy update to spring.io/platform

### DIFF
--- a/sagan-site/src/main/resources/templates/pages/platform.html
+++ b/sagan-site/src/main/resources/templates/pages/platform.html
@@ -21,7 +21,7 @@
           <div class="span6 mobile-left-pane">
             <h1 class="index-page--title">The Spring IO Platform</h1>
             <p class="index-page--subtitle">Spring IO brings together the core Spring APIs into a cohesive and versioned foundational platform for modern applications. On top of this foundation it also provides domain-specific runtime environments (DSRs) optimized for selected application types. Spring IO is comprised of the Spring IO Foundation and Spring IO Execution layers.</p>
-            <p class="index-page--subtitle">Spring IO is 100% open source, lean, and modular. You can deploy the parts you need, and only what you need. A detailed list of modules and versions included in the forthcoming Spring IO platform initial release will be available soon.</p>
+            <p class="index-page--subtitle">Spring IO is 100% open source, lean, and modular. You can deploy the parts you need, and only what you need. <a href="http://docs.spring.io/platform/docs/current/reference/htmlsingle/#appendix-dependency-versions">Click here for a detailed list of modules and versions</a> that are included in the Spring IO platform distribution.</p>
             <p class="index-page--subtitle">Read all about Spring IO in more detail below, and on the <a href="http://platform.spring.io/platform/">project page</a>.</p>
           </div>
           <div class="span6">


### PR DESCRIPTION
Please remove this text right at the top:

A detailed list of modules and versions included in the forthcoming Spring IO platform initial release will be available soon.

and replace with:

Click here[1] for a detailed list of modules and versions that are included in the Spring IO platform distribution.

[1] http://docs.spring.io/platform/docs/current/reference/htmlsingle/#appendix-dependency-versions