### PR TITLE
Tweak search query to return projects

### DIFF
--- a/sagan-common/src/main/java/sagan/search/support/SaganQueryBuilders.java
+++ b/sagan-common/src/main/java/sagan/search/support/SaganQueryBuilders.java
@@ -36,7 +36,8 @@ class SaganQueryBuilders {
 
         BoolQueryBuilder query = QueryBuilders.boolQuery()
                 .must(multiMatch)
-                .should(matchCurrent.boost(0.5f));
+                .should(matchCurrent.boost(0.5f))
+                .should(matchProjectPages());
 
         String search = buildSearch(query, filters, pageable);
 
@@ -178,6 +179,11 @@ class SaganQueryBuilders {
             orFilter.add(new TermFilterBuilder("version", supportedVersion));
         }
         return orFilter;
+    }
+
+    private static FilteredQueryBuilder matchProjectPages() {
+        return QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(),
+                FilterBuilders.typeFilter(SearchType.PROJECT_PAGE.toString()));
     }
 
 }

--- a/sagan-common/src/main/java/sagan/search/support/SaganQueryBuilders.java
+++ b/sagan-common/src/main/java/sagan/search/support/SaganQueryBuilders.java
@@ -29,7 +29,7 @@ class SaganQueryBuilders {
 
         MultiMatchQueryBuilder multiMatch = QueryBuilders
                 .multiMatchQuery(queryTerm, BOOSTED_TITLE_FIELD, RAW_CONTENT_FIELD, AUTHOR_FIELD)
-                .fuzziness(Fuzziness.AUTO)
+                .fuzziness(Fuzziness.ONE)
                 .tieBreaker(0.3f);
 
         TermQueryBuilder matchCurrent = QueryBuilders.termQuery("current", true);

--- a/sagan-common/src/main/java/sagan/search/support/SpringFacetsBuilder.java
+++ b/sagan-common/src/main/java/sagan/search/support/SpringFacetsBuilder.java
@@ -16,6 +16,7 @@ class SpringFacetsBuilder {
         ensureFacetExists(1, "Guides");
         SearchFacet projects = ensureFacetExists(2, "Projects");
         moveFacetToHeader(projects, "Api");
+        moveFacetToHeader(projects, "HomePage");
         moveFacetToHeader(projects, "Reference");
         return new SearchFacet("", "", 0, facets);
     }

--- a/sagan-common/src/main/java/sagan/search/types/ProjectPage.java
+++ b/sagan-common/src/main/java/sagan/search/types/ProjectPage.java
@@ -1,0 +1,9 @@
+package sagan.search.types;
+
+public class ProjectPage extends SearchEntry {
+
+    @Override
+    public String getType() {
+        return SearchType.PROJECT_PAGE.toString();
+    }
+}

--- a/sagan-common/src/main/java/sagan/search/types/SearchEntry.java
+++ b/sagan-common/src/main/java/sagan/search/types/SearchEntry.java
@@ -1,17 +1,11 @@
 package sagan.search.types;
 
-import org.springframework.security.crypto.codec.Base64;
-
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.List;
 
 public abstract class SearchEntry {
-
-    public static final List<String> TYPES = Arrays.asList(SearchType.SITE_PAGE.toString(),
-            SearchType.BLOG_POST.toString(), SearchType.GUIDE.toString(),
-            SearchType.API_DOC.toString(), SearchType.REFERENCE_DOC.toString());
-
 
     private String path;
 
@@ -28,9 +22,7 @@ public abstract class SearchEntry {
     public abstract String getType();
 
     public String getId() {
-        byte[] encodedId = Base64.encode(path.toLowerCase().getBytes());
-
-        return new String(encodedId);
+        return Base64.getEncoder().encodeToString(path.toLowerCase().getBytes());
     }
 
     public String getPath() {

--- a/sagan-common/src/main/java/sagan/search/types/SearchType.java
+++ b/sagan-common/src/main/java/sagan/search/types/SearchType.java
@@ -3,7 +3,7 @@ package sagan.search.types;
 public enum SearchType {
 
     SITE_PAGE("sitepage"), BLOG_POST("blogpost"), GUIDE("guidedoc"),
-    API_DOC("apidoc"), REFERENCE_DOC("referencedoc");
+    API_DOC("apidoc"), REFERENCE_DOC("referencedoc"), PROJECT_PAGE("projectpage");
 
     private final String name;
 

--- a/sagan-common/src/test-util/java/sagan/search/support/SearchEntryBuilder.java
+++ b/sagan-common/src/test-util/java/sagan/search/support/SearchEntryBuilder.java
@@ -119,8 +119,13 @@ public class SearchEntryBuilder {
         return ref;
     }
 
-    public SitePage page() {
+    public SitePage sitePage() {
         SitePage page = build(new SitePage());
+        return page;
+    }
+
+    public ProjectPage projectPage() {
+        ProjectPage page = build(new ProjectPage());
         return page;
     }
 

--- a/sagan-common/src/test/resources/fulltext-query.json
+++ b/sagan-common/src/test/resources/fulltext-query.json
@@ -13,14 +13,25 @@
               "tie_breaker" : 0.3
             }
           },
-          "should" : {
+          "should" : [ {
             "term" : {
               "current" : {
                 "value" : true,
                 "boost" : 0.5
               }
             }
-          }
+          }, {
+            "filtered" : {
+              "query" : {
+                "match_all" : { }
+              },
+              "filter" : {
+                "type" : {
+                  "value" : "projectpage"
+                }
+              }
+            }
+          } ]
         }
       },
       "filter" : {

--- a/sagan-common/src/test/resources/fulltext-query.json
+++ b/sagan-common/src/test/resources/fulltext-query.json
@@ -9,7 +9,7 @@
             "multi_match" : {
               "query" : "spring",
               "fields" : [ "title^2", "rawContent", "author" ],
-              "fuzziness" : "AUTO",
+              "fuzziness" : 1,
               "tie_breaker" : 0.3
             }
           },

--- a/sagan-indexer/src/it/java/sagan/IndexSchedulerTests.java
+++ b/sagan-indexer/src/it/java/sagan/IndexSchedulerTests.java
@@ -5,6 +5,7 @@ import sagan.docs.support.ProjectDocumentationIndexer;
 import sagan.guides.support.GettingStartedGuideIndexer;
 import sagan.guides.support.TutorialIndexer;
 import sagan.guides.support.UnderstandingDocIndexer;
+import sagan.projects.support.ProjectPagesIndexer;
 import sagan.staticpage.support.StaticPageIndexer;
 import sagan.support.SetSystemProperty;
 import sagan.tools.support.ToolsIndexer;
@@ -31,6 +32,12 @@ public class IndexSchedulerTests extends AbstractIndexerIntegrationTests {
         @Primary
         public ProjectDocumentationIndexer mockProjectDocumentationIndexer() {
             return mock(ProjectDocumentationIndexer.class);
+        }
+
+        @Bean
+        @Primary
+        public ProjectPagesIndexer mockProjectPagesIndexer() {
+            return mock(ProjectPagesIndexer.class);
         }
 
         @Bean
@@ -79,6 +86,8 @@ public class IndexSchedulerTests extends AbstractIndexerIntegrationTests {
     @Autowired
     private ProjectDocumentationIndexer projectDocumentationIndexer;
     @Autowired
+    private ProjectPagesIndexer projectPagesIndexer;
+    @Autowired
     private GettingStartedGuideIndexer gettingStartedGuideIndexer;
     @Autowired
     private IndexerService indexerService;
@@ -103,6 +112,7 @@ public class IndexSchedulerTests extends AbstractIndexerIntegrationTests {
         Thread.sleep(INDEXER_DELAY);
         verify(indexerService).index(gettingStartedGuideIndexer);
         verify(indexerService).index(projectDocumentationIndexer);
+        verify(indexerService).index(projectPagesIndexer);
         verify(indexerService).index(toolsIndexer);
         verify(indexerService).index(staticPageIndexer);
         verify(indexerService).index(understandingGuideIndexer);
@@ -114,6 +124,7 @@ public class IndexSchedulerTests extends AbstractIndexerIntegrationTests {
     public void indexerServiceRespectsTheConfiguredDelay() throws Exception {
         verify(indexerService, never()).index(gettingStartedGuideIndexer);
         verify(indexerService, never()).index(projectDocumentationIndexer);
+        verify(indexerService, never()).index(projectPagesIndexer);
         verify(indexerService, never()).index(toolsIndexer);
         verify(indexerService, never()).index(staticPageIndexer);
         verify(indexerService, never()).index(understandingGuideIndexer);

--- a/sagan-indexer/src/main/java/sagan/IndexScheduler.java
+++ b/sagan-indexer/src/main/java/sagan/IndexScheduler.java
@@ -5,6 +5,7 @@ import sagan.docs.support.ProjectDocumentationIndexer;
 import sagan.guides.support.GettingStartedGuideIndexer;
 import sagan.guides.support.TutorialIndexer;
 import sagan.guides.support.UnderstandingDocIndexer;
+import sagan.projects.support.ProjectPagesIndexer;
 import sagan.staticpage.support.StaticPageIndexer;
 import sagan.tools.support.ToolsIndexer;
 
@@ -33,6 +34,8 @@ class IndexScheduler {
     private TutorialIndexer tutorialIndexer;
     @Autowired
     private PublishedBlogPostsIndexer publishedBlogPostsIndexer;
+    @Autowired
+    private ProjectPagesIndexer projectPagesIndexer;
 
     @Scheduled(fixedDelay = ONE_HOUR, initialDelayString = "${search.indexer.delay:0}")
     public void indexGettingStartedGuides() {
@@ -65,7 +68,12 @@ class IndexScheduler {
     }
 
     @Scheduled(fixedDelay = ONE_DAY, initialDelayString = "${search.indexer.delay:0}")
-    public void setPublishedBlogPosts() {
+    public void indexProjectPages() {
+        indexerService.index(projectPagesIndexer);
+    }
+
+    @Scheduled(fixedDelay = ONE_DAY, initialDelayString = "${search.indexer.delay:0}")
+    public void indexPublishedBlogPosts() {
         indexerService.index(publishedBlogPostsIndexer);
     }
 }

--- a/sagan-indexer/src/main/java/sagan/projects/support/GithubPagesSearchEntryMapper.java
+++ b/sagan-indexer/src/main/java/sagan/projects/support/GithubPagesSearchEntryMapper.java
@@ -1,10 +1,17 @@
 package sagan.projects.support;
 
 import org.jsoup.nodes.Document;
+import sagan.projects.Project;
 import sagan.search.SearchEntryMapper;
 import sagan.search.types.ProjectPage;
 
 public class GithubPagesSearchEntryMapper implements SearchEntryMapper<Document> {
+
+    private final Project project;
+
+    public GithubPagesSearchEntryMapper(Project project) {
+        this.project = project;
+    }
 
     @Override
     public ProjectPage map(Document document) {
@@ -14,6 +21,7 @@ public class GithubPagesSearchEntryMapper implements SearchEntryMapper<Document>
         entry.setSummary(text.substring(0, Math.min(500, text.length())));
         entry.setTitle(document.title());
         entry.setPath(document.baseUri());
+        entry.addFacetPaths("Projects", "Projects/Homepage", "Projects/" + project.getName());
         return entry;
     }
 

--- a/sagan-indexer/src/main/java/sagan/projects/support/GithubPagesSearchEntryMapper.java
+++ b/sagan-indexer/src/main/java/sagan/projects/support/GithubPagesSearchEntryMapper.java
@@ -1,0 +1,20 @@
+package sagan.projects.support;
+
+import org.jsoup.nodes.Document;
+import sagan.search.SearchEntryMapper;
+import sagan.search.types.ProjectPage;
+
+public class GithubPagesSearchEntryMapper implements SearchEntryMapper<Document> {
+
+    @Override
+    public ProjectPage map(Document document) {
+        ProjectPage entry = new ProjectPage();
+        String text = document.getElementsByClass("body--container").text();
+        entry.setRawContent(text);
+        entry.setSummary(text.substring(0, Math.min(500, text.length())));
+        entry.setTitle(document.title());
+        entry.setPath(document.baseUri());
+        return entry;
+    }
+
+}

--- a/sagan-indexer/src/main/java/sagan/projects/support/ProjectPagesIndexer.java
+++ b/sagan-indexer/src/main/java/sagan/projects/support/ProjectPagesIndexer.java
@@ -1,0 +1,62 @@
+package sagan.projects.support;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import sagan.Indexer;
+import sagan.projects.Project;
+import sagan.search.support.CrawledWebDocumentProcessor;
+import sagan.search.support.CrawlerService;
+import sagan.search.support.SearchService;
+
+@Service
+public class ProjectPagesIndexer implements Indexer<Project> {
+
+    private static final Log logger = LogFactory.getLog(ProjectPagesIndexer.class);
+
+    @Value(value = "${search.indexer.gh_pages.domains:projects.spring.io}")
+    private String githubPagesDomains;
+
+    private final ProjectMetadataService metadataService;
+    private final CrawlerService crawlerService;
+    private final CrawledWebDocumentProcessor documentProcessor;
+
+    @Autowired
+    public ProjectPagesIndexer(ProjectMetadataService metadataService, CrawlerService crawlerService, SearchService searchService) {
+        this.metadataService = metadataService;
+        this.crawlerService = crawlerService;
+        this.documentProcessor = new CrawledWebDocumentProcessor(searchService, new GithubPagesSearchEntryMapper());
+    }
+
+    @Override
+    public Iterable<Project> indexableItems() {
+        return metadataService.getProjectsWithReleases();
+    }
+
+    @Override
+    public void indexItem(Project project) {
+        logger.debug("Indexing project page for: " + project.getId());
+        String projectPageUrl = project.getSiteUrl();
+        if (StringUtils.commaDelimitedListToSet(githubPagesDomains).stream()
+                .anyMatch(domain -> projectPageUrl.startsWith("http://" + domain) ||
+                        projectPageUrl.startsWith("https://" + domain))) {
+            crawlerService.crawl(projectPageUrl, 0, documentProcessor);
+        }
+        else {
+            logger.debug(projectPageUrl + " does not match allowed domains");
+        }
+    }
+
+    @Override
+    public String counterName() {
+        return "projects_pages";
+    }
+
+    @Override
+    public String getId(Project project) {
+        return project.getId();
+    }
+}

--- a/sagan-indexer/src/main/java/sagan/projects/support/ProjectPagesIndexer.java
+++ b/sagan-indexer/src/main/java/sagan/projects/support/ProjectPagesIndexer.java
@@ -10,6 +10,7 @@ import sagan.Indexer;
 import sagan.projects.Project;
 import sagan.search.support.CrawledWebDocumentProcessor;
 import sagan.search.support.CrawlerService;
+import sagan.search.support.DocumentProcessor;
 import sagan.search.support.SearchService;
 
 @Service
@@ -22,13 +23,13 @@ public class ProjectPagesIndexer implements Indexer<Project> {
 
     private final ProjectMetadataService metadataService;
     private final CrawlerService crawlerService;
-    private final CrawledWebDocumentProcessor documentProcessor;
+    private final SearchService searchService;
 
     @Autowired
     public ProjectPagesIndexer(ProjectMetadataService metadataService, CrawlerService crawlerService, SearchService searchService) {
         this.metadataService = metadataService;
         this.crawlerService = crawlerService;
-        this.documentProcessor = new CrawledWebDocumentProcessor(searchService, new GithubPagesSearchEntryMapper());
+        this.searchService = searchService;
     }
 
     @Override
@@ -40,6 +41,8 @@ public class ProjectPagesIndexer implements Indexer<Project> {
     public void indexItem(Project project) {
         logger.debug("Indexing project page for: " + project.getId());
         String projectPageUrl = project.getSiteUrl();
+        GithubPagesSearchEntryMapper mapper = new GithubPagesSearchEntryMapper(project);
+        DocumentProcessor documentProcessor = new CrawledWebDocumentProcessor(searchService, mapper);
         if (StringUtils.commaDelimitedListToSet(githubPagesDomains).stream()
                 .anyMatch(domain -> projectPageUrl.startsWith("http://" + domain) ||
                         projectPageUrl.startsWith("https://" + domain))) {

--- a/sagan-indexer/src/main/resources/application.yml
+++ b/sagan-indexer/src/main/resources/application.yml
@@ -32,6 +32,8 @@ security:
 search:
   indexer:
     delay: 0
+    gh_pages:
+      domains: projects.spring.io,platform.spring.io,cloud.spring.io
 
 elasticsearch:
   client:
@@ -91,6 +93,7 @@ logging:
     org.apache.http.headers: WARN
     # turn up to DEBUG to see information about guides as they are fetched and processed
     sagan.guides.support: WARN
+    sagan.projects.support: DEBUG
 
 ---
 

--- a/sagan-indexer/src/main/resources/application.yml
+++ b/sagan-indexer/src/main/resources/application.yml
@@ -93,7 +93,6 @@ logging:
     org.apache.http.headers: WARN
     # turn up to DEBUG to see information about guides as they are fetched and processed
     sagan.guides.support: WARN
-    sagan.projects.support: DEBUG
 
 ---
 

--- a/sagan-indexer/src/test/java/sagan/projects/support/ProjectPagesIndexerTests.java
+++ b/sagan-indexer/src/test/java/sagan/projects/support/ProjectPagesIndexerTests.java
@@ -1,0 +1,78 @@
+package sagan.projects.support;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.test.util.ReflectionTestUtils;
+import sagan.projects.Project;
+import sagan.search.support.CrawlerService;
+import sagan.search.support.SearchService;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.iterableWithSize;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ProjectPagesIndexerTests {
+
+    private final Project springProject = new Project("spring", "Spring Project",
+            "http://www.example.com/repo/spring-project",
+            "http://www.example.com/spring-project", Collections.emptyList(), false, "release");
+
+    private final Project springFramework = new Project("spring-framework", "Spring Framework",
+            "http://www.example.com/repo/spring-framework",
+            "https://projects.spring.io/spring-framework", Collections.emptyList(), false, "release");
+
+
+    private final Project ioPlatform = new Project("spring-platform", "Spring IO Platform",
+            "http://www.example.com/repo/spring-io-platform",
+            "http://platform.spring.io/platform/", Collections.emptyList(), false, "release");
+    @Mock
+    private CrawlerService crawlerService;
+
+    @Mock
+    private ProjectMetadataService projectMetadataService;
+
+    @Mock
+    private SearchService searchService;
+
+    private ProjectPagesIndexer indexer;
+
+
+    private List<Project> projects = Arrays.asList(springProject, springFramework, ioPlatform);
+
+    @Before
+    public void setUp() {
+        indexer = new ProjectPagesIndexer(projectMetadataService, crawlerService, searchService);
+        ReflectionTestUtils.setField(indexer, "githubPagesDomains", "projects.spring.io,platform.spring.io");
+    }
+
+    @Test
+    public void itReturnsProjects() {
+        given(projectMetadataService.getProjectsWithReleases()).willReturn(this.projects);
+        Iterable<Project> projects = indexer.indexableItems();
+        assertThat(projects, iterableWithSize(3));
+    }
+
+    @Test
+    public void itOnlyCrawlsMatchingDomains() {
+        indexer.indexItem(springProject);
+        verify(crawlerService, never()).crawl(eq(springProject.getSiteUrl()), eq(0), any());
+
+        indexer.indexItem(springFramework);
+        verify(crawlerService, times(1)).crawl(eq(springFramework.getSiteUrl()), eq(0), any());
+
+        indexer.indexItem(ioPlatform);
+        verify(crawlerService, times(1)).crawl(eq(ioPlatform.getSiteUrl()), eq(0), any());
+    }
+
+}

--- a/sagan-site/src/it/java/sagan/search/support/SearchServiceIntegrationTests.java
+++ b/sagan-site/src/it/java/sagan/search/support/SearchServiceIntegrationTests.java
@@ -188,7 +188,7 @@ public class SearchServiceIntegrationTests extends AbstractIntegrationTests {
                 .summary("Html summary").publishAt("2013-01-01 10:00").blog();
         searchService.saveToIndex(entry);
 
-        assertThatSearchReturnsEntry("exmaple");
+        assertThatSearchReturnsEntry("exaaple");
     }
 
     @Test

--- a/sagan-site/src/it/java/sagan/search/support/SearchServiceIntegrationTests.java
+++ b/sagan-site/src/it/java/sagan/search/support/SearchServiceIntegrationTests.java
@@ -303,7 +303,7 @@ public class SearchServiceIntegrationTests extends AbstractIntegrationTests {
                 .path("http://example.com/content5").title("ApplicationContext")
                 .rawContent("This is an api doc for ApplicationContext.")
                 .summary("class level description").publishAt("2013-01-01 10:00")
-                .notCurrent().page();
+                .notCurrent().sitePage();
 
         searchService.saveToIndex(nonApiDoc);
 
@@ -367,7 +367,7 @@ public class SearchServiceIntegrationTests extends AbstractIntegrationTests {
                 .path("http://example.com/content5").title("ApplicationContext")
                 .rawContent("This is an api doc for ApplicationContext.")
                 .summary("class level description").publishAt("2013-01-01 10:00")
-                .notCurrent().page();
+                .notCurrent().sitePage();
 
         searchService.saveToIndex(nonReferenceDoc);
 
@@ -376,7 +376,7 @@ public class SearchServiceIntegrationTests extends AbstractIntegrationTests {
                 .rawContent("This is an api doc for ApplicationContext.")
                 .summary("class level description").publishAt("2013-01-01 10:00")
                 .notCurrent().projectId("not id to delete").version("3.4.5.RELEASE")
-                .page();
+                .sitePage();
 
         searchService.saveToIndex(othersite);
 

--- a/sagan-site/src/main/resources/elasticsearch/mappings/projectpage.json
+++ b/sagan-site/src/main/resources/elasticsearch/mappings/projectpage.json
@@ -1,0 +1,37 @@
+{
+  "projectpage": {
+    "properties": {
+      "path": {
+        "type": "string",
+        "store": "yes",
+        "index": "no"
+      },
+      "title": {
+        "type": "string",
+        "store": "yes",
+        "analyzer": "simple"
+      },
+      "subTitle": {
+        "type": "string",
+        "store": "yes",
+        "index": "no"
+      },
+      "summary": {
+        "type": "string",
+        "store": "yes",
+        "index": "no"
+      },
+      "rawContent": {
+        "type": "string",
+        "store": "yes",
+        "term_vector": "with_positions_offsets",
+        "analyzer": "fulltext"
+      },
+      "facetPaths": {
+        "type": "string",
+        "store": "no",
+        "index": "not_analyzed"
+      }
+    }
+  }
+}

--- a/util/recreate-elasticsearch-index.sh
+++ b/util/recreate-elasticsearch-index.sh
@@ -40,6 +40,8 @@ curl -XPOST "$ENDPOINT/$INDEX/referencedoc/_mapping" -d @../sagan-site/src/main/
 sleep 1
 curl -XPOST "$ENDPOINT/$INDEX/sitepage/_mapping" -d @../sagan-site/src/main/resources/elasticsearch/mappings/sitepage.json
 sleep 1
+curl -XPOST "$ENDPOINT/$INDEX/projectpage/_mapping" -d @../sagan-site/src/main/resources/elasticsearch/mappings/projectpage.json
+sleep 1
 curl -XPOST "$ENDPOINT/$INDEX/_open"
 sleep 1
 


### PR DESCRIPTION
When submitting one of the most popular search queries like "spring boot", one should get the project page as the first result.

- [x] index github pages for projects
- [x] boost this type in search queries
- [x] map this new type in UI search filters