### PR TITLE
Remove redundant default release version

### DIFF
--- a/sagan-common/src/test-util/java/sagan/projects/ProjectReleaseBuilder.java
+++ b/sagan-common/src/test-util/java/sagan/projects/ProjectReleaseBuilder.java
@@ -2,7 +2,7 @@ package sagan.projects;
 
 public class ProjectReleaseBuilder {
     private String versionName = "";
-    private ProjectRelease.ReleaseStatus releaseStatus = ProjectRelease.ReleaseStatus.GENERAL_AVAILABILITY;
+    private ProjectRelease.ReleaseStatus releaseStatus = null;
     private boolean current = false;
     private String refDocUrl = "";
     private String apiDocUrl = "";

--- a/sagan-common/src/test/java/sagan/projects/ProjectReleaseVersionTests.java
+++ b/sagan-common/src/test/java/sagan/projects/ProjectReleaseVersionTests.java
@@ -30,7 +30,7 @@ public class ProjectReleaseVersionTests {
     @Test
     public void snapshotDetected() {
         ProjectRelease version =
-                new ProjectReleaseBuilder().versionName("1.0.0.BUILD-SNAPSHOT").releaseStatus(null).build();
+                new ProjectReleaseBuilder().versionName("1.0.0.BUILD-SNAPSHOT").build();
         assertThat(version.isSnapshot(), equalTo(true));
         assertThat(version.getRepository().getUrl(), containsString("snapshot"));
     }
@@ -38,14 +38,14 @@ public class ProjectReleaseVersionTests {
     @Test
     public void snapshotDetectedCiStyle() {
         ProjectRelease version =
-                new ProjectReleaseBuilder().versionName("1.0.0.CI-SNAPSHOT").releaseStatus(null).build();
+                new ProjectReleaseBuilder().versionName("1.0.0.CI-SNAPSHOT").build();
         assertThat(version.isSnapshot(), equalTo(true));
         assertThat(version.getRepository().getUrl(), containsString("snapshot"));
     }
 
     @Test
     public void snapshotDetectedMavenStyle() {
-        ProjectRelease version = new ProjectReleaseBuilder().versionName("1.0.0-SNAPSHOT").releaseStatus(null).build();
+        ProjectRelease version = new ProjectReleaseBuilder().versionName("1.0.0-SNAPSHOT").build();
         assertThat(version.isSnapshot(), equalTo(true));
         assertThat(version.getRepository().getUrl(), containsString("snapshot"));
     }
@@ -53,42 +53,42 @@ public class ProjectReleaseVersionTests {
     @Test
     public void releaseTrainSnapshotDetected() {
         ProjectRelease version =
-                new ProjectReleaseBuilder().versionName("Angel.BUILD-SNAPSHOT").releaseStatus(null).build();
+                new ProjectReleaseBuilder().versionName("Angel.BUILD-SNAPSHOT").build();
         assertThat(version.isSnapshot(), equalTo(true));
         assertThat(version.getRepository().getUrl(), containsString("snapshot"));
     }
 
     @Test
     public void prereleaseDetected() {
-        ProjectRelease version = new ProjectReleaseBuilder().versionName("1.0.0.RC1").releaseStatus(null).build();
+        ProjectRelease version = new ProjectReleaseBuilder().versionName("1.0.0.RC1").build();
         assertThat(version.isPreRelease(), equalTo(true));
         assertThat(version.getRepository().getUrl(), containsString("milestone"));
     }
 
     @Test
     public void releaseTrainPrereleaseDetected() {
-        ProjectRelease version = new ProjectReleaseBuilder().versionName("Angel.RC1").releaseStatus(null).build();
+        ProjectRelease version = new ProjectReleaseBuilder().versionName("Angel.RC1").build();
         assertThat(version.isPreRelease(), equalTo(true));
         assertThat(version.getRepository().getUrl(), containsString("milestone"));
     }
 
     @Test
     public void gaDetected() {
-        ProjectRelease version = new ProjectReleaseBuilder().versionName("1.0.0.RELEASE").releaseStatus(null).build();
+        ProjectRelease version = new ProjectReleaseBuilder().versionName("1.0.0.RELEASE").build();
         assertThat(version.isGeneralAvailability(), equalTo(true));
         assertThat(version.getRepository(), is(nullValue()));
     }
 
     @Test
     public void releaseTrainGaDetected() {
-        ProjectRelease version = new ProjectReleaseBuilder().versionName("Angel.RELEASE").releaseStatus(null).build();
+        ProjectRelease version = new ProjectReleaseBuilder().versionName("Angel.RELEASE").build();
         assertThat(version.isGeneralAvailability(), equalTo(true));
         assertThat(version.getRepository(), is(nullValue()));
     }
 
     @Test
     public void releaseServiceReleaseTrainGaDetected() {
-        ProjectRelease version = new ProjectReleaseBuilder().versionName("Angel.SR1").releaseStatus(null).build();
+        ProjectRelease version = new ProjectReleaseBuilder().versionName("Angel.SR1").build();
         assertThat(version.isGeneralAvailability(), equalTo(true));
         assertThat(version.getRepository(), is(nullValue()));
     }


### PR DESCRIPTION
This change is only in test code, just tidying up the 
ProjectReleaseBuilder utility a bit so that it actually
uses the releease status detection logic by default.