### PR TITLE
Fix issue #594 - version ordering

### DIFF
--- a/sagan-common/src/main/java/sagan/projects/Project.java
+++ b/sagan-common/src/main/java/sagan/projects/Project.java
@@ -9,7 +9,8 @@ import java.util.Set;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.Id;
-import javax.persistence.OrderBy;
+
+import static java.util.stream.Collectors.toList;
 
 @Entity
 public class Project {
@@ -22,7 +23,6 @@ public class Project {
     private String category;
 
     @ElementCollection
-    @OrderBy("versionName DESC")
     private List<ProjectRelease> releaseList = new ArrayList<>();
     private boolean isAggregator;
     private String stackOverflowTags;
@@ -94,7 +94,10 @@ public class Project {
     }
 
     public List<ProjectRelease> getProjectReleases() {
-        return releaseList;
+        return releaseList.stream()
+            .sorted((release1, release2) -> release1.getVersionDisplayName().compareTo(release2.getVersionDisplayName()))
+            .sorted(ProjectRelease::compareTo)
+            .collect(toList());
     }
 
     public String getRepoUrl() {

--- a/sagan-common/src/main/java/sagan/projects/ProjectRelease.java
+++ b/sagan-common/src/main/java/sagan/projects/ProjectRelease.java
@@ -1,6 +1,6 @@
 package sagan.projects;
 
-import java.util.regex.Pattern;
+import java.util.regex.*;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Embeddable;
@@ -161,7 +161,38 @@ public class ProjectRelease implements Comparable<ProjectRelease> {
 
     @Override
     public int compareTo(ProjectRelease other) {
-        return versionName.compareTo(other.versionName);
+        Pattern pattern = Pattern.compile("([0-9]+)");
+
+        Matcher thisMatcher = pattern.matcher(this.getVersionDisplayName());
+        Matcher otherMatcher = pattern.matcher(other.getVersionDisplayName());
+
+        int versionDiff = 0;
+
+        boolean thisFind = thisMatcher.find();
+        boolean otherFind = otherMatcher.find();
+
+        while (thisFind && otherFind) {
+            int thisFoundVersion = Integer.parseInt(thisMatcher.group(0));
+            int otherFoundVersion = Integer.parseInt(otherMatcher.group(0));
+            versionDiff = otherFoundVersion - thisFoundVersion;
+
+            if (versionDiff != 0) {
+                return versionDiff;
+            }
+
+            thisFind = thisMatcher.find();
+            otherFind = otherMatcher.find();
+        }
+
+        if (thisFind) {
+            return -1;
+        }
+
+        if (otherFind) {
+            return 1;
+        }
+
+        return versionDiff;
     }
 
     @Override

--- a/sagan-common/src/test/java/sagan/projects/ProjectVersionOrderTests.java
+++ b/sagan-common/src/test/java/sagan/projects/ProjectVersionOrderTests.java
@@ -1,0 +1,63 @@
+package sagan.projects;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static java.util.stream.Collectors.toList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+public class ProjectVersionOrderTests {
+    @Test
+    public void getProjectReleases_ordersVersionsByNumber_major() throws Exception {
+        Project project = getProject("10.0.0", "9.0.0", "11.0.0");
+        assertThat(getProjectReleases(project), equalTo(asList("11.0.0", "10.0.0", "9.0.0")));
+    }
+
+    @Test
+    public void getProjectReleases_ordersVersionsByNumber_minor() throws Exception {
+        Project project = getProject("0.10.0", "0.9.0", "0.11.0");
+        assertThat(getProjectReleases(project), equalTo(asList("0.11.0", "0.10.0", "0.9.0")));
+    }
+
+    @Test
+    public void getProjectReleases_ordersVersionsByNumber_patch() throws Exception {
+        Project project = getProject("0.0.10", "0.0.9", "0.0.11");
+        assertThat(getProjectReleases(project), equalTo(asList("0.0.11", "0.0.10", "0.0.9")));
+    }
+
+    @Test
+    public void getProjectReleases_ordersVersionsByNumber_milestones() throws Exception {
+        Project project = getProject("0.0.10.RELEASE", "0.0.9.BUILD-SNAPSHOT", "0.0.11.MILESTONE");
+        assertThat(getProjectReleases(project), equalTo(asList("0.0.11.MILESTONE", "0.0.10.RELEASE", "0.0.9.BUILD-SNAPSHOT")));
+    }
+
+    @Test
+    public void getProjectReleases_ordersVersionsByNumber_milestonesWithVersions() throws Exception {
+        Project project = getProject("0.1 M1", "0.1", "0.1 M2");
+        assertThat(getProjectReleases(project), equalTo(asList("0.1 M2", "0.1 M1", "0.1")));
+    }
+
+    @Test
+    public void getProjectReleases_ordersVersionsByNumber_otherCharacters() throws Exception {
+        Project project = getProject("Gosling-RC9", "Angel.RC10", "Gosling-RC10", "Angel.RC9");
+        assertThat(getProjectReleases(project), equalTo(asList("Angel.RC10", "Gosling-RC10", "Angel.RC9", "Gosling-RC9")));
+    }
+
+    private Project getProject(String... projectReleaseStrings) {
+        List<ProjectRelease> projectReleases = asList(projectReleaseStrings).stream()
+            .map(release -> new ProjectRelease(release, null, false, "", "", "", ""))
+            .collect(toList());
+
+        return new Project("", "", "", "", projectReleases, false, "");
+    }
+
+    private List<String> getProjectReleases(Project project) {
+        return project.getProjectReleases().stream()
+            .map(ProjectRelease::getVersion)
+            .collect(toList());
+    }
+
+}


### PR DESCRIPTION
Issue #594 seems to be occurring because versions are stored as strings and compared as strings - 1.10 is compared to 1.9 as character '1' vs character '9' instead of number '10' vs '9'. This change addresses issue #594 by adding a comparator that cares about numbers - however, I'm not sure on a couple of things:

1. How you guys feel about getters with logic (see: Project::getProjectReleases)
1. Whether `0.0.1M2 0.0.1M1 0.0.1` is correct or `0.0.1 0.0.1M2 0.0.1M1` (I went with the former, but just have to remove the two conditionals in ProjectRelease::compareTo to get the latter)
1. Where projects.spring.io is being rendered from - can't for the life of me find the controller doing that. Tested against http://localhost:8080/docs/reference instead, which I presume has model objects in common with projects.spring.io (`Project` and `ProjectRelease`). Please let me know if this incorrect