### PR TITLE
Add query param matcher to project API test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ configure(javaProjects) {
                             'elasticsearch.version': '1.7.1' // see io.searchbox:jest
                     ])
                 }
-                mavenBom("org.springframework.cloud:spring-cloud-dependencies:Camden.SR7")
+                mavenBom("org.springframework.cloud:spring-cloud-dependencies:Dalston.SR3")
             }
         }
     }


### PR DESCRIPTION
So that stubs are uniqely identified for GET.

Fixes gh-793