### PR TITLE
update github API re:gravatar

### DIFF
--- a/sagan-common/src/main/java/sagan/team/support/TeamService.java
+++ b/sagan-common/src/main/java/sagan/team/support/TeamService.java
@@ -105,11 +105,10 @@ public class TeamService {
             profile = new MemberProfile();
             profile.setGithubId(githubId);
             profile.setUsername(username);
-            profile.setAvatarUrl(avatarUrl);
-            profile.setName(name);
             profile.setHidden(true);
         }
-
+        profile.setAvatarUrl(avatarUrl);
+        profile.setName(name);
         profile.setGithubUsername(username);
         return teamRepository.save(profile);
     }

--- a/sagan-site/src/it/java/sagan/team/support/ImportTeamFromGithubTests.java
+++ b/sagan-site/src/it/java/sagan/team/support/ImportTeamFromGithubTests.java
@@ -43,11 +43,14 @@ public class ImportTeamFromGithubTests extends AbstractIntegrationTests {
         ResponseEntity<GitHubUser[]> responseEntity = new ResponseEntity<>(gitHubUsers, HttpStatus.OK);
 
         given(
-                restOperations.getForEntity("https://api.github.com/teams/{teamId}/members", GitHubUser[].class,
+                restOperations.getForEntity("https://api.github.com/teams/{teamId}/members?per_page=100", GitHubUser[].class,
                         "482984")).willReturn(responseEntity);
 
-        stubRestClient.putResponse("/users/jdoe", Fixtures.load("/fixtures/github/ghUserProfile-jdoe.json"));
-        stubRestClient.putResponse("/users/asmith", Fixtures.load("/fixtures/github/ghUserProfile-asmith.json"));
+        given(restOperations.getForObject("https://api.github.com/users/{user}", GitHubUser.class, "jdoe"))
+                .willReturn(mapper.readValue(Fixtures.load("/fixtures/github/ghUserProfile-jdoe.json"), GitHubUser.class));
+
+        given(restOperations.getForObject("https://api.github.com/users/{user}", GitHubUser.class, "asmith"))
+                .willReturn(mapper.readValue(Fixtures.load("/fixtures/github/ghUserProfile-asmith.json"), GitHubUser.class));
     }
 
     @Test


### PR DESCRIPTION
The "import team members from github" button in the admin interface does not work properly for several reasons:
* it's only listing the first 30 team members as the "team" GitHub API endpoint is paginated
* it's requesting user profile information with a non-authenticated REST client, thus rate-limited
* it's not updating user profile information (such as name and avatar_url)