### PR TITLE
URL Cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ def gradleDir = "${rootProject.rootDir}/gradle"
 wrapper.gradleVersion = '2.13'
 
 buildscript {
-    ext.springRepo = 'http://repo.spring.io/libs-release'
+    ext.springRepo = 'https://repo.spring.io/libs-release'
 
     repositories {
         maven { url springRepo }
@@ -59,7 +59,7 @@ configure(javaProjects) {
     // during the normal `gradle eclipse` / `gradle cleanEclipse` lifecycle, as
     // these files have been checked in with formatting settings imported from
     // style/sagan-format.xml and style/sagan.importorder.
-    // See http://www.gradle.org/docs/current/userguide/eclipse_plugin.html
+    // See https://www.gradle.org/docs/current/userguide/eclipse_plugin.html
     eclipseJdt.onlyIf { false }
     cleanEclipseJdt.onlyIf { false }
 }

--- a/sagan-client/build.gradle
+++ b/sagan-client/build.gradle
@@ -19,7 +19,7 @@ jar {
         details.path = details.path.startsWith('META-INF') ?: 'static/'+details.path
     }
     // Jar contains duplicate empty folders, see Gradle issue:
-    // http://issues.gradle.org/browse/GRADLE-1830
+    // https://issues.gradle.org/browse/GRADLE-1830
     // so we need to set includeEmptyDirs to false
     includeEmptyDirs = false
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://issues.gradle.org/browse/GRADLE-1830 with 1 occurrences migrated to:  
  https://issues.gradle.org/browse/GRADLE-1830 ([https](https://issues.gradle.org/browse/GRADLE-1830) result 200).
* http://www.gradle.org/docs/current/userguide/eclipse_plugin.html with 1 occurrences migrated to:  
  https://www.gradle.org/docs/current/userguide/eclipse_plugin.html ([https](https://www.gradle.org/docs/current/userguide/eclipse_plugin.html) result 301).
* http://repo.spring.io/libs-release with 1 occurrences migrated to:  
  https://repo.spring.io/libs-release ([https](https://repo.spring.io/libs-release) result 302).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8080/webhook/gh-pages/default with 1 occurrences
* http://localhost:9200 with 1 occurrences