### PR TITLE
Fix logic for detecting version types (milestone/snapshot)

### DIFF
--- a/sagan-common/src/main/java/sagan/projects/ProjectRelease.java
+++ b/sagan-common/src/main/java/sagan/projects/ProjectRelease.java
@@ -53,7 +53,7 @@ public class ProjectRelease implements Comparable<ProjectRelease> {
         this.apiDocUrl = apiDocUrl;
         this.groupId = groupId;
         this.artifactId = artifactId;
-        repository = ProjectRepository.get(versionName);
+        repository = ProjectRepository.get(versionName, this.releaseStatus);
     }
 
     public boolean isCurrent() {
@@ -126,8 +126,8 @@ public class ProjectRelease implements Comparable<ProjectRelease> {
     }
 
     public void setVersion(String versionName) {
-        repository = ProjectRepository.get(versionName);
         this.releaseStatus = ReleaseStatus.getFromVersion(versionName);
+        repository = ProjectRepository.get(versionName, this.releaseStatus);
         this.versionName = versionName;
     }
 

--- a/sagan-common/src/main/java/sagan/projects/ProjectRepository.java
+++ b/sagan-common/src/main/java/sagan/projects/ProjectRepository.java
@@ -1,5 +1,7 @@
 package sagan.projects;
 
+import sagan.projects.ProjectRelease.ReleaseStatus;
+
 import javax.persistence.Entity;
 import javax.persistence.Id;
 
@@ -27,12 +29,12 @@ public class ProjectRepository {
         this.snapshotsEnabled = snapshotsEnabled;
     }
 
-    public static ProjectRepository get(String versionName) {
-        if (versionName.contains("RELEASE")) {
+    public static ProjectRepository get(String versionName, ReleaseStatus status) {
+        if (status == ReleaseStatus.GENERAL_AVAILABILITY) {
             return null;
         }
 
-        if (versionName.contains("SNAPSHOT")) {
+        if (status == ReleaseStatus.SNAPSHOT) {
             return SNAPSHOT;
         }
 

--- a/sagan-common/src/test/java/sagan/projects/ProjectReleaseVersionTests.java
+++ b/sagan-common/src/test/java/sagan/projects/ProjectReleaseVersionTests.java
@@ -19,7 +19,7 @@ package sagan.projects;
 import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.*;
 
 /**
  * @author Dave Syer
@@ -29,56 +29,68 @@ public class ProjectReleaseVersionTests {
 
     @Test
     public void snapshotDetected() {
-        ProjectRelease version = new ProjectReleaseBuilder().versionName("1.0.0.BUILD-SNAPSHOT").releaseStatus(null).build();
+        ProjectRelease version =
+                new ProjectReleaseBuilder().versionName("1.0.0.BUILD-SNAPSHOT").releaseStatus(null).build();
         assertThat(version.isSnapshot(), equalTo(true));
+        assertThat(version.getRepository().getUrl(), containsString("snapshot"));
     }
 
     @Test
     public void snapshotDetectedCiStyle() {
-        ProjectRelease version = new ProjectReleaseBuilder().versionName("1.0.0.CI-SNAPSHOT").releaseStatus(null).build();
+        ProjectRelease version =
+                new ProjectReleaseBuilder().versionName("1.0.0.CI-SNAPSHOT").releaseStatus(null).build();
         assertThat(version.isSnapshot(), equalTo(true));
+        assertThat(version.getRepository().getUrl(), containsString("snapshot"));
     }
 
     @Test
     public void snapshotDetectedMavenStyle() {
         ProjectRelease version = new ProjectReleaseBuilder().versionName("1.0.0-SNAPSHOT").releaseStatus(null).build();
         assertThat(version.isSnapshot(), equalTo(true));
+        assertThat(version.getRepository().getUrl(), containsString("snapshot"));
     }
 
     @Test
     public void releaseTrainSnapshotDetected() {
-        ProjectRelease version = new ProjectReleaseBuilder().versionName("Angel.BUILD-SNAPSHOT").releaseStatus(null).build();
+        ProjectRelease version =
+                new ProjectReleaseBuilder().versionName("Angel.BUILD-SNAPSHOT").releaseStatus(null).build();
         assertThat(version.isSnapshot(), equalTo(true));
+        assertThat(version.getRepository().getUrl(), containsString("snapshot"));
     }
 
     @Test
     public void prereleaseDetected() {
         ProjectRelease version = new ProjectReleaseBuilder().versionName("1.0.0.RC1").releaseStatus(null).build();
         assertThat(version.isPreRelease(), equalTo(true));
+        assertThat(version.getRepository().getUrl(), containsString("milestone"));
     }
 
     @Test
     public void releaseTrainPrereleaseDetected() {
         ProjectRelease version = new ProjectReleaseBuilder().versionName("Angel.RC1").releaseStatus(null).build();
         assertThat(version.isPreRelease(), equalTo(true));
+        assertThat(version.getRepository().getUrl(), containsString("milestone"));
     }
 
     @Test
     public void gaDetected() {
         ProjectRelease version = new ProjectReleaseBuilder().versionName("1.0.0.RELEASE").releaseStatus(null).build();
         assertThat(version.isGeneralAvailability(), equalTo(true));
+        assertThat(version.getRepository(), is(nullValue()));
     }
 
     @Test
     public void releaseTrainGaDetected() {
         ProjectRelease version = new ProjectReleaseBuilder().versionName("Angel.RELEASE").releaseStatus(null).build();
         assertThat(version.isGeneralAvailability(), equalTo(true));
+        assertThat(version.getRepository(), is(nullValue()));
     }
 
     @Test
     public void releaseServiceReleaseTrainGaDetected() {
         ProjectRelease version = new ProjectReleaseBuilder().versionName("Angel.SR1").releaseStatus(null).build();
         assertThat(version.isGeneralAvailability(), equalTo(true));
+        assertThat(version.getRepository(), is(nullValue()));
     }
 
 }


### PR DESCRIPTION
The logic was duplicated in ProjectRelease and ProjectRepository.
This change consolidates it in ProjectRelease so that the repository
metadata is correct in all ProjectReleases (even those that do not
end in "RELEASE").

Fixes gh-565