### PR TITLE
Upgrade to Spring IO Platform 1.1.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ def javaProjects = [ project(':sagan-site'), project(':sagan-indexer'), project(
 def bootProjects = javaProjects - project(':sagan-common')
 def gradleDir = "${rootProject.rootDir}/gradle"
 
-wrapper.gradleVersion = '2.4'
+wrapper.gradleVersion = '2.8'
 
 buildscript {
     ext.springRepo = 'http://repo.spring.io/libs-release'
@@ -14,7 +14,7 @@ buildscript {
 
     dependencies {
 		classpath 'io.spring.gradle:dependency-management-plugin:0.5.3.RELEASE'
-        classpath "org.springframework.boot:spring-boot-gradle-plugin:1.2.5.RELEASE"
+        classpath "org.springframework.boot:spring-boot-gradle-plugin:1.2.7.RELEASE"
         classpath 'org.cloudfoundry:cf-gradle-plugin:1.1.3' // see deploy.gradle
     }
 }
@@ -36,6 +36,9 @@ configure(javaProjects) {
     repositories {
         maven { url springRepo }
     }
+
+    // Override Spring IO Platform versions
+    ext['elasticsearch.version'] = '1.7.1' // see io.searchbox:jest
 
     dependencies {
         compile 'org.slf4j:slf4j-api'
@@ -78,7 +81,7 @@ configure(bootProjects) {
 
 	dependencyManagement {
 		imports {
-			mavenBom 'io.spring.platform:platform-bom:1.1.3.RELEASE'
+			mavenBom 'io.spring.platform:platform-bom:1.1.4.RELEASE'
 		}
 	}
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Jun 01 12:42:29 CEST 2015
+#Wed Oct 21 21:29:56 CEST 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.8-bin.zip

--- a/sagan-common/build.gradle
+++ b/sagan-common/build.gradle
@@ -18,10 +18,9 @@ sourceSets {
 
 dependencyManagement {
 	imports {
-		mavenBom 'io.spring.platform:platform-bom:1.1.3.RELEASE'
+		mavenBom 'io.spring.platform:platform-bom:1.1.4.RELEASE'
 	}
 }
-
 
 dependencies {
 
@@ -32,13 +31,13 @@ dependencies {
 
     compile 'org.apache.httpcomponents:httpclient'
 
-    compile 'org.elasticsearch:elasticsearch:1.5.2'
+    compile 'org.elasticsearch:elasticsearch'
     compile 'io.searchbox:jest:0.1.6'
     compile 'commons-codec:commons-codec' // needed by Jest's HTTP client?
     compile 'org.springframework.cloud:spring-cloud-spring-service-connector'
     compile 'org.springframework.cloud:spring-cloud-cloudfoundry-connector'
 
-    compile 'org.pegdown:pegdown:1.5.0'
+    compile 'org.pegdown:pegdown:1.6.0'
 
     // datasource and connection pool dependencies
     runtime 'org.postgresql:postgresql:9.4-1201-jdbc4'
@@ -55,7 +54,7 @@ dependencies {
     compile "com.fasterxml.jackson.dataformat:jackson-dataformat-xml"
     compile "org.codehaus.woodstox:woodstox-core-asl"
 
-    compile 'org.jsoup:jsoup:1.8.2'
+    compile 'org.jsoup:jsoup:1.8.3'
     compile 'joda-time:joda-time'
     compile 'org.hibernate:hibernate-validator'
 

--- a/sagan-site/src/it/java/sagan/projects/support/ProjectsMetadataApiTests.java
+++ b/sagan-site/src/it/java/sagan/projects/support/ProjectsMetadataApiTests.java
@@ -56,7 +56,7 @@ public class ProjectsMetadataApiTests extends AbstractIntegrationTests {
         String functionNameRegex = "^([^(]*)\\((.*)\\);$";
         Matcher matcher = Pattern.compile(functionNameRegex).matcher(content);
         if (matcher.find()) {
-            assertThat(matcher.group(1), equalTo("a_function_name"));
+            assertThat(matcher.group(1), equalTo("/**/a_function_name"));
 
             Map<String, Object> projectMetadata = new JacksonJsonParser().parseMap(matcher.group(2));
 


### PR DESCRIPTION
* Upgrade to Spring Boot 1.2.7
* elasticsearch is now a dependency managed by Boot, so we need
to override its version at the IO Platform level
* Spring Framework is now prepending JSONP responses with a "/**/"
prefix
* Upgrade to Gradle 2.8
* various dependency upgrades