### PR TITLE
Revert to old behaviour with placeholders in UI

### DIFF
--- a/sagan-common/src/main/java/sagan/projects/Project.java
+++ b/sagan-common/src/main/java/sagan/projects/Project.java
@@ -3,7 +3,6 @@ package sagan.projects;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.regex.Pattern;
 
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
@@ -13,9 +12,6 @@ import org.springframework.util.StringUtils;
 
 @Entity
 public class Project {
-
-    private static final String VERSION_PLACEHOLDER = "{version}";
-    private static final String VERSION_PATTERN = Pattern.quote(VERSION_PLACEHOLDER);
 
     @Id
     private String id;
@@ -168,21 +164,6 @@ public class Project {
                 '}';
     }
 
-    public void normalizeProjectReleases(String groupId) {
-        for (ProjectRelease release : getProjectReleases()) {
-            if (groupId != null) {
-                release.setGroupId(groupId);
-            }
-            String version = release.getVersion();
-            release.setApiDocUrl(release.getApiDocUrl().replaceAll(VERSION_PATTERN, version));
-            release.setRefDocUrl(release.getRefDocUrl().replaceAll(VERSION_PATTERN, version));
-        }
-    }
-
-    public void normalizeProjectReleases() {
-        normalizeProjectReleases(null);
-    }
-
     public boolean updateProjectRelease(ProjectRelease release) {
         boolean found = false;
         List<ProjectRelease> releases = getProjectReleases();
@@ -200,7 +181,7 @@ public class Project {
         if (!found) {
             releases.add(release);
         }
-        normalizeProjectReleases();
+        release.replaceVersionPattern();
         return found;
     }
 

--- a/sagan-common/src/main/java/sagan/projects/ProjectRelease.java
+++ b/sagan-common/src/main/java/sagan/projects/ProjectRelease.java
@@ -17,6 +17,8 @@ public class ProjectRelease implements Comparable<ProjectRelease> {
 
     private static final Pattern PRERELEASE_PATTERN = Pattern.compile("[A-Za-z0-9\\.\\-]+?(M|RC)\\d+");
     private static final String SNAPSHOT_SUFFIX = "SNAPSHOT";
+    private static final String VERSION_PLACEHOLDER = "{version}";
+    private static final String VERSION_PATTERN = Pattern.quote(VERSION_PLACEHOLDER);
 
     public enum ReleaseStatus {
         SNAPSHOT, PRERELEASE, GENERAL_AVAILABILITY;
@@ -161,6 +163,21 @@ public class ProjectRelease implements Comparable<ProjectRelease> {
 
     public void setRepository(ProjectRepository repository) {
         this.repository = repository;
+    }
+
+    public void replaceVersionPattern() {
+        String version = getVersion();
+        setApiDocUrl(getApiDocUrl().replaceAll(VERSION_PATTERN, version));
+        setRefDocUrl(getRefDocUrl().replaceAll(VERSION_PATTERN, version));
+    }
+
+    public ProjectRelease createWithVersionPattern() {
+        String version = getVersion();
+        ProjectRelease release = new ProjectRelease(version, releaseStatus, isCurrent, refDocUrl, apiDocUrl, groupId,
+                artifactId);
+        release.setApiDocUrl(getApiDocUrl().replaceAll(version, VERSION_PLACEHOLDER));
+        release.setRefDocUrl(getRefDocUrl().replaceAll(version, VERSION_PLACEHOLDER));
+        return release;
     }
 
     @Override

--- a/sagan-site/src/main/java/sagan/projects/support/ProjectAdminController.java
+++ b/sagan-site/src/main/java/sagan/projects/support/ProjectAdminController.java
@@ -86,7 +86,7 @@ class ProjectAdminController {
             return "pages/404";
         }
 
-        project.normalizeProjectReleases();
+        denormalizeProjectReleases(project);
 
         List<ProjectRelease> releases = project.getProjectReleases();
         if (!releases.isEmpty()) {
@@ -107,9 +107,27 @@ class ProjectAdminController {
                 iReleases.remove();
             }
         }
-        project.normalizeProjectReleases(groupId);
+        normalizeProjectReleases(project, groupId);
         service.save(project);
 
         return "redirect:" + project.getId();
     }
+
+    private void normalizeProjectReleases(Project project, String groupId) {
+        for (ProjectRelease release : project.getProjectReleases()) {
+            if (groupId != null) {
+                release.setGroupId(groupId);
+            }
+            release.replaceVersionPattern();
+        }
+    }
+
+    private void denormalizeProjectReleases(Project project) {
+        List<ProjectRelease> releases = new ArrayList<>();
+        for (ProjectRelease release : project.getProjectReleases()) {
+            releases.add(release.createWithVersionPattern());
+        }
+        project.setProjectReleases(releases);
+    }
+
 }

--- a/sagan-site/src/test/java/sagan/projects/support/ProjectAdminControllerTests.java
+++ b/sagan-site/src/test/java/sagan/projects/support/ProjectAdminControllerTests.java
@@ -1,0 +1,66 @@
+package sagan.projects.support;
+
+import sagan.projects.Project;
+import sagan.projects.ProjectRelease;
+import sagan.projects.ProjectRelease.ReleaseStatus;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import org.springframework.ui.ExtendedModelMap;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ProjectAdminControllerTests {
+
+    @Mock
+    private ProjectMetadataService projectMetadataService;
+
+    private List<ProjectRelease> releases = new ArrayList<>();
+    Project project = new Project("spring-framework", "spring", "http://example.com", "http://examples.com", releases,
+            false, "project");
+    private ExtendedModelMap model = new ExtendedModelMap();
+    private ProjectAdminController controller;
+
+    @Before
+    public void setUp() throws Exception {
+        controller = new ProjectAdminController(projectMetadataService);
+    }
+
+    @Test
+    public void listProjects_providesProjectMetadataServiceInModel() {
+        releases.add(new ProjectRelease("1.2.3", ReleaseStatus.GENERAL_AVAILABILITY, false,
+                "http://example.com/1.2.3",
+                "http://example.com/1.2.3", "org.springframework", "spring-core"));
+        when(projectMetadataService.getProject("spring-framework")).thenReturn(project);
+        List<Project> list = Arrays.asList(project);
+        when(projectMetadataService.getProjects()).thenReturn(list);
+        controller.list(model);
+        assertThat(model.get("projects"), equalTo(list));
+        assertThat(project.getProjectReleases().iterator().next().getApiDocUrl(), equalTo(
+                "http://example.com/1.2.3"));
+    }
+
+    @Test
+    public void editProject_presentsVersionPatternsInUris() {
+        releases.add(new ProjectRelease("1.2.3", ReleaseStatus.GENERAL_AVAILABILITY, false,
+                "http://example.com/1.2.3",
+                "http://example.com/1.2.3", "org.springframework", "spring-core"));
+        when(projectMetadataService.getProject("spring-framework")).thenReturn(project);
+        controller.edit("spring-framework", model);
+        assertThat(model.get("project"), equalTo(project));
+        assertThat(((Project) model.get("project")).getProjectReleases().iterator().next().getApiDocUrl(), equalTo(
+                "http://example.com/{version}"));
+    }
+
+}

--- a/sagan-site/src/test/java/sagan/projects/support/ProjectMetadataControllerTests.java
+++ b/sagan-site/src/test/java/sagan/projects/support/ProjectMetadataControllerTests.java
@@ -1,0 +1,81 @@
+package sagan.projects.support;
+
+import sagan.projects.Project;
+import sagan.projects.ProjectRelease;
+import sagan.projects.ProjectRelease.ReleaseStatus;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ProjectMetadataControllerTests {
+
+    /**
+     * 
+     */
+    private static final String PROJECT_ID = "spring-framework";
+
+    @Mock
+    private ProjectMetadataService projectMetadataService;
+
+    private List<ProjectRelease> releases = new ArrayList<>();
+    Project project = new Project(PROJECT_ID, "spring", "http://example.com", "http://examples.com", releases,
+            false, "project");
+    private ProjectMetadataController controller;
+
+    @Before
+    public void setUp() throws Exception {
+        controller = new ProjectMetadataController(projectMetadataService);
+    }
+
+    @Test
+    public void getProject_doesNotContainVersionPlaceholders() throws Exception {
+        ProjectRelease release = new ProjectRelease("1.2.3", ReleaseStatus.GENERAL_AVAILABILITY, false,
+                "http://example.com/1.2.3",
+                "http://example.com/1.2.3", "org.springframework", "spring-core");
+        releases.add(release);
+        when(projectMetadataService.getProject(PROJECT_ID)).thenReturn(project);
+        Project result = controller.projectMetadata(PROJECT_ID);
+        assertThat(result.getProjectRelease("1.2.3"), equalTo(release));
+        assertThat(project.getProjectReleases().iterator().next().getApiDocUrl(), equalTo(
+                "http://example.com/1.2.3"));
+    }
+
+    @Test
+    public void editProjectReleases_replacesVersionPatterns() throws Exception {
+        ProjectRelease release = new ProjectRelease("1.2.3", ReleaseStatus.GENERAL_AVAILABILITY, false,
+                "http://example.com/1.2.3",
+                "http://example.com/1.2.3", "org.springframework", "spring-core");
+        ProjectRelease update = new ProjectRelease("1.2.4", ReleaseStatus.GENERAL_AVAILABILITY, false,
+                "http://example.com/{version}",
+                "http://example.com/{version}", "org.springframework", "spring-core");
+        releases.add(release);
+        when(projectMetadataService.getProject(PROJECT_ID)).thenReturn(project);
+        controller.updateProjectMetadata(PROJECT_ID, Arrays.asList(update));
+        assertThat(project.getProjectReleases().iterator().next().getApiDocUrl(), equalTo(
+                "http://example.com/1.2.4"));
+    }
+
+    @Test
+    public void addProjectRelease_replacesVersionPatterns() throws Exception {
+        ProjectRelease update = new ProjectRelease("1.2.4", ReleaseStatus.GENERAL_AVAILABILITY, false,
+                "http://example.com/{version}",
+                "http://example.com/{version}", "org.springframework", "spring-core");
+        when(projectMetadataService.getProject(PROJECT_ID)).thenReturn(project);
+        controller.updateReleaseMetadata(PROJECT_ID, update);
+        assertThat(project.getProjectReleases().iterator().next().getApiDocUrl(), equalTo(
+                "http://example.com/1.2.4"));
+    }
+
+}


### PR DESCRIPTION
The user sees {version} placholders when she edits a project in UI, but
the database only contains concrete URLs. The API endpoints are a bit
different: a GET returns the concrete URL, but you can POST or
PUT URLs with placeholders to mimic the UI.