### PR TITLE
Reinstate REST-based tutorial.

### DIFF
--- a/sagan-site/src/main/resources/urlrewrite.xml
+++ b/sagan-site/src/main/resources/urlrewrite.xml
@@ -70,7 +70,7 @@
     <rule>
         <name>Deprecated Tutorials</name>
         <note>https://github.com/spring-io/sagan/pull/475</note>
-        <from>/guides/tutorials/(rest|data|web)/$</from>
+        <from>/guides/tutorials/(data|web)/$</from>
         <to type="temporary-redirect" last="true">/guides</to>
     </rule>
     <rule>


### PR DESCRIPTION
An old, decomissions REST tutorial resulted in a temporary redirect to `/guides`. The newer REST tutorial (`tut-bookmarks`) has now been rewritten and renamed `tut-rest`, so this old redirect must be removed.