### PR TITLE
Add API endpoints for /project_metadata

### DIFF
--- a/sagan-common/src/main/java/sagan/projects/ProjectRelease.java
+++ b/sagan-common/src/main/java/sagan/projects/ProjectRelease.java
@@ -1,6 +1,7 @@
 package sagan.projects;
 
-import java.util.regex.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Embeddable;
@@ -8,7 +9,10 @@ import javax.persistence.ManyToOne;
 
 import org.springframework.util.Assert;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 @Embeddable
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ProjectRelease implements Comparable<ProjectRelease> {
 
     private static final Pattern PRERELEASE_PATTERN = Pattern.compile("[A-Za-z0-9\\.\\-]+?(M|RC)\\d+");
@@ -45,7 +49,7 @@ public class ProjectRelease implements Comparable<ProjectRelease> {
     public ProjectRelease(String versionName, ReleaseStatus releaseStatus, boolean isCurrent, String refDocUrl,
                           String apiDocUrl, String groupId, String artifactId) {
         setVersion(versionName);
-        if (releaseStatus!=null) {
+        if (releaseStatus != null) {
             this.releaseStatus = releaseStatus;
         }
         this.isCurrent = isCurrent;
@@ -89,7 +93,7 @@ public class ProjectRelease implements Comparable<ProjectRelease> {
         String versionLabel = "";
         if (versionName.contains(".")) {
             versionNumber = versionName.substring(0, versionName.lastIndexOf("."));
-            versionLabel = " " + versionName.substring(versionName.lastIndexOf(".")+1);
+            versionLabel = " " + versionName.substring(versionName.lastIndexOf(".") + 1);
             if (versionLabel.contains("SNAPSHOT") || versionLabel.equals(" RELEASE")) {
                 versionLabel = "";
             }

--- a/sagan-site/src/it/java/saganx/AbstractIntegrationTests.java
+++ b/sagan-site/src/it/java/saganx/AbstractIntegrationTests.java
@@ -1,6 +1,5 @@
 package saganx;
 
-import org.springframework.test.context.ActiveProfiles;
 import sagan.SaganProfiles;
 import sagan.blog.support.BlogService;
 import sagan.support.github.StubGithubRestClient;
@@ -10,12 +9,13 @@ import org.junit.Before;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.ConfigFileApplicationContextInitializer;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.cache.CacheManager;
 import org.springframework.security.web.FilterChainProxy;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,12 +24,11 @@ import org.springframework.web.context.WebApplicationContext;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static sagan.support.SecurityRequestPostProcessors.*;
 
-@RunWith(SpringJUnit4ClassRunner.class)
-@WebAppConfiguration
-@ContextConfiguration(classes = { IntegrationTestsConfig.class, InMemoryElasticSearchConfig.class },
-                      initializers = ConfigFileApplicationContextInitializer.class)
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = WebEnvironment.MOCK)
+@ContextConfiguration(classes = { IntegrationTestsConfig.class, InMemoryElasticSearchConfig.class })
 @Transactional
-@ActiveProfiles(profiles = {SaganProfiles.STANDALONE})
+@ActiveProfiles(profiles = { SaganProfiles.STANDALONE })
 public abstract class AbstractIntegrationTests {
 
     @Autowired

--- a/sagan-site/src/main/java/sagan/projects/support/ProjectMetadataController.java
+++ b/sagan-site/src/main/java/sagan/projects/support/ProjectMetadataController.java
@@ -1,15 +1,22 @@
 package sagan.projects.support;
 
-import static org.springframework.web.bind.annotation.RequestMethod.*;
-
-import java.io.IOException;
-
 import sagan.projects.Project;
+import sagan.projects.ProjectRelease;
 import sagan.support.JsonPController;
 
+import java.io.IOException;
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import static org.springframework.web.bind.annotation.RequestMethod.*;
 
 /**
  * Controller that handles ajax requests for project metadata, typically from the
@@ -31,6 +38,89 @@ class ProjectMetadataController {
     @RequestMapping(value = "/{projectId}", method = { GET, HEAD })
     public Project projectMetadata(@PathVariable("projectId") String projectId) throws IOException {
         return service.getProject(projectId);
+    }
+
+    @RequestMapping(value = "/{projectId}/**", method = GET)
+    public ProjectRelease releaseMetadata(@PathVariable("projectId") String projectId) throws IOException {
+        Project project = service.getProject(projectId);
+        if (project == null) {
+            throw new MetadataNotFoundException("Cannot find project " + projectId);
+        }
+        List<ProjectRelease> releases = project.getProjectReleases();
+        String path = ServletUriComponentsBuilder.fromCurrentRequest().build().getPath();
+        String version = path.substring(("/project_metadata/" + projectId + "/").length());
+        for (ProjectRelease release : releases) {
+            if (release.getVersion().equals(version)) {
+                return release;
+            }
+        }
+        throw new MetadataNotFoundException("Could not find " + version + " for " + projectId);
+    }
+
+    @RequestMapping(value = "/{projectId}", method = POST)
+    public ProjectRelease updateReleaseMetadata(@PathVariable("projectId") String projectId,
+                                                @RequestBody ProjectRelease release) throws IOException {
+        Project project = service.getProject(projectId);
+        if (project == null) {
+            throw new MetadataNotFoundException("Cannot find project " + projectId);
+        }
+        List<ProjectRelease> releases = service.getProject(projectId).getProjectReleases();
+        boolean found = false;
+        for (int i = 0; i < releases.size(); i++) {
+            ProjectRelease projectRelease = releases.get(i);
+            if (release.getRepository() != null && release.getRepository().equals(projectRelease.getRepository())) {
+                release.setRepository(projectRelease.getRepository());
+            }
+            if (projectRelease.getVersion().equals(release)) {
+                releases.set(i, release);
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            releases.add(release);
+        }
+        service.save(project);
+        return release;
+    }
+
+    @RequestMapping(value = "/{projectId}/**", method = DELETE)
+    public ProjectRelease removeReleaseMetadata(@PathVariable("projectId") String projectId) throws IOException {
+        Project project = service.getProject(projectId);
+        if (project == null) {
+            throw new MetadataNotFoundException("Cannot find project " + projectId);
+        }
+        List<ProjectRelease> releases = project.getProjectReleases();
+        String path = ServletUriComponentsBuilder.fromCurrentRequest().build().getPath();
+        String version = path.substring(("/project_metadata/" + projectId + "/").length());
+        boolean found = false;
+        ProjectRelease release = null;
+        for (int i = 0; i < releases.size(); i++) {
+            ProjectRelease projectRelease = releases.get(i);
+            if (projectRelease.getVersion().equals(version)) {
+                release = releases.remove(i);
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            throw new MetadataNotFoundException("Could not find " + version + " for " + projectId);
+        }
+        service.save(project);
+        return release;
+    }
+
+    @ExceptionHandler(MetadataNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public void handle() {
+    }
+
+    static class MetadataNotFoundException extends RuntimeException {
+
+        public MetadataNotFoundException(String string) {
+            super(string);
+        }
+
     }
 
 }

--- a/sagan-site/src/main/resources/application.yml
+++ b/sagan-site/src/main/resources/application.yml
@@ -36,7 +36,6 @@ security:
     - /img/**
     - /500
     - /404
-    - /project_metadata/**
   headers:
     hsts: domain
   user:
@@ -119,7 +118,6 @@ spring:
       additional_paths:
         - ../sagan-client/src/
       additional_exclude: "**/*.js,**/*.css"
-
 
 disqus_shortname: ${DISQUS_SHORTNAME:spring-io-localhost}
 ---


### PR DESCRIPTION
User can GET or delete a release via /{projectId}/{version} or
add/edit a release by POSTing the whole release to /{projectId}.

Authentication is via HTTP Basic with a Github API token (as the
username and an empty password, just like Github native APIs).
All the new endpoints are protected.

Fixes gh-701