### PR TITLE
Add REST Docs to project metadata

### DIFF
--- a/sagan-common/src/main/java/sagan/projects/ProjectRelease.java
+++ b/sagan-common/src/main/java/sagan/projects/ProjectRelease.java
@@ -10,8 +10,11 @@ import javax.persistence.ManyToOne;
 import org.springframework.util.Assert;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
 @Embeddable
+@JsonInclude(Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ProjectRelease implements Comparable<ProjectRelease> {
 

--- a/sagan-site/build.gradle
+++ b/sagan-site/build.gradle
@@ -1,10 +1,24 @@
 plugins {
+	id "org.asciidoctor.convert" version "1.5.3"
     id "com.gorylenko.gradle-git-properties" version "1.4.6"
 }
 
 springBoot {
     mainClass = 'sagan.SiteApplication'
     requiresUnpack = ['org.jruby:jruby-complete', 'org.asciidoctor:asciidoctorj']
+}
+
+asciidoctor {
+    attributes \
+      'snippets': file('build/snippets')
+	dependsOn integTest
+}
+
+jar {
+	dependsOn asciidoctor
+	from ("${asciidoctor.outputDir}/html5") {
+		into 'static/docs'
+	}
 }
 
 dependencies {
@@ -38,6 +52,7 @@ dependencies {
     compile 'org.xmlbeam:xmlprojector:1.4.8'
 
     // for use in mocking http interactions
+    testCompile "org.springframework.restdocs:spring-restdocs-mockmvc"
     testCompile "org.springframework.boot:spring-boot-starter-test"
 
     // pick up common test utility classes

--- a/sagan-site/build.gradle
+++ b/sagan-site/build.gradle
@@ -38,8 +38,7 @@ dependencies {
     compile 'org.xmlbeam:xmlprojector:1.4.8'
 
     // for use in mocking http interactions
-    testCompile "org.springframework:spring-test"
-    testCompile "org.springframework.boot:spring-boot-test"
+    testCompile "org.springframework.boot:spring-boot-starter-test"
 
     // pick up common test utility classes
     testCompile project(':sagan-common').sourceSets.testUtil.output

--- a/sagan-site/src/docs/asciidoc/index.adoc
+++ b/sagan-site/src/docs/asciidoc/index.adoc
@@ -1,0 +1,63 @@
+= Project Metadata API Guide
+Dave Syer;
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 4
+:sectlinks:
+
+[[overview]]
+== Overview
+
+[[resources-project]]
+=== Accessing Project Metadata
+
+A `GET` request will list all of the projects's metadata, including releases. The resource path ends with the project id (e.g. "spring-framework"):
+
+include::{snippets}/project/http-request.adoc[]
+
+include::{snippets}/project/http-response.adoc[]
+
+The request can optionally include a "callback" query parameter for JSON-P clients.
+
+include::{snippets}/callback/http-request.adoc[]
+
+include::{snippets}/callback/http-response.adoc[]
+
+This resource is unprotected and open to all clients. It is used by the https://start.spring.io[Spring Initializr] as well as by the individual https://projects.spring.io[project pages] to list their available releases and create documentation links.
+
+[[resources-project-releases]]
+=== Project Releases
+
+This resource is protected by HTTP Basic authentication. The username is a Github API token and the password is empty (just like Github API access). Access is denied is the key does not belong to one of the Spring developer team.
+
+The releases of each project can be accessed and manipulated independently of the top-level metadata.
+
+A `GET` is used to access a release by version:
+
+include::{snippets}/get_release/http-request.adoc[]
+
+include::{snippets}/get_release/http-response.adoc[]
+
+A `POST` request is used to create a new release, or to update an existing one. Note that in the request body the documentation URLs can contain a `{version}` placeholder, and this is replaced in the backend (as shown in the example response):
+
+include::{snippets}/add_release/http-request.adoc[]
+
+include::{snippets}/add_release/http-response.adoc[]
+
+NOTE: the only mandatory properties for a release are the ones shown above in the example request. Normally only snapshot and milestone releases need a repository (anything in Maven Ceantral does not need it).
+
+A `DELETE` request is used to remove a release.
+
+include::{snippets}/delete_release/http-request.adoc[]
+
+include::{snippets}/delete_release/http-response.adoc[]
+
+A `PUT` request without any version is used to update all the releases in one request. Version placeholders can also be used here.
+
+include::{snippets}/update_project/http-request.adoc[]
+
+include::{snippets}/update_project/http-response.adoc[]
+
+

--- a/sagan-site/src/it/java/sagan/search/support/InMemoryElasticSearchConfig.java
+++ b/sagan-site/src/it/java/sagan/search/support/InMemoryElasticSearchConfig.java
@@ -1,4 +1,4 @@
-package saganx;
+package sagan.search.support;
 
 import sagan.search.support.SearchService;
 

--- a/sagan-site/src/it/java/sagan/search/support/SearchFacetsIntegrationTests.java
+++ b/sagan-site/src/it/java/sagan/search/support/SearchFacetsIntegrationTests.java
@@ -1,10 +1,13 @@
 package sagan.search.support;
 
 import sagan.search.types.SearchEntry;
-import saganx.AbstractIntegrationTests;
 
 import java.text.ParseException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
 
 import org.junit.After;
 import org.junit.Before;
@@ -14,6 +17,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ContextConfiguration;
 
 import io.searchbox.client.JestClient;
 
@@ -21,6 +25,9 @@ import static java.util.stream.Collectors.toList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
+import saganx.AbstractIntegrationTests;
+
+@ContextConfiguration(classes = InMemoryElasticSearchConfig.class)
 public class SearchFacetsIntegrationTests extends AbstractIntegrationTests {
 
     private final Pageable pageable = new PageRequest(0, 10);

--- a/sagan-site/src/it/java/sagan/search/support/SearchPageTests.java
+++ b/sagan-site/src/it/java/sagan/search/support/SearchPageTests.java
@@ -1,20 +1,25 @@
 package sagan.search.support;
 
+import sagan.search.types.SearchEntry;
+
+import java.util.Calendar;
+
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.junit.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.web.servlet.MvcResult;
-import sagan.search.types.SearchEntry;
-import saganx.AbstractIntegrationTests;
 
-import java.util.Calendar;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.servlet.MvcResult;
 
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 
+import saganx.AbstractIntegrationTests;
+
+@ContextConfiguration(classes = InMemoryElasticSearchConfig.class)
 public class SearchPageTests extends AbstractIntegrationTests {
 
     @Autowired

--- a/sagan-site/src/it/java/sagan/search/support/SearchServiceIntegrationTests.java
+++ b/sagan-site/src/it/java/sagan/search/support/SearchServiceIntegrationTests.java
@@ -1,7 +1,6 @@
 package sagan.search.support;
 
 import sagan.search.types.SearchEntry;
-import saganx.AbstractIntegrationTests;
 
 import java.text.ParseException;
 import java.util.Arrays;
@@ -17,12 +16,16 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ContextConfiguration;
 
 import io.searchbox.client.JestClient;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
+import saganx.AbstractIntegrationTests;
+
+@ContextConfiguration(classes = InMemoryElasticSearchConfig.class)
 public class SearchServiceIntegrationTests extends AbstractIntegrationTests {
 
     private final Pageable pageable = new PageRequest(0, 10);

--- a/sagan-site/src/it/java/sagan/support/SecurityRequestPostProcessors.java
+++ b/sagan-site/src/it/java/sagan/support/SecurityRequestPostProcessors.java
@@ -80,9 +80,11 @@ public final class SecurityRequestPostProcessors {
          */
         @Override
         public MockHttpServletRequest postProcessRequest(MockHttpServletRequest request) {
-            CsrfToken token = repository.generateToken(request);
-            repository.saveToken(token, request, new MockHttpServletResponse());
-            request.setParameter(token.getParameterName(), token.getToken());
+            if (!request.getRequestURI().startsWith("/project_metadata")) {
+                CsrfToken token = repository.generateToken(request);
+                repository.saveToken(token, request, new MockHttpServletResponse());
+                request.setParameter(token.getParameterName(), token.getToken());
+            }
             return request;
         }
     }
@@ -123,6 +125,7 @@ public final class SecurityRequestPostProcessors {
             this.securityContext = securityContext;
         }
 
+        @Override
         public MockHttpServletRequest postProcessRequest(MockHttpServletRequest request) {
             save(securityContext, request);
             return request;
@@ -188,6 +191,7 @@ public final class SecurityRequestPostProcessors {
             return this;
         }
 
+        @Override
         public MockHttpServletRequest postProcessRequest(MockHttpServletRequest request) {
             UsernamePasswordAuthenticationToken authentication =
                     new UsernamePasswordAuthenticationToken(username, credentials, authorities);
@@ -220,6 +224,7 @@ public final class SecurityRequestPostProcessors {
             return this;
         }
 
+        @Override
         public MockHttpServletRequest postProcessRequest(MockHttpServletRequest request) {
             UsernamePasswordAuthenticationToken authentication = authentication(request.getServletContext());
             save(authentication, request);

--- a/sagan-site/src/it/java/saganx/AbstractIntegrationTests.java
+++ b/sagan-site/src/it/java/saganx/AbstractIntegrationTests.java
@@ -9,6 +9,7 @@ import org.junit.Before;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.cache.CacheManager;
@@ -17,18 +18,15 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.WebApplicationContext;
-
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static sagan.support.SecurityRequestPostProcessors.*;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.MOCK)
 @ContextConfiguration(classes = { IntegrationTestsConfig.class })
 @Transactional
 @ActiveProfiles(profiles = { SaganProfiles.STANDALONE })
+@AutoConfigureMockMvc(addFilters = false)
 public abstract class AbstractIntegrationTests {
 
     @Autowired
@@ -43,6 +41,7 @@ public abstract class AbstractIntegrationTests {
     @Autowired
     protected FilterChainProxy springSecurityFilterChain;
 
+    @Autowired
     protected MockMvc mockMvc;
 
     @Autowired
@@ -51,10 +50,6 @@ public abstract class AbstractIntegrationTests {
     @Before
     public void setupMockMvc() {
         stubRestClient.clearResponses();
-        mockMvc = MockMvcBuilders.webAppContextSetup(wac)
-                .addFilters(springSecurityFilterChain)
-                .defaultRequest(get("/").with(csrf()).with(user(123L).roles("ADMIN")))
-                .build();
     }
 
     @After

--- a/sagan-site/src/it/java/saganx/AbstractIntegrationTests.java
+++ b/sagan-site/src/it/java/saganx/AbstractIntegrationTests.java
@@ -26,7 +26,7 @@ import static sagan.support.SecurityRequestPostProcessors.*;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.MOCK)
-@ContextConfiguration(classes = { IntegrationTestsConfig.class, InMemoryElasticSearchConfig.class })
+@ContextConfiguration(classes = { IntegrationTestsConfig.class })
 @Transactional
 @ActiveProfiles(profiles = { SaganProfiles.STANDALONE })
 public abstract class AbstractIntegrationTests {

--- a/sagan-site/src/it/java/saganx/IntegrationTestsConfig.java
+++ b/sagan-site/src/it/java/saganx/IntegrationTestsConfig.java
@@ -1,6 +1,5 @@
 package saganx;
 
-import sagan.SiteApplication;
 import sagan.support.github.StubGithubRestClient;
 
 import javax.servlet.Filter;
@@ -9,7 +8,6 @@ import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.boot.test.autoconfigure.web.servlet.MockMvcBuilderCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
 import org.springframework.web.client.RestTemplate;
 
@@ -18,7 +16,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static sagan.support.SecurityRequestPostProcessors.*;
 
 @Configuration
-@Import(SiteApplication.class)
 class IntegrationTestsConfig {
 
     @Primary

--- a/sagan-site/src/it/java/saganx/IntegrationTestsConfig.java
+++ b/sagan-site/src/it/java/saganx/IntegrationTestsConfig.java
@@ -3,6 +3,10 @@ package saganx;
 import sagan.SiteApplication;
 import sagan.support.github.StubGithubRestClient;
 
+import javax.servlet.Filter;
+
+import org.springframework.beans.factory.ListableBeanFactory;
+import org.springframework.boot.test.autoconfigure.web.servlet.MockMvcBuilderCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -10,6 +14,8 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.web.client.RestTemplate;
 
 import static org.mockito.Mockito.mock;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static sagan.support.SecurityRequestPostProcessors.*;
 
 @Configuration
 @Import(SiteApplication.class)
@@ -25,5 +31,14 @@ class IntegrationTestsConfig {
     @Bean
     public StubGithubRestClient stubGithubRestClient() {
         return new StubGithubRestClient();
+    }
+
+    @Bean
+    public MockMvcBuilderCustomizer mockMvcBuilderCustomizer(ListableBeanFactory beanFactory) {
+        Filter springSecurityFilterChain = beanFactory.getBean("springSecurityFilterChain", Filter.class);
+        return builder -> builder.addFilters(springSecurityFilterChain)
+                .defaultRequest(get("/").with(csrf()).with(user(123L).roles("ADMIN")))
+                .build();
+
     }
 }

--- a/sagan-site/src/main/java/sagan/projects/support/ProjectMetadataController.java
+++ b/sagan-site/src/main/java/sagan/projects/support/ProjectMetadataController.java
@@ -74,9 +74,8 @@ class ProjectMetadataController {
             throws IOException {
         Project project = service.getProject(projectId);
         for (ProjectRelease release : releases) {
-            release.replaceVersionPattern();
+            project.updateProjectRelease(release);
         }
-        project.setProjectReleases(releases);
         service.save(project);
         return project;
     }

--- a/sagan-site/src/main/resources/templates/docs/index.html
+++ b/sagan-site/src/main/resources/templates/docs/index.html
@@ -55,7 +55,7 @@
             <div class="content-section-title--container">
                 <a href="https://github.com/spring-io/sagan"><div class="pull-left icon icon-sagan"></div></a>
                 <h2>Sagan Application</h2>
-                <p>This website is an open source application running on Spring Boot and <a href="https://run.pivotal.io">Pivotal Web Services</a>.</p>
+                <p>This website is an open source application running on Spring Boot and <a href="https://run.pivotal.io">Pivotal Web Services</a>. The API documemtation for project metadata is deployed <a href="index.html">along with the application</a> itself.</p>
                 <p><a href="https://github.com/spring-io/sagan">Check out Sagan on Github <i class="icon-chevron-right"></i></a></p>
             </div>
 


### PR DESCRIPTION
Also fixes a bug with PUT /{projectId}/releases where the repository would
not be merged and the endpoint throws an exception (for any request
containing a repository).

Fixes gh-703