### PR TITLE
Fix issue #594 - version ordering

### DIFF
--- a/sagan-common/src/main/java/sagan/projects/Project.java
+++ b/sagan-common/src/main/java/sagan/projects/Project.java
@@ -9,7 +9,6 @@ import java.util.Set;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.Id;
-import javax.persistence.OrderBy;
 
 @Entity
 public class Project {
@@ -22,7 +21,6 @@ public class Project {
     private String category;
 
     @ElementCollection
-    @OrderBy("versionName DESC")
     private List<ProjectRelease> releaseList = new ArrayList<>();
     private boolean isAggregator;
     private String stackOverflowTags;
@@ -94,6 +92,15 @@ public class Project {
     }
 
     public List<ProjectRelease> getProjectReleases() {
+        releaseList.sort((release1, release2) -> {
+            if (release1.getVersion() == null || release2.getVersion() == null) {
+                return 0;
+            }
+
+            return release1.getVersion().compareTo(release2.getVersion());
+        });
+        releaseList.sort(ProjectRelease::compareTo);
+
         return releaseList;
     }
 

--- a/sagan-common/src/main/java/sagan/projects/ProjectRelease.java
+++ b/sagan-common/src/main/java/sagan/projects/ProjectRelease.java
@@ -1,6 +1,6 @@
 package sagan.projects;
 
-import java.util.regex.Pattern;
+import java.util.regex.*;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Embeddable;
@@ -161,7 +161,42 @@ public class ProjectRelease implements Comparable<ProjectRelease> {
 
     @Override
     public int compareTo(ProjectRelease other) {
-        return versionName.compareTo(other.versionName);
+        if (this.getVersion() == null || other.getVersion() == null) {
+            return 0;
+        }
+
+        Pattern pattern = Pattern.compile("([0-9]+)");
+
+        Matcher thisMatcher = pattern.matcher(this.getVersion());
+        Matcher otherMatcher = pattern.matcher(other.getVersion());
+
+        int versionDiff = 0;
+
+        boolean thisFind = thisMatcher.find();
+        boolean otherFind = otherMatcher.find();
+
+        while (thisFind && otherFind) {
+            int thisFoundVersion = Integer.parseInt(thisMatcher.group(0));
+            int otherFoundVersion = Integer.parseInt(otherMatcher.group(0));
+            versionDiff = otherFoundVersion - thisFoundVersion;
+
+            if (versionDiff != 0) {
+                return versionDiff;
+            }
+
+            thisFind = thisMatcher.find();
+            otherFind = otherMatcher.find();
+        }
+
+        if (thisFind) {
+            return -1;
+        }
+
+        if (otherFind) {
+            return 1;
+        }
+
+        return versionDiff;
     }
 
     @Override

--- a/sagan-common/src/test/java/sagan/projects/ProjectVersionOrderTests.java
+++ b/sagan-common/src/test/java/sagan/projects/ProjectVersionOrderTests.java
@@ -1,0 +1,63 @@
+package sagan.projects;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static java.util.stream.Collectors.toList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+public class ProjectVersionOrderTests {
+    @Test
+    public void getProjectReleases_ordersVersionsByNumber_major() throws Exception {
+        Project project = getProject("10.0.0", "9.0.0", "11.0.0");
+        assertThat(getProjectReleases(project), equalTo(asList("11.0.0", "10.0.0", "9.0.0")));
+    }
+
+    @Test
+    public void getProjectReleases_ordersVersionsByNumber_minor() throws Exception {
+        Project project = getProject("0.10.0", "0.9.0", "0.11.0");
+        assertThat(getProjectReleases(project), equalTo(asList("0.11.0", "0.10.0", "0.9.0")));
+    }
+
+    @Test
+    public void getProjectReleases_ordersVersionsByNumber_patch() throws Exception {
+        Project project = getProject("0.0.10", "0.0.9", "0.0.11");
+        assertThat(getProjectReleases(project), equalTo(asList("0.0.11", "0.0.10", "0.0.9")));
+    }
+
+    @Test
+    public void getProjectReleases_ordersVersionsByNumber_milestones() throws Exception {
+        Project project = getProject("0.0.10.RELEASE", "0.0.9.BUILD-SNAPSHOT", "0.0.11.MILESTONE");
+        assertThat(getProjectReleases(project), equalTo(asList("0.0.11.MILESTONE", "0.0.10.RELEASE", "0.0.9.BUILD-SNAPSHOT")));
+    }
+
+    @Test
+    public void getProjectReleases_ordersVersionsByNumber_milestonesWithVersions() throws Exception {
+        Project project = getProject("0.1 M1", "0.1", "0.1 M2");
+        assertThat(getProjectReleases(project), equalTo(asList("0.1 M2", "0.1 M1", "0.1")));
+    }
+
+    @Test
+    public void getProjectReleases_ordersVersionsByNumber_otherCharacters() throws Exception {
+        Project project = getProject("Gosling-RC9", "Angel.RC10", "Gosling-RC10", "Angel.RC9");
+        assertThat(getProjectReleases(project), equalTo(asList("Angel.RC10", "Gosling-RC10", "Angel.RC9", "Gosling-RC9")));
+    }
+
+    private Project getProject(String... projectReleaseStrings) {
+        List<ProjectRelease> projectReleases = asList(projectReleaseStrings).stream()
+            .map(release -> new ProjectRelease(release, null, false, "", "", "", ""))
+            .collect(toList());
+
+        return new Project("", "", "", "", projectReleases, false, "");
+    }
+
+    private List<String> getProjectReleases(Project project) {
+        return project.getProjectReleases().stream()
+            .map(ProjectRelease::getVersion)
+            .collect(toList());
+    }
+
+}


### PR DESCRIPTION
Issue #594 seems to be occurring because versions are stored as strings and compared as strings - 1.10 is compared to 1.9 as character '1' vs character '9' instead of number '10' vs '9'. This change addresses issue #594 by adding a comparator that cares about numbers and using that comparator whenever we call Project::getProjectReleases.

Two quick notes:

- Not sure if people are comfortable solving this kind of problem through getters. Figured the alternative is to find all places we're using projectReleases and sort - which seems like a lot of duplicated effort - or change the db model to not have version as a string, which seems like a big chore.
- ProjectAdminController - `@RequestMapping(value = "{id}", method = POST) public String save(@Valid Project project... etc` - calls Project::getProjectReleases several times before the object is fully constructed. I'm guessing it's part of the json->object building process. This has the unfortunate side-affect of our getter needing nullchecks, which sucks. Would love other suggestions if there's a better way to solve that problem. I was thinking of looking into removing setters on the object entirely and seeing if that solves it.

edit: Additional note - I noticed that `ProjectAdminController` does a fair amount of mutation to Project during its CRUD operations. I'm thinking of refactoring it to be a bit more stateless. Let me know if that's a bad idea.