### PR TITLE
Fix bug with equals() comparison in Project metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ test.log
 logs/
 work/
 .bower-*
+.cram/
+lib/
+dist/
 
 # Eclipse
 # > the following should be created by `./gradlew eclipse`

--- a/sagan-common/src/main/java/sagan/projects/Project.java
+++ b/sagan-common/src/main/java/sagan/projects/Project.java
@@ -183,7 +183,7 @@ public class Project {
             if (release.getRepository() != null && release.getRepository().equals(projectRelease.getRepository())) {
                 release.setRepository(projectRelease.getRepository());
             }
-            if (projectRelease.getVersion().equals(release)) {
+            if (projectRelease.getVersion().equals(release.getVersion())) {
                 releases.set(i, release);
                 found = true;
                 break;

--- a/sagan-site/src/it/java/sagan/projects/support/ProjectsMetadataApiTests.java
+++ b/sagan-site/src/it/java/sagan/projects/support/ProjectsMetadataApiTests.java
@@ -11,6 +11,8 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import javax.persistence.EntityManager;
+
 import org.junit.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,6 +43,9 @@ public class ProjectsMetadataApiTests extends AbstractIntegrationTests {
 
     @Autowired
     private ObjectMapper mapper;
+
+    @Autowired
+    private EntityManager entityManager;
 
     private RestDocumentationResultHandler docs(String name) {
         return document(name,
@@ -143,7 +148,7 @@ public class ProjectsMetadataApiTests extends AbstractIntegrationTests {
             Map<String, Object> map = getRelease(release);
             releases.add(map);
         }
-        project.getProjectReleases().iterator().next().setVersion("1.2.8.RELEASE");
+        releases.iterator().next().put("version", "1.2.8.RELEASE");
         mockMvc
                 .perform(
                         MockMvcRequestBuilders
@@ -153,6 +158,7 @@ public class ProjectsMetadataApiTests extends AbstractIntegrationTests {
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith("application/json"))
                 .andDo(docs("update_project"));
+        entityManager.flush();
     }
 
     private Map<String, Object> getRelease(ProjectRelease release) {


### PR DESCRIPTION
I think this also fixes gh-733, but it's quite hard to test because the
integration tests are all `@Transactional` and the changes are only
persisted on commit (so the error never shows up in tests).