### PR TITLE
Correct STS4 Atom package links

### DIFF
--- a/sagan-site/src/main/resources/templates/pages/tools.html
+++ b/sagan-site/src/main/resources/templates/pages/tools.html
@@ -74,7 +74,7 @@
                 <img class='icon-vsc' src='/img/tools4/icon-atom.png'/>
                 <h3>Spring Tools 4 <br/> for Atom IDE</h3>
                 <p>Free. Open source.</p>
-                <a class='btn' href='https://atom.io/packages/boot-java'>
+                <a class='btn' href='https://atom.io/packages/spring-boot'>
                   <strong>Spring Tools 4</strong>
                   <br/>
                   (as package for Atom)
@@ -176,7 +176,7 @@
                   <img class='icon-vsc' src='/img/tools4/icon-atom.png'/>
                   <h3>Spring Tools 4<br/>for Atom IDE</h3>
                   <p>Free. Open source.</p>
-                  <h4><a class='download-link' href='https://atom.io/packages/boot-java'> Spring Tools 4 <br/>as package for Atom</a></h4>
+                  <h4><a class='download-link' href='https://atom.io/packages/spring-boot'> Spring Tools 4 <br/>as package for Atom</a></h4>
                 </div>
               </div>
             </div>     


### PR DESCRIPTION
STS4 Atom package links point to `boot-java` instead of `spring-boot`