### PR TITLE
Add link to current filter on /guides and /docs pages.

### DIFF
--- a/sagan-client/src/css/base.css
+++ b/sagan-client/src/css/base.css
@@ -828,6 +828,12 @@ input.floating-input:focus {
 .content-container--wrapper .content-container--header .btn {
   margin: 6px;
 }
+.content-container--wrapper .content-container--header .filter-link {
+  color: #6db33f;
+}
+.content-container--wrapper .content-container--header .filter-link:hover {
+  color: #7ac04c;
+}
 .content-container--wrapper .content-container--body {
   padding: 20px;
   border-top: 1px solid white;

--- a/sagan-client/src/feature/filterableList/getUrlFilter.js
+++ b/sagan-client/src/feature/filterableList/getUrlFilter.js
@@ -4,5 +4,5 @@ function getUrlFilter() {
     // grab first "filter=..." param in url
     var query = document.location.search;
     var matches = query.match(/[&?]filter=([^&]+)/);
-    return matches ? decodeURIComponent(matches[1]) : '';
+    return matches ? decodeURIComponent(matches[1]).replace('+', ' ') : '';
 }

--- a/sagan-client/src/feature/filterableList/main.js
+++ b/sagan-client/src/feature/filterableList/main.js
@@ -5,7 +5,7 @@ var $ = require('jquery');
 module.exports = createFilterableList;
 
 function createFilterableList() {
-    var filterList, filterInput;
+    var filterList, filterInput, setFilterLink;
 
     $(ready);
 
@@ -20,10 +20,31 @@ function createFilterableList() {
         filterInput = document.getElementById('doc_filter');
         filterList = filterableList(onFilterMatch, 'data-filterable', containers);
 
+        setFilterLink = function (filter) {
+            var filterLink = $("#filter-link");
+            if (!filter) {
+                filterLink.hide();
+            } else {
+                filterLink.show();
+            }
+
+            var param = jQuery.param({filter: filter});
+            var currentSearch = window.location.search;
+            var destination = '';
+            if (!currentSearch) {
+                destination = window.location.href + '?' + param;
+            } else {
+                destination = window.location.href.replace(currentSearch, '?' + param);
+            }
+
+            filterLink.attr("href", destination);
+        };
+
         if (initialFilter) {
             $(filterInput).val(initialFilter);
             filterList(initialFilter);
         }
+        setFilterLink(initialFilter);
         // jquery has a "paste" event, but it fires too late.
         // "keyup" and "input" should catch mostly everything.
         $(filterInput).on('keyup input', onInputChange);
@@ -33,12 +54,13 @@ function createFilterableList() {
         }
     }
 
-    function onInputChange (e) {
+    function onInputChange(e) {
         filterList(e.target.value);
+        setFilterLink(e.target.value);
     }
 
     function destroy() {
-        if(filterList) {
+        if (filterList) {
             $(filterInput).off('keyup input', filterList);
         }
     }

--- a/sagan-site/src/main/resources/templates/docs/reference.html
+++ b/sagan-site/src/main/resources/templates/docs/reference.html
@@ -27,6 +27,7 @@
         <div class="row-fluid content-container--wrapper docs--body" >
             <div class="content-container--header">
                 <input type='text' id='doc_filter' style="color:#aaa;" onfocus="this.value=''; this.style.color='#000'; this.style.fontStyle='normal'; this.onfocus='';" autofocus value="Find a project..." placeholder="Find a project..." class="content-container--filter"/>
+                <a id="filter-link" th:hidden="true" href="#" class="filter-link">Link to this search</a>
             </div>
             <div data-filterable-container>
                 <section class="js-item-dropdown-widget--wrapper">

--- a/sagan-site/src/main/resources/templates/guides/index.html
+++ b/sagan-site/src/main/resources/templates/guides/index.html
@@ -1,7 +1,8 @@
 <html   xmlns:th="http://www.thymeleaf.org"
         xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
         layout:decorator="layout"
-        data-filterable-list>
+        data-filterable-list
+        data-clipboard-buttons>
 <head>
     <title>Guides</title>
     <link rel="stylesheet" type="text/css" th:href="@{/css/guide.css}"/>
@@ -26,6 +27,7 @@
       <div class="row-fluid content-container--wrapper guides-section--container">
         <div class="content-container--header">
           <input type='text' id='doc_filter' style="color:#aaa;" onfocus="this.value=''; this.style.color='#000'; this.style.fontStyle='normal'; this.onfocus='';" autofocus value="Find a guide..." placeholder="Find a guide..." class="content-container--filter"/>
+          <a id="filter-link" th:hidden="true" href="#" class="filter-link">Link to this search</a>
         </div>
         <section class="content-container--body">
           <div data-filterable-container>


### PR DESCRIPTION
Fixes #64
Only provides an anchor, rather than modifying the query string directly (as this is impossible to do without reloading). UX may be further improved by e.g. using a clipboard button instead.
Incidentally corrects an issue with decoding query parameters.
