### PR TITLE
Release trains are not properly sorted by name (fixes #716)

### DIFF
--- a/sagan-client/package.json
+++ b/sagan-client/package.json
@@ -35,7 +35,7 @@
       "eonasdan/bootstrap-datetimepicker": "github:eonasdan/bootstrap-datetimepicker@0.0.10",
       "font-awesome": "github:FortAwesome/font-awesome@3.2.1",
       "gmaps": "npm:gmaps@^0.4.14",
-      "google-code-prettify": "github:tcollard/google-code-prettify@^1.0.4",
+      "google-code-prettify": "github:spencewood/google-code-prettify@^1.0.4",
       "jquery": "npm:jquery@^1.8.3",
       "jquery-timeago": "github:rmm5t/jquery-timeago@^1.4.1",
       "most": "npm:most@^0.2.0"

--- a/sagan-common/src/main/java/sagan/projects/Project.java
+++ b/sagan-common/src/main/java/sagan/projects/Project.java
@@ -1,6 +1,7 @@
 package sagan.projects;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -90,16 +91,11 @@ public class Project {
         return id;
     }
 
+    /**
+     * @return The list of releases sorted in descending order by version
+     */
     public List<ProjectRelease> getProjectReleases() {
-        releaseList.sort((release1, release2) -> {
-            if (release1.getVersion() == null || release2.getVersion() == null) {
-                return 0;
-            }
-
-            return release1.getVersion().compareTo(release2.getVersion());
-        });
-        releaseList.sort(ProjectRelease::compareTo);
-
+        releaseList.sort(Collections.reverseOrder(ProjectRelease::compareTo));
         return releaseList;
     }
 

--- a/sagan-common/src/main/java/sagan/projects/ProjectRelease.java
+++ b/sagan-common/src/main/java/sagan/projects/ProjectRelease.java
@@ -1,5 +1,7 @@
 package sagan.projects;
 
+import java.util.Locale;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -7,11 +9,13 @@ import javax.persistence.CascadeType;
 import javax.persistence.Embeddable;
 import javax.persistence.ManyToOne;
 
+import com.google.common.collect.ImmutableMap;
 import org.springframework.util.Assert;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import sagan.projects.support.Version;
 
 @Embeddable
 @JsonInclude(Include.NON_NULL)
@@ -183,44 +187,75 @@ public class ProjectRelease implements Comparable<ProjectRelease> {
         return release;
     }
 
+    private static final Map<String, Integer> SPECIAL_MEANINGS =
+            ImmutableMap.of("dev", -1, "rc", 1, "release", 2, "final", 3);
+
+    /**
+     * Adapted from Gradle's StaticVersionComparator
+     */
     @Override
     public int compareTo(ProjectRelease other) {
-        if (this.getVersion() == null || other.getVersion() == null) {
+        if(other == null) return -1;
+
+        Version version1 = Version.build(getVersion());
+        Version version2 = Version.build(other.getVersion());
+
+        if(version1 == null && version2 == null) {
+            return 0;
+        }
+        else if(version1 == null) {
+            return -1;
+        }
+        else if(version2 == null) {
+            return 1;
+        }
+        if (version1.equals(version2)) {
             return 0;
         }
 
-        Pattern pattern = Pattern.compile("([0-9]+)");
+        String[] parts1 = version1.getParts();
+        String[] parts2 = version2.getParts();
 
-        Matcher thisMatcher = pattern.matcher(this.getVersion());
-        Matcher otherMatcher = pattern.matcher(other.getVersion());
-
-        int versionDiff = 0;
-
-        boolean thisFind = thisMatcher.find();
-        boolean otherFind = otherMatcher.find();
-
-        while (thisFind && otherFind) {
-            int thisFoundVersion = Integer.parseInt(thisMatcher.group(0));
-            int otherFoundVersion = Integer.parseInt(otherMatcher.group(0));
-            versionDiff = otherFoundVersion - thisFoundVersion;
-
-            if (versionDiff != 0) {
-                return versionDiff;
+        int i = 0;
+        for (; i < parts1.length && i < parts2.length; i++) {
+            if (parts1[i].equals(parts2[i])) {
+                continue;
             }
-
-            thisFind = thisMatcher.find();
-            otherFind = otherMatcher.find();
+            boolean is1Number = isNumber(parts1[i]);
+            boolean is2Number = isNumber(parts2[i]);
+            if (is1Number && !is2Number) {
+                return 1;
+            }
+            if (is2Number && !is1Number) {
+                return -1;
+            }
+            if (is1Number) {
+                return Long.valueOf(parts1[i]).compareTo(Long.valueOf(parts2[i]));
+            }
+            // both are strings, we compare them taking into account special meaning
+            Integer sm1 = SPECIAL_MEANINGS.get(parts1[i].toLowerCase());
+            Integer sm2 = SPECIAL_MEANINGS.get(parts2[i].toLowerCase());
+            if (sm1 != null) {
+                sm2 = sm2 == null ? 0 : sm2;
+                return sm1 - sm2;
+            }
+            if (sm2 != null) {
+                return -sm2;
+            }
+            return parts1[i].compareTo(parts2[i]);
+        }
+        if (i < parts1.length) {
+            return isNumber(parts1[i]) ? 1 : -1;
+        }
+        if (i < parts2.length) {
+            return isNumber(parts2[i]) ? -1 : 1;
         }
 
-        if (thisFind) {
-            return -1;
-        }
+        return 0;
+    }
 
-        if (otherFind) {
-            return 1;
-        }
-
-        return versionDiff;
+    private boolean isNumber(String str) {
+        return str.matches("\\d+");
     }
 
     @Override

--- a/sagan-common/src/main/java/sagan/projects/support/Version.java
+++ b/sagan-common/src/main/java/sagan/projects/support/Version.java
@@ -1,8 +1,29 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package sagan.projects.support;
 
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * An artifact version.
+ *
+ * @author Jon Schneider (or Gradle, on which this class is largely based)
+ */
 public class Version {
     private final String source;
     private final String[] parts;
@@ -59,13 +80,16 @@ public class Version {
                 digit = false;
             }
         }
+
         if (pos > startPart) {
             parts.add(raw.substring(startPart, pos));
         }
+
         Version base = null;
         if (endBaseStr > 0) {
             base = new Version(raw.substring(0, endBaseStr), parts.subList(0, endBase), null);
         }
+
         return new Version(raw, parts, base);
     }
 

--- a/sagan-common/src/main/java/sagan/projects/support/Version.java
+++ b/sagan-common/src/main/java/sagan/projects/support/Version.java
@@ -1,0 +1,105 @@
+package sagan.projects.support;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Version {
+    private final String source;
+    private final String[] parts;
+    private final Version baseVersion;
+
+    private Version(String source, List<String> parts, Version baseVersion) {
+        this.source = source;
+        this.parts = parts.toArray(new String[0]);
+        this.baseVersion = baseVersion == null ? this : baseVersion;
+    }
+
+    /**
+     * Adapted from Gradle's VersionParser
+     */
+    public static Version build(String raw) {
+        if(raw == null)
+            return null;
+
+        List<String> parts = new ArrayList<String>();
+        boolean digit = false;
+        int startPart = 0;
+        int pos = 0;
+        int endBase = 0;
+        int endBaseStr = 0;
+        for (; pos < raw.length(); pos++) {
+            char ch = raw.charAt(pos);
+            if (ch == '.' || ch == '_' || ch == '-' || ch == '+' || ch == ' ') {
+                parts.add(raw.substring(startPart, pos));
+                startPart = pos + 1;
+                digit = false;
+                if (ch != '.' && endBaseStr == 0) {
+                    endBase = parts.size();
+                    endBaseStr = pos;
+                }
+            } else if (ch >= '0' && ch <= '9') {
+                if (!digit && pos > startPart) {
+                    if (endBaseStr == 0) {
+                        endBase = parts.size() + 1;
+                        endBaseStr = pos;
+                    }
+                    parts.add(raw.substring(startPart, pos));
+                    startPart = pos;
+                }
+                digit = true;
+            } else {
+                if (digit) {
+                    if (endBaseStr == 0) {
+                        endBase = parts.size() + 1;
+                        endBaseStr = pos;
+                    }
+                    parts.add(raw.substring(startPart, pos));
+                    startPart = pos;
+                }
+                digit = false;
+            }
+        }
+        if (pos > startPart) {
+            parts.add(raw.substring(startPart, pos));
+        }
+        Version base = null;
+        if (endBaseStr > 0) {
+            base = new Version(raw.substring(0, endBaseStr), parts.subList(0, endBase), null);
+        }
+        return new Version(raw, parts, base);
+    }
+
+    @Override
+    public String toString() {
+        return source;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (obj == null || obj.getClass() != getClass()) {
+            return false;
+        }
+        Version other = (Version) obj;
+        return source.equals(other.source);
+    }
+
+    @Override
+    public int hashCode() {
+        return source.hashCode();
+    }
+
+    public boolean isQualified() {
+        return baseVersion != this;
+    }
+
+    public Version getBaseVersion() {
+        return baseVersion;
+    }
+
+    public String[] getParts() {
+        return parts;
+    }
+}

--- a/sagan-common/src/test/java/sagan/projects/ProjectVersionOrderTests.java
+++ b/sagan-common/src/test/java/sagan/projects/ProjectVersionOrderTests.java
@@ -41,9 +41,21 @@ public class ProjectVersionOrderTests {
     }
 
     @Test
+    public void getProjectReleases_ordersMultipleStylesOfMilestones() throws Exception {
+        Project project = getProject("Gosling-RC9", "Gosling.RC10");
+        assertThat(getProjectReleases(project), equalTo(asList( "Gosling.RC10", "Gosling-RC9")));
+    }
+
+    @Test
+    public void getProjectReleases_ordersElementsWithinAReleaseTrain() throws Exception {
+        Project project = getProject("Camden.BUILD-SNAPSHOT", "Camden.M1", "Camden.RC1", "Camden.RELEASE", "Camden.SR5", "Camden.SR6");
+        assertThat(getProjectReleases(project), equalTo(asList( "Camden.SR6", "Camden.SR5", "Camden.RELEASE", "Camden.RC1", "Camden.M1", "Camden.BUILD-SNAPSHOT")));
+    }
+
+    @Test
     public void getProjectReleases_ordersReleaseTrainsByName() throws Exception {
-        Project project = getProject("Brixton.SR7", "Camden.RELEASE", "Camden.SR5", "Camden.SR6", "Dalston.RELEASE");
-        assertThat(getProjectReleases(project), equalTo(asList("Dalston.RELEASE", "Camden.RELEASE", "Camden.SR6", "Camden.SR5", "Brixton.SR7")));
+        Project project = getProject("Brixton.SR7", "Camden.SR5", "Dalston.RELEASE");
+        assertThat(getProjectReleases(project), equalTo(asList("Dalston.RELEASE", "Camden.SR5", "Brixton.SR7")));
     }
 
     @Test

--- a/sagan-common/src/test/java/sagan/projects/ProjectVersionOrderTests.java
+++ b/sagan-common/src/test/java/sagan/projects/ProjectVersionOrderTests.java
@@ -37,13 +37,19 @@ public class ProjectVersionOrderTests {
     @Test
     public void getProjectReleases_ordersVersionsByNumber_milestonesWithVersions() throws Exception {
         Project project = getProject("0.1 M1", "0.1", "0.1 M2");
-        assertThat(getProjectReleases(project), equalTo(asList("0.1 M2", "0.1 M1", "0.1")));
+        assertThat(getProjectReleases(project), equalTo(asList("0.1", "0.1 M2", "0.1 M1")));
+    }
+
+    @Test
+    public void getProjectReleases_ordersReleaseTrainsByName() throws Exception {
+        Project project = getProject("Brixton.SR7", "Camden.RELEASE", "Camden.SR5", "Camden.SR6", "Dalston.RELEASE");
+        assertThat(getProjectReleases(project), equalTo(asList("Dalston.RELEASE", "Camden.RELEASE", "Camden.SR6", "Camden.SR5", "Brixton.SR7")));
     }
 
     @Test
     public void getProjectReleases_ordersVersionsByNumber_otherCharacters() throws Exception {
         Project project = getProject("Gosling-RC9", "Angel.RC10", "Gosling-RC10", "Angel.RC9");
-        assertThat(getProjectReleases(project), equalTo(asList("Angel.RC10", "Gosling-RC10", "Angel.RC9", "Gosling-RC9")));
+        assertThat(getProjectReleases(project), equalTo(asList( "Gosling-RC10", "Gosling-RC9", "Angel.RC10", "Angel.RC9")));
     }
 
     private Project getProject(String... projectReleaseStrings) {

--- a/sagan-site/src/test/java/sagan/projects/support/BadgeControllerTest.java
+++ b/sagan-site/src/test/java/sagan/projects/support/BadgeControllerTest.java
@@ -122,14 +122,14 @@ public class BadgeControllerTest {
     }
 
     @Test
-    public void projecWithTwoReleasesUsingSymbolicNamesWithNumbersWithoutCurrentFlagPicksFirstRelease() throws Exception {
+    public void projecWithTwoReleasesUsingSymbolicNamesWithNumbersWithoutCurrentFlagPicksMostRecentRelease() throws Exception {
 
         releases.add(new ProjectRelease("Angel-SR6", ReleaseStatus.GENERAL_AVAILABILITY, false, "", "", "", ""));
         releases.add(new ProjectRelease("Brixton-SR2", ReleaseStatus.GENERAL_AVAILABILITY, false, "", "", "", ""));
         ResponseEntity<byte[]> response = controller.releaseBadge("spring-data-redis");
 
         String content = new String(response.getBody());
-        assertThat(content, containsString("Angel-SR6"));
+        assertThat(content, containsString("Brixton-SR2"));
     }
 
     @Test
@@ -140,7 +140,7 @@ public class BadgeControllerTest {
         ResponseEntity<byte[]> response = controller.releaseBadge("spring-data-redis");
 
         String content = new String(response.getBody());
-        assertThat(content, containsString("Angel-SR6"));
+        assertThat(content, containsString("Brixton-RELEASE"));
     }
 
     @Test


### PR DESCRIPTION
Sorts release train names in alphabetically descending order, then considers SR numbers and such secondarily.