### PR TITLE
Add ElasticSearch health indicator

### DIFF
--- a/sagan-site/src/main/java/sagan/SiteConfig.java
+++ b/sagan-site/src/main/java/sagan/SiteConfig.java
@@ -2,6 +2,7 @@ package sagan;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import io.searchbox.client.JestClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.h2.server.web.WebServlet;
 import org.springframework.boot.actuate.health.AbstractHealthIndicator;
@@ -21,6 +22,7 @@ import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.servlet.DispatcherServlet;
 import org.tuckey.web.filters.urlrewrite.UrlRewriteFilter;
+import sagan.support.health.ElasticsearchHealthIndicator;
 
 import javax.sql.DataSource;
 
@@ -42,7 +44,7 @@ public class SiteConfig {
     public static final String REWRITE_FILTER_CONF_PATH = "/urlrewrite.xml";
 
     @Bean
-    public HealthIndicator healthIndicator(DataSource dataSource) {
+    public HealthIndicator dataSourceHealth(DataSource dataSource) {
         if (dataSource instanceof org.apache.tomcat.jdbc.pool.DataSource) {
             org.apache.tomcat.jdbc.pool.DataSource tcDataSource =
                     (org.apache.tomcat.jdbc.pool.DataSource) dataSource;
@@ -61,6 +63,11 @@ public class SiteConfig {
         }
         return null;
     }
+
+	@Bean
+	public ElasticsearchHealthIndicator elasticsearch(JestClient jestClient) {
+		return new ElasticsearchHealthIndicator(jestClient);
+	}
 
     @Bean
     public RestTemplate restTemplate() {

--- a/sagan-site/src/main/java/sagan/support/health/ElasticsearchHealthIndicator.java
+++ b/sagan-site/src/main/java/sagan/support/health/ElasticsearchHealthIndicator.java
@@ -1,0 +1,51 @@
+package sagan.support.health;
+
+import com.google.gson.JsonObject;
+import io.searchbox.client.JestClient;
+import io.searchbox.client.JestResult;
+
+import org.springframework.boot.actuate.health.AbstractHealthIndicator;
+import org.springframework.boot.actuate.health.Health.Builder;
+
+public class ElasticsearchHealthIndicator extends AbstractHealthIndicator {
+
+
+	private final JestClient jestClient;
+
+	public ElasticsearchHealthIndicator(JestClient jestClient) {
+		this.jestClient = jestClient;
+	}
+
+	@Override
+	protected void doHealthCheck(Builder builder) throws Exception {
+
+
+		JestResult result = jestClient.execute(new io.searchbox.cluster.Health.Builder().build());
+		JsonObject map = result.getJsonObject();
+		switch(getProperty(map, "status")) {
+			case "green":
+			case "yellow":
+				builder.up();
+				break;
+			case "red":
+			default:
+				builder.down();
+				break;
+		}
+		builder.withDetail("cluster_status", getProperty(map, "status"));
+		builder.withDetail("timed_out", getProperty(map, "timed_out"));
+		builder.withDetail("number_of_nodes", getProperty(map, "number_of_nodes"));
+		builder.withDetail("number_of_data_nodes", getProperty(map, "number_of_data_nodes"));
+		builder.withDetail("active_primary_shards", getProperty(map, "active_primary_shards"));
+		builder.withDetail("active_shards", getProperty(map, "active_shards"));
+		builder.withDetail("relocating_shards", getProperty(map, "relocating_shards"));
+		builder.withDetail("initializing_shards", getProperty(map, "initializing_shards"));
+		builder.withDetail("unassigned_shards", getProperty(map, "unassigned_shards"));
+		builder.withDetail("number_of_pending_tasks", getProperty(map, "number_of_pending_tasks"));
+
+	}
+
+	private String getProperty(JsonObject map, String prop) {
+		return map.get(prop).getAsString();
+	}
+}

--- a/sagan-site/src/main/resources/application.yml
+++ b/sagan-site/src/main/resources/application.yml
@@ -106,7 +106,7 @@ logging:
 ---
 
 spring:
-  profiles: default,staging,production
+  profiles: staging,production
 security:
   require_ssl: true
 server:

--- a/sagan-site/src/main/resources/elasticsearch/settings.json
+++ b/sagan-site/src/main/resources/elasticsearch/settings.json
@@ -1,6 +1,4 @@
 {
-  "settings.number_of_shards": 1,
-  "settings.number_of_replicas": 0,
   "index.analysis.analyzer.fulltext.tokenizer": "standard",
   "index.analysis.analyzer.fulltext.char_filter.0": "html_strip",
   "index.analysis.analyzer.fulltext.filter.0": "standard",

--- a/util/recreate-elasticsearch-index.sh
+++ b/util/recreate-elasticsearch-index.sh
@@ -22,10 +22,12 @@ curl -XDELETE "$ENDPOINT/$INDEX"
 sleep 1
 
 echo "\nCreate the index again."
-curl -X PUT $ENDPOINT/$INDEX -d @../sagan-site/src/main/resources/elasticsearch/settings.json
+curl -X PUT $ENDPOINT/$INDEX -d '{ "number_of_shards" : 5, "number_of_replicas" : 0}'
 sleep 1
 echo "\nClosing index."
 curl -XPOST "$ENDPOINT/$INDEX/_close"
+sleep 1
+curl -XPUT $ENDPOINT/$INDEX/_settings -d @../sagan-site/src/main/resources/elasticsearch/settings.json
 sleep 1
 echo "\nInstall the mapping - do once per type/mapping file."
 curl -XPOST "$ENDPOINT/$INDEX/apidoc/_mapping" -d @../sagan-site/src/main/resources/elasticsearch/mappings/apidoc.json


### PR DESCRIPTION
This change adds a new HealthIndicator implementation that relies on the
JestClient to get information on the ElasticSearch cluster status.

The ElasticSearch init script has been fixed to initialize the index
with fixed shard/replica values and initialize later settings.

Local deployments don't require SSL anymore to see sensitive health
endpoints.

Fixes #551