### PR TITLE
removed STS update site for Eclipse 4.5, no longer supported

### DIFF
--- a/sagan-site/src/main/resources/templates/tools/sts/all.html
+++ b/sagan-site/src/main/resources/templates/tools/sts/all.html
@@ -72,10 +72,6 @@
               <td>4.6</td>
               <td><a href="http://dist.springsource.com/release/TOOLS/update/e4.6/">http://dist.springsource.com/release/TOOLS/update/e4.6/</a></td>
             </tr>
-            <tr>
-              <td>4.5</td>
-              <td><a href="http://dist.springsource.com/release/TOOLS/update/e4.5/">http://dist.springsource.com/release/TOOLS/update/e4.5/</a></td>
-            </tr>
           </tbody>
         </table>
         <p>


### PR DESCRIPTION
since the latest STS 3.9.0 release we don't ship update sites for Eclipse 4.5 anymore