### PR TITLE
Use libs repositories in example pom.xml and build.gradle snippets

### DIFF
--- a/sagan-common/src/main/java/sagan/projects/ProjectRepository.java
+++ b/sagan-common/src/main/java/sagan/projects/ProjectRepository.java
@@ -8,9 +8,9 @@ import javax.persistence.Id;
 @Entity
 public class ProjectRepository {
     private static final ProjectRepository SNAPSHOT = new ProjectRepository("spring-snapshots", "Spring Snapshots",
-            "http://repo.spring.io/snapshot", true);
+            "https://repo.spring.io/libs-snapshot", true);
     private static final ProjectRepository MILESTONE = new ProjectRepository("spring-milestones", "Spring Milestones",
-            "http://repo.spring.io/milestone", false);
+            "https://repo.spring.io/libs-milestone", false);
 
     @Id
     private String id;

--- a/sagan-common/src/main/resources/db/migration/V6__update_repository_urls.sql
+++ b/sagan-common/src/main/resources/db/migration/V6__update_repository_urls.sql
@@ -1,0 +1,2 @@
+update projectrepository set url='https://repo.spring.io/libs-snapshot' where id='spring-snapshots';
+update projectrepository set url='https://repo.spring.io/libs-milestone' where id='spring-milestones';

--- a/sagan-site/src/it/java/sagan/projects/support/ProjectsMetadataApiTests.java
+++ b/sagan-site/src/it/java/sagan/projects/support/ProjectsMetadataApiTests.java
@@ -119,7 +119,7 @@ public class ProjectsMetadataApiTests extends AbstractIntegrationTests {
 
         assertThat((String) repository.get("id"), equalTo("spring-snapshots"));
         assertThat((String) repository.get("name"), equalTo("Spring Snapshots"));
-        assertThat((String) repository.get("url"), equalTo("http://repo.spring.io/snapshot"));
+        assertThat((String) repository.get("url"), equalTo("https://repo.spring.io/libs-snapshot"));
         assertThat((Boolean) repository.get("snapshotsEnabled"), equalTo(true));
     }
 


### PR DESCRIPTION
Previously, the project pages used http://repo.spring.io/milestone and http://repo.spring.io/snapshot repository URLs in the sample pom.xml and build.gradle snippets for milestone and snapshot versions
of a project. This is problematic as it assumes that all of project's dependencies will be available in the snapshot or milestone repository. This won't always be the case. For example, current Spring Boot 1.4 snapshots depend on Spring Data Hopper M1 which isn't available in the snapshot repository.

This pull request updates the project metadata to use https://repo.spring.io/libs-snapshot and
https://repo.spring.io/libs-milestone. These virtual repositories make content from the more stable repositories, e.g. libs-snapshot provides access to the contents of the snapshot, milestone, and
release repositories. This ensures that all of a project's dependencies are available, without having to configure multiple repositories.