### PR TITLE
add a redirect from jar/war guide

### DIFF
--- a/sagan-site/src/main/resources/urlrewrite.xml
+++ b/sagan-site/src/main/resources/urlrewrite.xml
@@ -68,6 +68,12 @@
         <to type="temporary-redirect" last="true">/guides</to>
     </rule>
     <rule>
+        <name>Deprecated Spring Boot WAR Guide</name>
+        <note>https://github.com/spring-io/sagan/issues/480</note>
+        <from>/guides/gs/convert-jar-to-war-maven/$</from>
+        <to type="temporary-redirect" last="true">/guides/gs/convert-jar-to-war/</to>
+    </rule>
+    <rule>
         <name>Remove www</name>
         <note>Redirect www.spring.io => spring.io[#54747656]</note>
         <condition name="host">www.spring.io</condition>

--- a/sagan-site/src/test/java/sagan/rewrite/support/RewriteTests.java
+++ b/sagan-site/src/test/java/sagan/rewrite/support/RewriteTests.java
@@ -143,6 +143,11 @@ public class RewriteTests {
         validateTemporaryRedirect("http://spring.io/guides/tutorials/web/","/guides");
     }
 
+    @Test
+    public void deprecatedWarGuideRedirected() throws Exception {
+        validateTemporaryRedirect("http://spring.io/guides/gs/convert-jar-to-war-maven/","/guides/gs/convert-jar-to-war/");
+    }
+
     private void validateTemporaryRedirect(String requestedUrl, String redirectedUrl) throws IOException,
             ServletException, URISyntaxException {
         validateRedirect(requestedUrl, redirectedUrl, 302);


### PR DESCRIPTION
update https://spring.io/guides/gs/convert-jar-to-war-maven/ so that it simply redirects to https://spring.io/guides/gs/convert-jar-to-war/? The latter now covers both.