### PR TITLE
Remove elastic search data in gradle clean

### DIFF
--- a/sagan-site/build.gradle
+++ b/sagan-site/build.gradle
@@ -59,3 +59,8 @@ dependencies {
     testCompile project(':sagan-common').sourceSets.testUtil.output
 
 }
+
+clean.doFirst {
+    delete "${projectDir}/data/"
+    println "Deleted ${projectDir}/data/"
+}


### PR DESCRIPTION
Otherwise I get integration test failures, but not all the time.