### PR TITLE
Add Docs link to mobile navigation

### DIFF
--- a/sagan-site/src/main/resources/templates/_mobile-nav.html
+++ b/sagan-site/src/main/resources/templates/_mobile-nav.html
@@ -21,6 +21,12 @@
               <i class="icon-chevron-right pull-right"></i>
             </a>
           </div>
+          <div th:class="${beans.uih.navClass(navSection?:'','docs')}">
+            <a th:href="@{/docs}" href="docs/index.html">
+              Docs
+              <i class="icon-chevron-right pull-right"></i>
+            </a>
+          </div>
           <div th:class="${beans.uih.navClass(navSection?:'','guides')}">
             <a th:href="@{/guides}" href="guides/index.html">
               Guides


### PR DESCRIPTION
Adds a Doc link to the mobile navigation menu:

![capture3](https://cloud.githubusercontent.com/assets/7154425/15255795/068ff486-18f3-11e6-97b1-d3dcbcf57405.PNG)

Resolves #653 