### PR TITLE
List of Spring guides are difficult to read on mobile

### DIFF
--- a/sagan-client/src/css/guide.css
+++ b/sagan-client/src/css/guide.css
@@ -40,15 +40,6 @@
   font-size: 14px;
   line-height: 21px;
 }
-.guides-section--container .guides--wrapper {
-  margin-right: -40px;
-}
-
-@media (max-width:600px){
-  .guides-section--container .guide--container {
-    width: 100%;
-  }
-}
 
 .guides-section--container .guide--container {
   display: inline-block;

--- a/sagan-client/src/css/responsive.css
+++ b/sagan-client/src/css/responsive.css
@@ -437,14 +437,14 @@
     display: none;
   }
 
-  .guides-section--container {
+  body .guides-section--container {
     margin-top: 0;
   }
-  .guides-section--container .guide--container {
+
+  body .guides-section--container .guide--container {
     display: block;
-    margin: 0;
     width: auto;
-    margin-bottom: 20px;
+    margin: 0 0 20px;
   }
 
   .project--container {


### PR DESCRIPTION
Guide titles overlap on mobile screens
![sagan-mobile](https://cloud.githubusercontent.com/assets/40810/7898862/c7eb1cda-06db-11e5-84da-74701f3529f5.png)

Guide container width can be set to 100% at mobile breakpoint.