### PR TITLE
Make some expensive initializations happen lazily

### DIFF
--- a/sagan-common/src/main/java/sagan/AsciidoctorConfig.java
+++ b/sagan-common/src/main/java/sagan/AsciidoctorConfig.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sagan;
+
+import org.asciidoctor.Asciidoctor;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.ScopedProxyMode;
+
+/**
+ * @author Dave Syer
+ *
+ */
+@Configuration
+public class AsciidoctorConfig {
+
+    @Bean
+    @Lazy
+    @Scope(proxyMode = ScopedProxyMode.INTERFACES)
+    public Asciidoctor asciidoctor() {
+        return Asciidoctor.Factory.create();
+    }
+}

--- a/sagan-common/src/main/java/sagan/blog/support/AsciidoctorMarkdownService.java
+++ b/sagan-common/src/main/java/sagan/blog/support/AsciidoctorMarkdownService.java
@@ -7,7 +7,11 @@ import org.asciidoctor.SafeMode;
 
 public class AsciidoctorMarkdownService implements MarkdownService {
 
-    Asciidoctor asciidoctor = Asciidoctor.Factory.create();
+    private final Asciidoctor asciidoctor;
+
+    public AsciidoctorMarkdownService(Asciidoctor asciidoctor) {
+        this.asciidoctor = asciidoctor;
+    }
 
     @Override
     public String renderToHtml(String markdownSource) {

--- a/sagan-common/src/main/java/sagan/blog/support/FormatAwarePostContentRenderer.java
+++ b/sagan-common/src/main/java/sagan/blog/support/FormatAwarePostContentRenderer.java
@@ -5,6 +5,8 @@ import sagan.blog.PostFormat;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.asciidoctor.Asciidoctor;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Profile;
@@ -17,9 +19,10 @@ public class FormatAwarePostContentRenderer extends PostContentRenderer {
     private Map<PostFormat, MarkdownService> renderers = new HashMap<>();
 
     @Autowired
-    public FormatAwarePostContentRenderer(@Qualifier("pegdown") MarkdownService markdownService) {
+    public FormatAwarePostContentRenderer(@Qualifier("pegdown") MarkdownService markdownService,
+                                          Asciidoctor asciidoctor) {
         super(markdownService);
-        renderers.put(PostFormat.ASCIIDOC, new AsciidoctorMarkdownService());
+        renderers.put(PostFormat.ASCIIDOC, new AsciidoctorMarkdownService(asciidoctor));
     }
 
     public String render(String content, PostFormat format) {

--- a/sagan-common/src/test/java/sagan/blog/support/AsciidoctorMarkdownServiceTests.java
+++ b/sagan-common/src/test/java/sagan/blog/support/AsciidoctorMarkdownServiceTests.java
@@ -1,5 +1,6 @@
 package sagan.blog.support;
 
+import org.asciidoctor.Asciidoctor;
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Before;
@@ -11,7 +12,7 @@ public class AsciidoctorMarkdownServiceTests {
 
     @Before
     public void setup() {
-        service = new AsciidoctorMarkdownService();
+        service = new AsciidoctorMarkdownService(Asciidoctor.Factory.create());
     }
 
     @Test

--- a/sagan-common/src/test/java/sagan/guides/support/DynamicSidebarTests.java
+++ b/sagan-common/src/test/java/sagan/guides/support/DynamicSidebarTests.java
@@ -1,6 +1,5 @@
 package sagan.guides.support;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import sagan.support.github.GitHubClient;
 
 import java.io.IOException;
@@ -13,6 +12,8 @@ import org.mockito.Mock;
 
 import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.util.StreamUtils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
@@ -32,7 +33,7 @@ public class DynamicSidebarTests {
     @Before
     public void setup() throws IOException {
         initMocks(this);
-        org = new GuideOrganization("spring-guides", "orgs", github, new ObjectMapper());
+        org = new GuideOrganization("spring-guides", "orgs", github, new ObjectMapper(), null);
     }
 
     @Test

--- a/sagan-common/src/test/java/sagan/guides/support/GuidesOrgTests.java
+++ b/sagan-common/src/test/java/sagan/guides/support/GuidesOrgTests.java
@@ -1,6 +1,5 @@
 package sagan.guides.support;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import sagan.support.Fixtures;
 import sagan.support.github.GitHubClient;
 
@@ -14,6 +13,8 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import org.springframework.social.github.api.GitHubRepo;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -32,7 +33,7 @@ public class GuidesOrgTests {
 
     @Before
     public void setUp() throws Exception {
-        service = new GuideOrganization(OWNER_NAME, OWNER_TYPE, ghClient, new ObjectMapper());
+        service = new GuideOrganization(OWNER_NAME, OWNER_TYPE, ghClient, new ObjectMapper(), null);
     }
 
     @Test

--- a/sagan-site/build.gradle
+++ b/sagan-site/build.gradle
@@ -59,3 +59,8 @@ dependencies {
     testCompile project(':sagan-common').sourceSets.testUtil.output
 
 }
+
+clean.doFirst {
+    delete "${projectDir}/data/"
+    println "Deleted ${projectDir}/data/"
+}

--- a/sagan-site/src/it/java/sagan/search/support/InMemoryElasticSearchConfig.java
+++ b/sagan-site/src/it/java/sagan/search/support/InMemoryElasticSearchConfig.java
@@ -1,46 +1,53 @@
 package sagan.search.support;
 
-import sagan.search.support.SearchService;
-
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 
 import org.elasticsearch.client.Client;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.node.NodeBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 class InMemoryElasticSearchConfig {
 
+    private static final Logger log = LoggerFactory.getLogger(InMemoryElasticSearchConfig.class);
+
     @Autowired
     private SearchService searchService;
 
-    @Autowired
     private Client client;
 
     private Node node;
 
-    @Bean
-    public Client elasticSearchClient() throws Exception {
-        NodeBuilder nodeBuilder = NodeBuilder.nodeBuilder().local(true);
-        nodeBuilder.getSettings().put("network.host", "127.0.0.1");
-        node = nodeBuilder.node();
-        Client client = node.client();
-        return client;
-    }
-
     @PostConstruct
     public void configureSearchService() {
         searchService.setUseRefresh(true);
+        new Thread(this::start).start();
+    }
+
+    private void start() {
+        log.info("Starting Elastic Search");
+        NodeBuilder nodeBuilder = NodeBuilder.nodeBuilder().local(true);
+        nodeBuilder.getSettings().put("network.host", "127.0.0.1");
+        node = nodeBuilder.node();
+        client = node.client();
+        log.info("Started Elastic Search");
     }
 
     @PreDestroy
     public void shutDownElasticSearch() throws Exception {
-        client.close();
-        node.close();
+        if (node != null) {
+            try {
+                client.close();
+                node.close();
+            } catch (Throwable e) {
+                log.warn("Failed to shutdown Elastic Search");
+            }
+        }
     }
 }


### PR DESCRIPTION
Asciidoctor and Elasticsearch (embedded) are expensive to
start, especially the first time. This change makes them
lazy or backgrounds the initialization. Startup time goes
down from 8sec to 5sec for me.

Also useful, some JVM command line flags:

```
-noverify -XX:TieredStopAtLevel=1 -Xss256K -Xms16M -Xmx256M -XX:MaxMetaspaceSize=128M -Djava.security.egd=file:/dev/./urandom
```

and switch to Java 8u131-zulu (available via sdkman) - it's faster than the official openjdk build.