### PR TITLE
Add extra webhook handler

### DIFF
--- a/sagan-common/src/main/java/sagan/guides/support/GettingStartedGuides.java
+++ b/sagan-common/src/main/java/sagan/guides/support/GettingStartedGuides.java
@@ -41,7 +41,7 @@ public class GettingStartedGuides implements DocRepository<GettingStartedGuide, 
     private static final String README_PATH_ASC = REPO_BASE_PATH + "/zipball";
 
     private final GuideOrganization org;
-    private final MultiValueMap<String, String> tagMultimap = new LinkedMultiValueMap();
+    private final MultiValueMap<String, String> tagMultimap = new LinkedMultiValueMap<>();
     private final ProjectMetadataService projectMetadataService;
     private final AsciidoctorUtils asciidoctorUtils = new AsciidoctorUtils();
 
@@ -66,8 +66,8 @@ public class GettingStartedGuides implements DocRepository<GettingStartedGuide, 
     public List<GettingStartedGuide> findAll() {
         return findAllMetadata()
                 .stream()
-                    .map(m -> new GettingStartedGuide(m))
-                    .map(g -> populate(g))
+                    .map(GettingStartedGuide::new)
+                    .map(this::populate)
                 .collect(Collectors.toList());
     }
 

--- a/sagan-site/src/test/java/sagan/guides/support/DocsWebhookControllerTests.java
+++ b/sagan-site/src/test/java/sagan/guides/support/DocsWebhookControllerTests.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.ResponseEntity;
@@ -17,9 +16,7 @@ import java.nio.charset.Charset;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 /**
  * Unit tests for {@link DocsWebhookController}.
@@ -85,12 +82,38 @@ public class DocsWebhookControllerTests {
     }
 
     @Test
+    public void testGuideCacheEviction2() throws Exception {
+        given(this.gettingStartedGuides.parseGuideName("gs-test-guide")).willReturn("test-guide");
+        String payload = StreamUtils.copyToString(
+                new ClassPathResource("fixtures/webhooks/docsWebhook.json").getInputStream(), Charset.forName("UTF-8"));
+
+        ResponseEntity response = this.controller.processGuidesUpdate(payload, "sha1=f808b2905e91e6a7a31526b9f44a95a5a7e3472a", "push",
+                "gs-test-guide");
+        assertThat(response.getBody(), is("{ \"message\": \"Successfully processed update\" }\n"));
+        assertThat(response.getStatusCode().value(), is(200));
+        verify(this.gettingStartedGuides, times(1)).evictFromCache("test-guide");
+    }
+
+    @Test
     public void testTutorialCacheEviction() throws Exception {
         given(this.tutorials.parseTutorialName("gs-test-guide")).willReturn("test-guide");
         String payload = StreamUtils.copyToString(
                 new ClassPathResource("fixtures/webhooks/docsWebhook.json").getInputStream(), Charset.forName("UTF-8"));
 
         ResponseEntity response = this.controller.processTutorialsUpdate(payload, "sha1=f808b2905e91e6a7a31526b9f44a95a5a7e3472a", "push");
+        assertThat(response.getBody(), is("{ \"message\": \"Successfully processed update\" }\n"));
+        assertThat(response.getStatusCode().value(), is(200));
+        verify(this.tutorials, times(1)).evictFromCache("test-guide");
+    }
+
+    @Test
+    public void testTutorialCacheEviction2() throws Exception {
+        given(this.tutorials.parseTutorialName("gs-test-guide")).willReturn("test-guide");
+        String payload = StreamUtils.copyToString(
+                new ClassPathResource("fixtures/webhooks/docsWebhook.json").getInputStream(), Charset.forName("UTF-8"));
+
+        ResponseEntity response = this.controller.processTutorialsUpdate(payload, "sha1=f808b2905e91e6a7a31526b9f44a95a5a7e3472a", "push",
+                "gs-test-guide");
         assertThat(response.getBody(), is("{ \"message\": \"Successfully processed update\" }\n"));
         assertThat(response.getStatusCode().value(), is(200));
         verify(this.tutorials, times(1)).evictFromCache("test-guide");


### PR DESCRIPTION
To make it possible for 3rd party sources of guides and tutorials to send a GitHub hook with the pertinent repository name embedded in the URL itself