### PR TITLE
Broken link (http://spring.io/guides/gs/spring-xd-osx/)

### DIFF
--- a/sagan-site/src/main/resources/urlrewrite.xml
+++ b/sagan-site/src/main/resources/urlrewrite.xml
@@ -16,6 +16,12 @@
         <to type="permanent-redirect" last="true">/guides/gs/accessing-data-mongodb/</to>
     </rule>
     <rule>
+        <name>Support renamed Spring XD guide</name>
+        <note>https://github.com/spring-io/sagan/issues/226</note>
+        <from>^/guides/gs/spring-xd-osx/?$</from>
+        <to type="permanent-redirect" last="true">/guides/gs/spring-xd/</to>
+    </rule>
+    <rule>
         <name>GSG trailing slash</name>
         <note>https://www.pivotaltracker.com/story/show/52214321</note>
         <from>/guides/gs/([^/]+)$</from>

--- a/sagan-site/src/test/java/sagan/rewrite/support/RewriteTests.java
+++ b/sagan-site/src/test/java/sagan/rewrite/support/RewriteTests.java
@@ -65,6 +65,12 @@ public class RewriteTests {
     }
 
     @Test
+    public void supportRenamedXDGuide() throws ServletException, IOException, URISyntaxException {
+        validatePermanentRedirect("/guides/gs/spring-xd-osx/", "/guides/gs/spring-xd/");
+        validateOk("/guides/gs/spring-xd/");
+    }
+
+    @Test
     public void gsgGuidesShouldAlwaysHaveTrailingSlash() throws ServletException, IOException, URISyntaxException {
         validatePermanentRedirect("/guides/gs/guide-name", "/guides/gs/guide-name/");
         validateOk("/guides/gs/guide-name/");


### PR DESCRIPTION
http://spring.io/guides/gs/spring-xd-osx/ is a broken link.  I'm assuming it should be redirected here: http://spring.io/guides/gs/spring-xd