### PR TITLE
updated STS download page for 3.7.0 release

### DIFF
--- a/sagan-site/src/main/resources/templates/tools/sts/all.html
+++ b/sagan-site/src/main/resources/templates/tools/sts/all.html
@@ -26,8 +26,8 @@
         <section>
         <h2>Update Site Archives</h2>
         <p>You can download archived versions of the update sites, if you
-            want to install STS/GGTS into an existing Eclipse installation or if
-            you want to update an existing STS/GGTS installation without
+            want to install STS into an existing Eclipse installation or if
+            you want to update an existing STS installation without
             accessing the hosted version of the update repository.</p>
         <table class="table table-striped tool-archive--table">
           <thead>
@@ -65,24 +65,12 @@
           </thead>
           <tbody>
             <tr>
+              <td>4.5</td>
+              <td><a href="http://dist.springsource.com/release/TOOLS/update/e4.4/">http://dist.springsource.com/release/TOOLS/update/e4.5/</a></td>
+            </tr>
+            <tr>
               <td>4.4</td>
               <td><a href="http://dist.springsource.com/release/TOOLS/update/e4.4/">http://dist.springsource.com/release/TOOLS/update/e4.4/</a></td>
-            </tr>
-            <tr>
-              <td>4.3</td>
-              <td><a href="http://dist.springsource.com/release/TOOLS/update/e4.3/">http://dist.springsource.com/release/TOOLS/update/e4.3/</a></td>
-            </tr>
-            <tr>
-              <td>4.2</td>
-              <td><a href="http://dist.springsource.com/release/TOOLS/update/e4.2/">http://dist.springsource.com/release/TOOLS/update/e4.2/</a></td>
-            </tr>
-            <tr>
-              <td>3.8</td>
-              <td><a href="http://dist.springsource.com/release/TOOLS/update/e3.8/">http://dist.springsource.com/release/TOOLS/update/e3.8/</a></td>
-            </tr>
-            <tr>
-              <td>3.7</td>
-              <td><a href="http://dist.springsource.com/release/TOOLS/update/e3.7/">http://dist.springsource.com/release/TOOLS/update/e3.7/</a></td>
             </tr>
           </tbody>
         </table>


### PR DESCRIPTION
removed outdated update sites and GGTS from description, but not sure if this is the right place to change this