### PR TITLE
remove outdated syntax hint for markdown

### DIFF
--- a/sagan-site/src/main/resources/templates/admin/blog/_post_form.html
+++ b/sagan-site/src/main/resources/templates/admin/blog/_post_form.html
@@ -29,7 +29,7 @@
                     <div class="help-block">Tips:
                         <ul>
                             <li>Be sure to wrap code blocks in <a href=" https://help.github.com/articles/github-flavored-markdown#syntax-highlighting">code fences</a> (including a language identifier).</li>
-                            <li>Syntax for embedding YouTube videos (see <a href="https://github.com/spring-io/sagan/commit/bf42d447aa8abf7a7eacfe823df9d4058d4102cb">this commit</a> for details): <pre>!{iframe src="//www.youtube.com/embed/jplkJIHPGos"}{/iframe}</pre></li>
+                            <li>All valid HTML tags are allowed, even script/iframe/style (to be used with great care...)</li>
                         </ul>
                     </div>
                 </div>


### PR DESCRIPTION
because of previous limitations with github's markdown engine (with rendering of some html tags), we had to implement workarounds.

Now that we have a complete markdown engine, all html tags are allowed and so those workarounds should be removed (implementation + documentation in UI).