### PR TITLE
Add Redis metrics

### DIFF
--- a/sagan-common/src/main/java/sagan/SaganApplication.java
+++ b/sagan-common/src/main/java/sagan/SaganApplication.java
@@ -33,6 +33,7 @@ public class SaganApplication extends SpringApplication {
         boolean standaloneActive = environment.acceptsProfiles(STANDALONE);
         boolean stagingActive = environment.acceptsProfiles(STAGING);
         boolean productionActive = environment.acceptsProfiles(PRODUCTION);
+        boolean redisMetrics = environment.acceptsProfiles(REDISMETRICS);
 
         if (stagingActive && productionActive) {
             throw new IllegalStateException(format("Only one of the following profiles may be specified: [%s]",
@@ -43,6 +44,9 @@ public class SaganApplication extends SpringApplication {
             logger.info(format("Activating '%s' profile because one of '%s' or '%s' profiles have been specified.",
                     CLOUDFOUNDRY, STAGING, PRODUCTION));
             environment.addActiveProfile(CLOUDFOUNDRY);
+        }
+        else if (redisMetrics) {
+            logger.info("Testing out Redis as the place for metrics!");
         }
         else if (standaloneActive) {
             logger.info("The default 'standalone' profile is active because no other profiles have been specified.");

--- a/sagan-common/src/main/java/sagan/SaganProfiles.java
+++ b/sagan-common/src/main/java/sagan/SaganProfiles.java
@@ -1,7 +1,5 @@
 package sagan;
 
-import org.springframework.core.env.ConfigurableEnvironment;
-
 /**
  * Spring profiles under which a {@link SaganApplication} can be run. If no profiles are
  * specified, the {@link #STANDALONE} profile will be implicitly activated, making
@@ -55,4 +53,10 @@ public final class SaganProfiles {
      * @see org.springframework.core.env.AbstractEnvironment#RESERVED_DEFAULT_PROFILE_NAME
      */
     public static final String STANDALONE = "default";
+
+    /**
+     * Profile to switch on collecting Spring Boot Actuator metrics inside Redis
+     * TODO: When confirmed, replace this with CLOUDFOUNDRY
+     */
+    public static final String REDISMETRICS = "redis-metrics";
 }

--- a/sagan-site/src/main/java/sagan/MetricsConfiguration.java
+++ b/sagan-site/src/main/java/sagan/MetricsConfiguration.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sagan;
+
+import org.springframework.boot.actuate.metrics.repository.MetricRepository;
+import org.springframework.boot.actuate.metrics.repository.redis.RedisMetricRepository;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+
+/**
+ * Configure metrics gathering per Spring Boot Actuator
+ */
+@Configuration
+@ConditionalOnClass({RedisConnectionFactory.class, MetricRepository.class})
+//@Profile(SaganProfiles.CLOUDFOUNDRY)
+@Profile(SaganProfiles.REDISMETRICS) // TODO: After verifiyication, upgrade to SaganProfiles.CLOUDFOUNDRY
+class MetricsConfiguration {
+
+    @Bean
+    public RedisMetricRepository redisMetricRepository(RedisConnectionFactory connectionFactory) {
+        return new RedisMetricRepository(connectionFactory);
+    }
+
+}


### PR DESCRIPTION
- Configures Redis metrics underneath a different profile, so it can be switched on and off. When verified, edit TODOs to instead use CLOUDFOUNDRY profile.
