### PR TITLE
UrlRewriting doesn't function 

### DIFF
--- a/sagan-site/src/main/java/sagan/SiteConfig.java
+++ b/sagan-site/src/main/java/sagan/SiteConfig.java
@@ -42,7 +42,7 @@ import javax.sql.DataSource;
 public class SiteConfig {
 
     public static final String REWRITE_FILTER_NAME = "rewriteFilter";
-    public static final String REWRITE_FILTER_CONF_PATH = "/urlrewrite.xml";
+    public static final String REWRITE_FILTER_CONF_PATH = "urlrewrite.xml";
 
     @Bean
     public HealthIndicator dataSourceHealth(DataSource dataSource) {


### PR DESCRIPTION
if the initParameter confPath on SiteConfig is "urlrewrite.xml" then, when the application start some exceptions occurs. I saw that the path was updated to "/urlrewrite.xml" and after that, there's no exceptions on startup. But in fact, the UrlRewriteFilter class doesn't found urlrewrite.xml file anymore.  

e.g: try to access https://spring.io/videos and you'll see that there's no redirection to http://www.youtube.com/springsourcedev