### PR TITLE
Change parsing of release versions

### DIFF
--- a/sagan-common/src/main/java/sagan/projects/ProjectRelease.java
+++ b/sagan-common/src/main/java/sagan/projects/ProjectRelease.java
@@ -11,7 +11,7 @@ import org.springframework.util.Assert;
 @Embeddable
 public class ProjectRelease implements Comparable<ProjectRelease> {
 
-    private static final Pattern PREREALSE_PATTERN = Pattern.compile("[A-Za-z0-9.]+(M|RC)\\d+");
+    private static final Pattern PRERElEASE_PATTERN = Pattern.compile("[A-Za-z0-9.]+(M|RC)\\d+");
     private static final Pattern SNAPSHOT_PATTERN = Pattern.compile("[A-Za-z0-9.].*(SNAPSHOT)");
 
     public enum ReleaseStatus {
@@ -19,7 +19,7 @@ public class ProjectRelease implements Comparable<ProjectRelease> {
 
         public static ReleaseStatus getFromVersion(String version) {
             Assert.notNull(version, "Version must not be null");
-            if (PREREALSE_PATTERN.matcher(version).matches()) {
+            if (PRERElEASE_PATTERN.matcher(version).matches()) {
                 return PRERELEASE;
             }
             if (SNAPSHOT_PATTERN.matcher(version).matches()) {

--- a/sagan-common/src/main/java/sagan/projects/ProjectRelease.java
+++ b/sagan-common/src/main/java/sagan/projects/ProjectRelease.java
@@ -1,6 +1,5 @@
 package sagan.projects;
 
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import javax.persistence.CascadeType;
@@ -12,9 +11,8 @@ import org.springframework.util.Assert;
 @Embeddable
 public class ProjectRelease implements Comparable<ProjectRelease> {
 
-    private static final Pattern VERSION_DISPLAY_REGEX = Pattern.compile("([0-9.]+)\\.(RC\\d+|M\\d+)?");
-    private static final Pattern PREREALSE_PATTERN = Pattern.compile("[0-9.]+(M|RC)\\d+");
-    private static final Pattern SNAPSHOT_PATTERN = Pattern.compile("[0-9.].*(SNAPSHOT)");
+    private static final Pattern PREREALSE_PATTERN = Pattern.compile("[A-Za-z0-9.]+(M|RC)\\d+");
+    private static final Pattern SNAPSHOT_PATTERN = Pattern.compile("[A-Za-z0-9.].*(SNAPSHOT)");
 
     public enum ReleaseStatus {
         SNAPSHOT, PRERELEASE, GENERAL_AVAILABILITY;
@@ -85,15 +83,16 @@ public class ProjectRelease implements Comparable<ProjectRelease> {
     }
 
     public String getVersionDisplayName(boolean includePreReleaseDescription) {
-        Matcher matcher = VERSION_DISPLAY_REGEX.matcher(versionName);
-        matcher.find();
-        String versionNumber = matcher.group(1);
-        String preReleaseDescription = matcher.group(2);
-
-        if (preReleaseDescription != null && includePreReleaseDescription) {
-            return versionNumber + " " + preReleaseDescription;
+        String versionNumber = versionName;
+        String versionLabel = "";
+        if (versionName.contains(".")) {
+            versionNumber = versionName.substring(0, versionName.lastIndexOf("."));
+            versionLabel = " " + versionName.substring(versionName.lastIndexOf(".")+1);
+            if (versionLabel.contains("SNAPSHOT") || versionLabel.equals(" RELEASE")) {
+                versionLabel = "";
+            }
         }
-        return versionNumber;
+        return versionNumber + versionLabel;
     }
 
     public String getRefDocUrl() {

--- a/sagan-common/src/main/java/sagan/projects/ProjectRelease.java
+++ b/sagan-common/src/main/java/sagan/projects/ProjectRelease.java
@@ -11,19 +11,19 @@ import org.springframework.util.Assert;
 @Embeddable
 public class ProjectRelease implements Comparable<ProjectRelease> {
 
-    private static final Pattern PRERElEASE_PATTERN = Pattern.compile("[A-Za-z0-9.]+(M|RC)\\d+");
-    private static final Pattern SNAPSHOT_PATTERN = Pattern.compile("[A-Za-z0-9.].*(SNAPSHOT)");
+    private static final Pattern PRERELEASE_PATTERN = Pattern.compile("[A-Za-z0-9.]+?(M|RC)\\d+");
+    private static final String SNAPSHOT_SUFFIX = "SNAPSHOT";
 
     public enum ReleaseStatus {
         SNAPSHOT, PRERELEASE, GENERAL_AVAILABILITY;
 
         public static ReleaseStatus getFromVersion(String version) {
             Assert.notNull(version, "Version must not be null");
-            if (PRERElEASE_PATTERN.matcher(version).matches()) {
-                return PRERELEASE;
-            }
-            if (SNAPSHOT_PATTERN.matcher(version).matches()) {
+            if (version.endsWith(SNAPSHOT_SUFFIX)) {
                 return SNAPSHOT;
+            }
+            if (PRERELEASE_PATTERN.matcher(version).matches()) {
+                return PRERELEASE;
             }
             return GENERAL_AVAILABILITY;
         }
@@ -45,7 +45,9 @@ public class ProjectRelease implements Comparable<ProjectRelease> {
     public ProjectRelease(String versionName, ReleaseStatus releaseStatus, boolean isCurrent, String refDocUrl,
                           String apiDocUrl, String groupId, String artifactId) {
         setVersion(versionName);
-        this.releaseStatus = releaseStatus;
+        if (releaseStatus!=null) {
+            this.releaseStatus = releaseStatus;
+        }
         this.isCurrent = isCurrent;
         this.refDocUrl = refDocUrl;
         this.apiDocUrl = apiDocUrl;

--- a/sagan-common/src/test/java/sagan/projects/ProjectReleaseVersionTests.java
+++ b/sagan-common/src/test/java/sagan/projects/ProjectReleaseVersionTests.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2014-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sagan.projects;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * @author Dave Syer
+ *
+ */
+public class ProjectReleaseVersionTests {
+
+    @Test
+    public void snapshotDetected() {
+        ProjectRelease version = new ProjectReleaseBuilder().versionName("1.0.0.BUILD-SNAPSHOT").releaseStatus(null).build();
+        assertThat(version.isSnapshot(), equalTo(true));
+    }
+
+    @Test
+    public void snapshotDetectedCiStyle() {
+        ProjectRelease version = new ProjectReleaseBuilder().versionName("1.0.0.CI-SNAPSHOT").releaseStatus(null).build();
+        assertThat(version.isSnapshot(), equalTo(true));
+    }
+
+    @Test
+    public void snapshotDetectedMavenStyle() {
+        ProjectRelease version = new ProjectReleaseBuilder().versionName("1.0.0-SNAPSHOT").releaseStatus(null).build();
+        assertThat(version.isSnapshot(), equalTo(true));
+    }
+
+    @Test
+    public void releaseTrainSnapshotDetected() {
+        ProjectRelease version = new ProjectReleaseBuilder().versionName("Angel.BUILD-SNAPSHOT").releaseStatus(null).build();
+        assertThat(version.isSnapshot(), equalTo(true));
+    }
+
+    @Test
+    public void prereleaseDetected() {
+        ProjectRelease version = new ProjectReleaseBuilder().versionName("1.0.0.RC1").releaseStatus(null).build();
+        assertThat(version.isPreRelease(), equalTo(true));
+    }
+
+    @Test
+    public void releaseTrainPrereleaseDetected() {
+        ProjectRelease version = new ProjectReleaseBuilder().versionName("Angel.RC1").releaseStatus(null).build();
+        assertThat(version.isPreRelease(), equalTo(true));
+    }
+
+    @Test
+    public void gaDetected() {
+        ProjectRelease version = new ProjectReleaseBuilder().versionName("1.0.0.RELEASE").releaseStatus(null).build();
+        assertThat(version.isGeneralAvailability(), equalTo(true));
+    }
+
+    @Test
+    public void releaseTrainGaDetected() {
+        ProjectRelease version = new ProjectReleaseBuilder().versionName("Angel.RELEASE").releaseStatus(null).build();
+        assertThat(version.isGeneralAvailability(), equalTo(true));
+    }
+
+    @Test
+    public void releaseServiceReleaseTrainGaDetected() {
+        ProjectRelease version = new ProjectReleaseBuilder().versionName("Angel.SR1").releaseStatus(null).build();
+        assertThat(version.isGeneralAvailability(), equalTo(true));
+    }
+
+}

--- a/sagan-common/src/test/java/sagan/projects/ProjectVersionDisplayNameTests.java
+++ b/sagan-common/src/test/java/sagan/projects/ProjectVersionDisplayNameTests.java
@@ -29,6 +29,21 @@ public class ProjectVersionDisplayNameTests {
         assertVersionDisplayName("1.2.3.RC1", "1.2.3 RC1");
     }
 
+    @Test
+    public void getDisplayNameForReleaseTrainVersion() {
+        assertVersionDisplayName("Angel.RELEASE", "Angel");
+    }
+
+    @Test
+    public void getDisplayNameForReleaseTrainServiceRelease() {
+        assertVersionDisplayName("Angel.SR1", "Angel SR1");
+    }
+
+    @Test
+    public void getDisplayNameForReleaseTrainSnapshot() {
+        assertVersionDisplayName("Angel.BUILD-SNAPSHOT", "Angel");
+    }
+
     private void assertVersionDisplayName(String versionName, String expectedDisplayName) {
         ProjectRelease version = new ProjectReleaseBuilder().versionName(versionName).build();
 

--- a/sagan-common/src/test/java/sagan/search/support/SearchServiceTests.java
+++ b/sagan-common/src/test/java/sagan/search/support/SearchServiceTests.java
@@ -1,25 +1,27 @@
 package sagan.search.support;
 
-import com.google.gson.Gson;
-import io.searchbox.action.Action;
-import io.searchbox.client.JestClient;
-import io.searchbox.client.JestResult;
-import io.searchbox.core.Index;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.ArgumentMatcher;
-import org.springframework.data.domain.Pageable;
 import sagan.search.SearchException;
 import sagan.search.types.SearchEntry;
 import sagan.search.types.SearchType;
 
 import java.util.Collections;
 
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentMatcher;
+
+import org.springframework.data.domain.Pageable;
+
+import io.searchbox.action.Action;
+import io.searchbox.client.JestClient;
+import io.searchbox.client.JestResult;
+import io.searchbox.core.Index;
+
+import com.google.gson.Gson;
+
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.argThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
 
 public class SearchServiceTests {
 
@@ -37,7 +39,7 @@ public class SearchServiceTests {
 
     @SuppressWarnings("unchecked")
     public void throwsException() throws Exception {
-        given(jestClient.execute(any(Action.class))).willThrow(Exception.class);
+        given(jestClient.execute(any(GenericAction.class))).willThrow(Exception.class);
     }
 
     @Test(expected = SearchException.class)
@@ -60,9 +62,9 @@ public class SearchServiceTests {
 
     @Test
     public void usesTheSearchEntriesType() throws Exception {
-        given(jestClient.execute(any(Action.class))).willReturn(mock(JestResult.class));
+        given(jestClient.execute(any(GenericAction.class))).willReturn(mock(JestResult.class));
         searchService.saveToIndex(entry);
-        verify(jestClient).execute(argThat(new ArgumentMatcher<Action>() {
+        verify(jestClient).execute(argThat(new ArgumentMatcher<GenericAction>() {
             @Override
             public boolean matches(Object item) {
                 Index action = (Index) item;
@@ -73,7 +75,9 @@ public class SearchServiceTests {
 
     @Test
     public void handlesNullFilters() throws Exception {
-        given(jestClient.execute(any(Action.class))).willReturn(mock(JestResult.class));
+        given(jestClient.execute(any(GenericAction.class))).willReturn(mock(JestResult.class));
         searchService.search("foo", mock(Pageable.class), null);
     }
+    
+    private interface GenericAction extends Action<JestResult> {} 
 }


### PR DESCRIPTION
Simplifies the parsing of a version to determine the "display name". It
didn't really need a regex, and the regex made it hard to match on
"release train" names (like in Spring Data or Spring Cloud)

Fixes gh-562