### PR TITLE
URL Cleanup

### DIFF
--- a/sagan-common/src/test-util/resources/fixtures/tools/eclipse.xml
+++ b/sagan-common/src/test-util/resources/fixtures/tools/eclipse.xml
@@ -1,1114 +1,1114 @@
 <downloads>
   <product name="SpringSource Tool Suites Downloads">
-    <package name="Spring Tool Suite 3.3.0.RELEASE - based on Eclipse Kepler 4.3 (Win32, 373MB)" icon="http://www.springsource.org/files/uploads/all/images/icons/Spring_ICO_48x48.png">
+    <package name="Spring Tool Suite 3.3.0.RELEASE - based on Eclipse Kepler 4.3 (Win32, 373MB)" icon="https://www.springsource.org/files/uploads/all/images/icons/Spring_ICO_48x48.png">
       <description><![CDATA[Spring Tool Suite&trade; (STS) provides the best Eclipse-powered development environment for building Spring-based enterprise applications. STS includes tools for all of the latest enterprise Java and Spring based technologies. STS supports application targeting to local, and cloud-based servers and provides built in support for vFabric tc Server. Spring Tool Suite is freely available for development and internal business operations use with no time limits.]]></description>
       <download os="windows" version="3.3.0.RELEASE" eclipse-version="4.3" size="373MB">
         <description>Windows</description>
         <file>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-win32-installer.exe</file>
         <md5>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-win32-installer.exe.md5</md5>
         <sha1>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-win32-installer.exe.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="windows" version="3.3.0.RELEASE" eclipse-version="4.3" size="373MB">
         <description>Windows (64bit)</description>
         <file>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-win32-x86_64-installer.exe</file>
         <md5>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-win32-x86_64-installer.exe.md5</md5>
         <sha1>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-win32-x86_64-installer.exe.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="mac" version="3.3.0.RELEASE" eclipse-version="4.3" size="373MB">
         <description>Mac OS X (Cocoa)</description>
         <file>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa-installer.dmg</file>
         <md5>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa-installer.dmg.md5</md5>
         <sha1>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa-installer.dmg.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="mac" version="3.3.0.RELEASE" eclipse-version="4.3" size="373MB">
         <description>Mac OS X (Cocoa, 64bit)</description>
         <file>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa-x86_64-installer.dmg</file>
         <md5>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa-x86_64-installer.dmg.md5</md5>
         <sha1>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="linux" version="3.3.0.RELEASE" eclipse-version="4.3" size="372MB">
         <description>Linux (GTK)</description>
         <file>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk-installer.sh</file>
         <md5>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk-installer.sh.md5</md5>
         <sha1>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk-installer.sh.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="linux" version="3.3.0.RELEASE" eclipse-version="4.3" size="372MB">
         <description>Linux (GTK, 64bit)</description>
         <file>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk-x86_64-installer.sh</file>
         <md5>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk-x86_64-installer.sh.md5</md5>
         <sha1>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk-x86_64-installer.sh.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
     </package>
-    <package name="Groovy/Grails Tool Suite 3.3.0.RELEASE - based on Eclipse Kepler 4.3 (Win32, 373MB)" icon="http://www.springsource.org/files/uploads/all/images/icons/GG_ICO_48x48.png">
+    <package name="Groovy/Grails Tool Suite 3.3.0.RELEASE - based on Eclipse Kepler 4.3 (Win32, 373MB)" icon="https://www.springsource.org/files/uploads/all/images/icons/GG_ICO_48x48.png">
       <description><![CDATA[Groovy/Grails Tool Suite&trade; (GGTS) provides the best Eclipse-powered development environment for building Groovy- and Grails-based enterprise applications. GGTS provides support for the latest versions of Groovy and Grails, and comes on top of the latest Eclipse releases. GGTS supports application targeting to local, and cloud-based servers and provides built in support for vFabric tc Server. Groovy/Grails Tool Suite is freely available for development and internal business operations use with no time limits.]]></description>
       <download os="windows" version="3.3.0.RELEASE" eclipse-version="4.3" size="468MB">
         <description>Windows</description>
         <file>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-win32-installer.exe</file>
         <md5>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-win32-installer.exe.md5</md5>
         <sha1>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-win32-installer.exe.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="windows" version="3.3.0.RELEASE" eclipse-version="4.3" size="468MB">
         <description>Windows (64bit)</description>
         <file>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-win32-x86_64-installer.exe</file>
         <md5>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-win32-x86_64-installer.exe.md5</md5>
         <sha1>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-win32-x86_64-installer.exe.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="mac" version="3.3.0.RELEASE" eclipse-version="4.3" size="468MB">
         <description>Mac OS X (Cocoa)</description>
         <file>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa-installer.dmg</file>
         <md5>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa-installer.dmg.md5</md5>
         <sha1>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa-installer.dmg.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="mac" version="3.3.0.RELEASE" eclipse-version="4.3" size="468MB">
         <description>Mac OS X (Cocoa, 64bit)</description>
         <file>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa-x86_64-installer.dmg</file>
         <md5>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa-x86_64-installer.dmg.md5</md5>
         <sha1>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="linux" version="3.3.0.RELEASE" eclipse-version="4.3" size="468MB">
         <description>Linux (GTK)</description>
         <file>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk-installer.sh</file>
         <md5>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk-installer.sh.md5</md5>
         <sha1>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk-installer.sh.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="linux" version="3.3.0.RELEASE" eclipse-version="4.3" size="468MB">
         <description>Linux (GTK, 64bit)</description>
         <file>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk-x86_64-installer.sh</file>
         <md5>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk-x86_64-installer.sh.md5</md5>
         <sha1>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk-x86_64-installer.sh.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
     </package>
-    <package name="Spring Tool Suite 3.3.0.RELEASE - based on Eclipse Juno 3.8.2 (Win32, 368MB)" icon="http://www.springsource.org/files/uploads/all/images/icons/Spring_ICO_48x48.png">
+    <package name="Spring Tool Suite 3.3.0.RELEASE - based on Eclipse Juno 3.8.2 (Win32, 368MB)" icon="https://www.springsource.org/files/uploads/all/images/icons/Spring_ICO_48x48.png">
       <description><![CDATA[Spring Tool Suite&trade; (STS) provides the best Eclipse-powered development environment for building Spring-based enterprise applications. STS includes tools for all of the latest enterprise Java and Spring based technologies. STS supports application targeting to local, and cloud-based servers and provides built in support for vFabric tc Server. Spring Tool Suite is freely available for development and internal business operations use with no time limits.]]></description>
       <download os="windows" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="368MB">
         <description>Windows</description>
         <file>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-win32-installer.exe</file>
         <md5>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-win32-installer.exe.md5</md5>
         <sha1>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-win32-installer.exe.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="windows" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="368MB">
         <description>Windows (64bit)</description>
         <file>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-win32-x86_64-installer.exe</file>
         <md5>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-win32-x86_64-installer.exe.md5</md5>
         <sha1>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-win32-x86_64-installer.exe.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="mac" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="368MB">
         <description>Mac OS X (Cocoa)</description>
         <file>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa-installer.dmg</file>
         <md5>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa-installer.dmg.md5</md5>
         <sha1>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa-installer.dmg.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="mac" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="368MB">
         <description>Mac OS X (Cocoa, 64bit)</description>
         <file>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg</file>
         <md5>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
         <sha1>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="linux" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="368MB">
         <description>Linux (GTK)</description>
         <file>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk-installer.sh</file>
         <md5>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk-installer.sh.md5</md5>
         <sha1>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk-installer.sh.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="linux" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="368MB">
         <description>Linux (GTK, 64bit)</description>
         <file>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh</file>
         <md5>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh.md5</md5>
         <sha1>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
     </package>
-    <package name="Groovy/Grails Tool Suite 3.3.0.RELEASE - based on Eclipse Juno 3.8.2 (Win32, 368MB)" icon="http://www.springsource.org/files/uploads/all/images/icons/GG_ICO_48x48.png">
+    <package name="Groovy/Grails Tool Suite 3.3.0.RELEASE - based on Eclipse Juno 3.8.2 (Win32, 368MB)" icon="https://www.springsource.org/files/uploads/all/images/icons/GG_ICO_48x48.png">
       <description><![CDATA[Groovy/Grails Tool Suite&trade; (GGTS) provides the best Eclipse-powered development environment for building Groovy- and Grails-based enterprise applications. GGTS provides support for the latest versions of Groovy and Grails, and comes on top of the latest Eclipse releases. GGTS supports application targeting to local, and cloud-based servers and provides built in support for vFabric tc Server. Groovy/Grails Tool Suite is freely available for development and internal business operations use with no time limits.]]></description>
       <download os="windows" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="464MB">
         <description>Windows</description>
         <file>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-win32-installer.exe</file>
         <md5>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-win32-installer.exe.md5</md5>
         <sha1>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-win32-installer.exe.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="windows" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="464MB">
         <description>Windows (64bit)</description>
         <file>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-win32-x86_64-installer.exe</file>
         <md5>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-win32-x86_64-installer.exe.md5</md5>
         <sha1>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-win32-x86_64-installer.exe.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="mac" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="463MB">
         <description>Mac OS X (Cocoa)</description>
         <file>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa-installer.dmg</file>
         <md5>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa-installer.dmg.md5</md5>
         <sha1>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa-installer.dmg.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="mac" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="463MB">
         <description>Mac OS X (Cocoa, 64bit)</description>
         <file>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg</file>
         <md5>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
         <sha1>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="linux" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="463MB">
         <description>Linux (GTK)</description>
         <file>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk-installer.sh</file>
         <md5>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk-installer.sh.md5</md5>
         <sha1>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk-installer.sh.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="linux" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="463MB">
         <description>Linux (GTK, 64bit)</description>
         <file>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh</file>
         <md5>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh.md5</md5>
         <sha1>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
     </package>
   </product>
   <product name="Eclipse Kepler Package Downloads (based on Eclipse 4.3)">
-    <package name="Eclipse Standard 4.3 (Win32, 0MB)" icon="http://www.springsource.org/files/uploads/all/images/product/classic2-nobg.png">
+    <package name="Eclipse Standard 4.3 (Win32, 0MB)" icon="https://www.springsource.org/files/uploads/all/images/product/classic2-nobg.png">
       <description><![CDATA[The Eclipse Platform, and all the tools needed to develop and debug it: Java and Plug-in Development Tooling, Git and CVS support, including source and developer documentation.]]></description>
       <download os="windows" eclipse-version="4.3.0" size="199MB">
         <description>Windows</description>
         <file>release/ECLIPSE/kepler/R/eclipse-standard-kepler-R-win32.zip</file>
         <md5>release/ECLIPSE/kepler/R/eclipse-standard-kepler-R-win32.zip.md5</md5>
         <sha1>release/ECLIPSE/kepler/R/eclipse-standard-kepler-R-win32.zip.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="windows" eclipse-version="4.3.0" size="199MB">
         <description>Windows (64bit)</description>
         <file>release/ECLIPSE/kepler/R/eclipse-standard-kepler-R-win32-x86_64.zip</file>
         <md5>release/ECLIPSE/kepler/R/eclipse-standard-kepler-R-win32-x86_64.zip.md5</md5>
         <sha1>release/ECLIPSE/kepler/R/eclipse-standard-kepler-R-win32-x86_64.zip.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="mac" eclipse-version="4.3.0" size="196MB">
         <description>Mac OS X (Cocoa)</description>
         <file>release/ECLIPSE/kepler/R/eclipse-standard-kepler-R-macosx-cocoa.tar.gz</file>
         <md5>release/ECLIPSE/kepler/R/eclipse-standard-kepler-R-macosx-cocoa.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/kepler/R/eclipse-standard-kepler-R-macosx-cocoa.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="mac" eclipse-version="4.3.0" size="198MB">
         <description>Mac OS X (Cocoa, 64bit)</description>
         <file>release/ECLIPSE/kepler/R/eclipse-standard-kepler-R-macosx-cocoa-x86_64.tar.gz</file>
         <md5>release/ECLIPSE/kepler/R/eclipse-standard-kepler-R-macosx-cocoa-x86_64.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/kepler/R/eclipse-standard-kepler-R-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="linux" eclipse-version="4.3.0" size="198MB">
         <description>Linux (GTK)</description>
         <file>release/ECLIPSE/kepler/R/eclipse-standard-kepler-R-linux-gtk.tar.gz</file>
         <md5>release/ECLIPSE/kepler/R/eclipse-standard-kepler-R-linux-gtk.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/kepler/R/eclipse-standard-kepler-R-linux-gtk.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="linux" eclipse-version="4.3.0" size="198MB">
         <description>Linux (GTK, 64bit)</description>
         <file>release/ECLIPSE/kepler/R/eclipse-standard-kepler-R-linux-gtk-x86_64.tar.gz</file>
         <md5>release/ECLIPSE/kepler/R/eclipse-standard-kepler-R-linux-gtk-x86_64.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/kepler/R/eclipse-standard-kepler-R-linux-gtk-x86_64.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
     </package>
-    <package name="Eclipse IDE for Java EE Developers (Win32, 245MB)" icon="http://www.springsource.org/files/uploads/all/images/product/jee-nobg.png">
+    <package name="Eclipse IDE for Java EE Developers (Win32, 245MB)" icon="https://www.springsource.org/files/uploads/all/images/product/jee-nobg.png">
       <description><![CDATA[Tools for Java developers creating Java EE and Web applications, including a Java IDE, tools for Java EE, JPA, JSF, Mylyn, EGit and others.]]></description>
       <download os="windows" eclipse-version="4.3.0" size="247MB">
         <description>Windows</description>
         <file>release/ECLIPSE/kepler/R/eclipse-jee-kepler-R-win32.zip</file>
         <md5>release/ECLIPSE/kepler/R/eclipse-jee-kepler-R-win32.zip.md5</md5>
         <sha1>release/ECLIPSE/kepler/R/eclipse-jee-kepler-R-win32.zip.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="windows" eclipse-version="4.3.0" size="247MB">
         <description>Windows (64bit)</description>
         <file>release/ECLIPSE/kepler/R/eclipse-jee-kepler-R-win32-x86_64.zip</file>
         <md5>release/ECLIPSE/kepler/R/eclipse-jee-kepler-R-win32-x86_64.zip.md5</md5>
         <sha1>release/ECLIPSE/kepler/R/eclipse-jee-kepler-R-win32-x86_64.zip.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="mac" eclipse-version="4.3.0" size="246MB">
         <description>Mac OS X (Cocoa)</description>
         <file>release/ECLIPSE/kepler/R/eclipse-jee-kepler-R-macosx-cocoa.tar.gz</file>
         <md5>release/ECLIPSE/kepler/R/eclipse-jee-kepler-R-macosx-cocoa.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/kepler/R/eclipse-jee-kepler-R-macosx-cocoa.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="mac" eclipse-version="4.3.0" size="246MB">
         <description>Mac OS X (Cocoa, 64bit)</description>
         <file>release/ECLIPSE/kepler/R/eclipse-jee-kepler-R-macosx-cocoa-x86_64.tar.gz</file>
         <md5>release/ECLIPSE/kepler/R/eclipse-jee-kepler-R-macosx-cocoa-x86_64.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/kepler/R/eclipse-jee-kepler-R-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="linux" eclipse-version="4.3.0" size="245MB">
         <description>Linux (GTK)</description>
         <file>release/ECLIPSE/kepler/R/eclipse-jee-kepler-R-linux-gtk.tar.gz</file>
         <md5>release/ECLIPSE/kepler/R/eclipse-jee-kepler-R-linux-gtk.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/kepler/R/eclipse-jee-kepler-R-linux-gtk.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="linux" eclipse-version="4.3.0" size="245MB">
         <description>Linux (GTK, 64bit)</description>
         <file>release/ECLIPSE/kepler/R/eclipse-jee-kepler-R-linux-gtk-x86_64.tar.gz</file>
         <md5>release/ECLIPSE/kepler/R/eclipse-jee-kepler-R-linux-gtk-x86_64.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/kepler/R/eclipse-jee-kepler-R-linux-gtk-x86_64.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
     </package>
-    <package name="Eclipse IDE for Java Developers (Win32, 150MB)" icon="http://www.springsource.org/files/uploads/all/images/product/java-nobg.png">
+    <package name="Eclipse IDE for Java Developers (Win32, 150MB)" icon="https://www.springsource.org/files/uploads/all/images/product/java-nobg.png">
       <description><![CDATA[The essential tools for any Java developer, including a Java IDE, a CVS client, Git client, XML Editor, Mylyn, Maven integration and WindowBuilder.]]></description>
       <download os="windows" eclipse-version="4.3.0" size="151MB">
         <description>Windows</description>
         <file>release/ECLIPSE/kepler/R/eclipse-java-kepler-R-win32.zip</file>
         <md5>release/ECLIPSE/kepler/R/eclipse-java-kepler-R-win32.zip.md5</md5>
         <sha1>release/ECLIPSE/kepler/R/eclipse-java-kepler-R-win32.zip.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="windows" eclipse-version="4.3.0" size="151MB">
         <description>Windows (64bit)</description>
         <file>release/ECLIPSE/kepler/R/eclipse-java-kepler-R-win32-x86_64.zip</file>
         <md5>release/ECLIPSE/kepler/R/eclipse-java-kepler-R-win32-x86_64.zip.md5</md5>
         <sha1>release/ECLIPSE/kepler/R/eclipse-java-kepler-R-win32-x86_64.zip.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="mac" eclipse-version="4.3.0" size="151MB">
         <description>Mac OS X (Cocoa)</description>
         <file>release/ECLIPSE/kepler/R/eclipse-java-kepler-R-macosx-cocoa.tar.gz</file>
         <md5>release/ECLIPSE/kepler/R/eclipse-java-kepler-R-macosx-cocoa.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/kepler/R/eclipse-java-kepler-R-macosx-cocoa.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="mac" eclipse-version="4.3.0" size="151MB">
         <description>Mac OS X (Cocoa, 64bit)</description>
         <file>release/ECLIPSE/kepler/R/eclipse-java-kepler-R-macosx-cocoa-x86_64.tar.gz</file>
         <md5>release/ECLIPSE/kepler/R/eclipse-java-kepler-R-macosx-cocoa-x86_64.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/kepler/R/eclipse-java-kepler-R-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="linux" eclipse-version="4.3.0" size="150MB">
         <description>Linux (GTK)</description>
         <file>release/ECLIPSE/kepler/R/eclipse-java-kepler-R-linux-gtk.tar.gz</file>
         <md5>release/ECLIPSE/kepler/R/eclipse-java-kepler-R-linux-gtk.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/kepler/R/eclipse-java-kepler-R-linux-gtk.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="linux" eclipse-version="4.3.0" size="150MB">
         <description>Linux (GTK, 64bit)</description>
         <file>release/ECLIPSE/kepler/R/eclipse-java-kepler-R-linux-gtk-x86_64.tar.gz</file>
         <md5>release/ECLIPSE/kepler/R/eclipse-java-kepler-R-linux-gtk-x86_64.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/kepler/R/eclipse-java-kepler-R-linux-gtk-x86_64.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
     </package>
-    <package name="Eclipse for RCP and RAP Developers (Win32, 235MB)" icon="http://www.springsource.org/files/uploads/all/images/product/rcp-nobg.png">
+    <package name="Eclipse for RCP and RAP Developers (Win32, 235MB)" icon="https://www.springsource.org/files/uploads/all/images/product/rcp-nobg.png">
       <description><![CDATA[A complete set of tools for developers who want to create Eclipse plug-ins, Rich Client or Rich Ajax Applications (RCP+RAP), plus Mylyn, and an XML editor. In addition to the CVS Eclipse Team provider, it also contains the EGit tooling for accessing Git version control systems.]]></description>
       <download os="windows" eclipse-version="4.3.0" size="236MB">
         <description>Windows</description>
         <file>release/ECLIPSE/kepler/R/eclipse-rcp-kepler-R-win32.zip</file>
         <md5>release/ECLIPSE/kepler/R/eclipse-rcp-kepler-R-win32.zip.md5</md5>
         <sha1>release/ECLIPSE/kepler/R/eclipse-rcp-kepler-R-win32.zip.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="windows" eclipse-version="4.3.0" size="236MB">
         <description>Windows (64bit)</description>
         <file>release/ECLIPSE/kepler/R/eclipse-rcp-kepler-R-win32-x86_64.zip</file>
         <md5>release/ECLIPSE/kepler/R/eclipse-rcp-kepler-R-win32-x86_64.zip.md5</md5>
         <sha1>release/ECLIPSE/kepler/R/eclipse-rcp-kepler-R-win32-x86_64.zip.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="mac" eclipse-version="4.3.0" size="233MB">
         <description>Mac OS X (Cocoa)</description>
         <file>release/ECLIPSE/kepler/R/eclipse-rcp-kepler-R-macosx-cocoa.tar.gz</file>
         <md5>release/ECLIPSE/kepler/R/eclipse-rcp-kepler-R-macosx-cocoa.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/kepler/R/eclipse-rcp-kepler-R-macosx-cocoa.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="mac" eclipse-version="4.3.0" size="235MB">
         <description>Mac OS X (Cocoa, 64bit)</description>
         <file>release/ECLIPSE/kepler/R/eclipse-rcp-kepler-R-macosx-cocoa-x86_64.tar.gz</file>
         <md5>release/ECLIPSE/kepler/R/eclipse-rcp-kepler-R-macosx-cocoa-x86_64.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/kepler/R/eclipse-rcp-kepler-R-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="linux" eclipse-version="4.3.0" size="235MB">
         <description>Linux (GTK)</description>
         <file>release/ECLIPSE/kepler/R/eclipse-rcp-kepler-R-linux-gtk.tar.gz</file>
         <md5>release/ECLIPSE/kepler/R/eclipse-rcp-kepler-R-linux-gtk.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/kepler/R/eclipse-rcp-kepler-R-linux-gtk.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="linux" eclipse-version="4.3.0" size="235MB">
         <description>Linux (GTK, 64bit)</description>
         <file>release/ECLIPSE/kepler/R/eclipse-rcp-kepler-R-linux-gtk-x86_64.tar.gz</file>
         <md5>release/ECLIPSE/kepler/R/eclipse-rcp-kepler-R-linux-gtk-x86_64.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/kepler/R/eclipse-rcp-kepler-R-linux-gtk-x86_64.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
     </package>
   </product>
   <product name="Eclipse Juno Package Downloads (based on Eclipse 4.2.2)">
-    <package name="Eclipse Classic 4.2.2 (Win32, 183MB)" icon="http://www.springsource.org/files/uploads/all/images/product/classic2-nobg.png">
+    <package name="Eclipse Classic 4.2.2 (Win32, 183MB)" icon="https://www.springsource.org/files/uploads/all/images/product/classic2-nobg.png">
       <description><![CDATA[The classic Eclipse download: the Eclipse Platform, Java Development Tools, and Plug-in Development Environment, including source and both user and programmer documentation.]]></description>
       <download os="windows" eclipse-version="4.2.2" size="183MB">
         <description>Windows</description>
         <file>release/ECLIPSE/juno/SR2/eclipse-SDK-4.2.2-win32.zip</file>
         <md5>release/ECLIPSE/juno/SR2/eclipse-SDK-4.2.2-win32.zip.md5</md5>
         <sha1>release/ECLIPSE/juno/SR2/eclipse-SDK-4.2.2-win32.zip.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="windows" eclipse-version="4.2.2" size="183MB">
         <description>Windows (64bit)</description>
         <file>release/ECLIPSE/juno/SR2/eclipse-SDK-4.2.2-win32-x86_64.zip</file>
         <md5>release/ECLIPSE/juno/SR2/eclipse-SDK-4.2.2-win32-x86_64.zip.md5</md5>
         <sha1>release/ECLIPSE/juno/SR2/eclipse-SDK-4.2.2-win32-x86_64.zip.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="mac" eclipse-version="4.2.2" size="182MB">
         <description>Mac OS X (Cocoa)</description>
         <file>release/ECLIPSE/juno/SR2/eclipse-SDK-4.2.2-macosx-cocoa.tar.gz</file>
         <md5>release/ECLIPSE/juno/SR2/eclipse-SDK-4.2.2-macosx-cocoa.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/juno/SR2/eclipse-SDK-4.2.2-macosx-cocoa.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="mac" eclipse-version="4.2.2" size="182MB">
         <description>Mac OS X (Cocoa, 64bit)</description>
         <file>release/ECLIPSE/juno/SR2/eclipse-SDK-4.2.2-macosx-cocoa-x86_64.tar.gz</file>
         <md5>release/ECLIPSE/juno/SR2/eclipse-SDK-4.2.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/juno/SR2/eclipse-SDK-4.2.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="linux" eclipse-version="4.2.2" size="183MB">
         <description>Linux (GTK)</description>
         <file>release/ECLIPSE/juno/SR2/eclipse-SDK-4.2.2-linux-gtk.tar.gz</file>
         <md5>release/ECLIPSE/juno/SR2/eclipse-SDK-4.2.2-linux-gtk.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/juno/SR2/eclipse-SDK-4.2.2-linux-gtk.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="linux" eclipse-version="4.2.2" size="183MB">
         <description>Linux (GTK, 64bit)</description>
         <file>release/ECLIPSE/juno/SR2/eclipse-SDK-4.2.2-linux-gtk-x86_64.tar.gz</file>
         <md5>release/ECLIPSE/juno/SR2/eclipse-SDK-4.2.2-linux-gtk-x86_64.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/juno/SR2/eclipse-SDK-4.2.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
     </package>
-    <package name="Eclipse IDE for Java EE Developers (Win32, 228MB)" icon="http://www.springsource.org/files/uploads/all/images/product/jee-nobg.png">
+    <package name="Eclipse IDE for Java EE Developers (Win32, 228MB)" icon="https://www.springsource.org/files/uploads/all/images/product/jee-nobg.png">
       <description><![CDATA[Tools for Java developers creating Java EE and Web applications, including a Java IDE, tools for Java EE, JPA, JSF, Mylyn and others.]]></description>
       <download os="windows" eclipse-version="4.2.2" size="229MB">
         <description>Windows</description>
         <file>release/ECLIPSE/juno/SR2/eclipse-jee-juno-SR2-win32.zip</file>
         <md5>release/ECLIPSE/juno/SR2/eclipse-jee-juno-SR2-win32.zip.md5</md5>
         <sha1>release/ECLIPSE/juno/SR2/eclipse-jee-juno-SR2-win32.zip.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="windows" eclipse-version="4.2.2" size="229MB">
         <description>Windows (64bit)</description>
         <file>release/ECLIPSE/juno/SR2/eclipse-jee-juno-SR2-win32-x86_64.zip</file>
         <md5>release/ECLIPSE/juno/SR2/eclipse-jee-juno-SR2-win32-x86_64.zip.md5</md5>
         <sha1>release/ECLIPSE/juno/SR2/eclipse-jee-juno-SR2-win32-x86_64.zip.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="mac" eclipse-version="4.2.2" size="227MB">
         <description>Mac OS X (Cocoa)</description>
         <file>release/ECLIPSE/juno/SR2/eclipse-jee-juno-SR2-macosx-cocoa.tar.gz</file>
         <md5>release/ECLIPSE/juno/SR2/eclipse-jee-juno-SR2-macosx-cocoa.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/juno/SR2/eclipse-jee-juno-SR2-macosx-cocoa.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="mac" eclipse-version="4.2.2" size="227MB">
         <description>Mac OS X (Cocoa, 64bit)</description>
         <file>release/ECLIPSE/juno/SR2/eclipse-jee-juno-SR2-macosx-cocoa-x86_64.tar.gz</file>
         <md5>release/ECLIPSE/juno/SR2/eclipse-jee-juno-SR2-macosx-cocoa-x86_64.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/juno/SR2/eclipse-jee-juno-SR2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="linux" eclipse-version="4.2.2" size="228MB">
         <description>Linux (GTK)</description>
         <file>release/ECLIPSE/juno/SR2/eclipse-jee-juno-SR2-linux-gtk.tar.gz</file>
         <md5>release/ECLIPSE/juno/SR2/eclipse-jee-juno-SR2-linux-gtk.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/juno/SR2/eclipse-jee-juno-SR2-linux-gtk.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="linux" eclipse-version="4.2.2" size="228MB">
         <description>Linux (GTK, 64bit)</description>
         <file>release/ECLIPSE/juno/SR2/eclipse-jee-juno-SR2-linux-gtk-x86_64.tar.gz</file>
         <md5>release/ECLIPSE/juno/SR2/eclipse-jee-juno-SR2-linux-gtk-x86_64.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/juno/SR2/eclipse-jee-juno-SR2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
     </package>
-    <package name="Eclipse IDE for Java Developers (Win32, 150MB)" icon="http://www.springsource.org/files/uploads/all/images/product/java-nobg.png">
+    <package name="Eclipse IDE for Java Developers (Win32, 150MB)" icon="https://www.springsource.org/files/uploads/all/images/product/java-nobg.png">
       <description><![CDATA[The essential tools for any Java developer, including a Java IDE, a CVS client, XML Editor and Mylyn.]]></description>
       <download os="windows" eclipse-version="4.2.2" size="151MB">
         <description>Windows</description>
         <file>release/ECLIPSE/juno/SR2/eclipse-java-juno-SR2-win32.zip</file>
         <md5>release/ECLIPSE/juno/SR2/eclipse-java-juno-SR2-win32.zip.md5</md5>
         <sha1>release/ECLIPSE/juno/SR2/eclipse-java-juno-SR2-win32.zip.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="windows" eclipse-version="4.2.2" size="151MB">
         <description>Windows (64bit)</description>
         <file>release/ECLIPSE/juno/SR2/eclipse-java-juno-SR2-win32-x86_64.zip</file>
         <md5>release/ECLIPSE/juno/SR2/eclipse-java-juno-SR2-win32-x86_64.zip.md5</md5>
         <sha1>release/ECLIPSE/juno/SR2/eclipse-java-juno-SR2-win32-x86_64.zip.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="mac" eclipse-version="4.2.2" size="150MB">
         <description>Mac OS X (Cocoa)</description>
         <file>release/ECLIPSE/juno/SR2/eclipse-java-juno-SR2-macosx-cocoa.tar.gz</file>
         <md5>release/ECLIPSE/juno/SR2/eclipse-java-juno-SR2-macosx-cocoa.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/juno/SR2/eclipse-java-juno-SR2-macosx-cocoa.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="mac" eclipse-version="4.2.2" size="150MB">
         <description>Mac OS X (Cocoa, 64bit)</description>
         <file>release/ECLIPSE/juno/SR2/eclipse-java-juno-SR2-macosx-cocoa-x86_64.tar.gz</file>
         <md5>release/ECLIPSE/juno/SR2/eclipse-java-juno-SR2-macosx-cocoa-x86_64.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/juno/SR2/eclipse-java-juno-SR2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="linux" eclipse-version="4.2.2" size="150MB">
         <description>Linux (GTK)</description>
         <file>release/ECLIPSE/juno/SR2/eclipse-java-juno-SR2-linux-gtk.tar.gz</file>
         <md5>release/ECLIPSE/juno/SR2/eclipse-java-juno-SR2-linux-gtk.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/juno/SR2/eclipse-java-juno-SR2-linux-gtk.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="linux" eclipse-version="4.2.2" size="150MB">
         <description>Linux (GTK, 64bit)</description>
         <file>release/ECLIPSE/juno/SR2/eclipse-java-juno-SR2-linux-gtk-x86_64.tar.gz</file>
         <md5>release/ECLIPSE/juno/SR2/eclipse-java-juno-SR2-linux-gtk-x86_64.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/juno/SR2/eclipse-java-juno-SR2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
     </package>
-    <package name="Eclipse RCP/Plug-in Developers (Win32, 228MB)" icon="http://www.springsource.org/files/uploads/all/images/product/rcp-nobg.png">
+    <package name="Eclipse RCP/Plug-in Developers (Win32, 228MB)" icon="https://www.springsource.org/files/uploads/all/images/product/rcp-nobg.png">
       <description><![CDATA[A complete set of tools for developers who want to create Eclipse plug-ins or Rich Client Applications. It includes a complete SDK, developer tools and source code, plus Mylyn, an XML editor and the Eclipse Communication Framework.]]></description>
       <download os="windows" eclipse-version="4.2.2" size="229MB">
         <description>Windows</description>
         <file>release/ECLIPSE/juno/SR2/eclipse-rcp-juno-SR2-win32.zip</file>
         <md5>release/ECLIPSE/juno/SR2/eclipse-rcp-juno-SR2-win32.zip.md5</md5>
         <sha1>release/ECLIPSE/juno/SR2/eclipse-rcp-juno-SR2-win32.zip.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="windows" eclipse-version="4.2.2" size="229MB">
         <description>Windows (64bit)</description>
         <file>release/ECLIPSE/juno/SR2/eclipse-rcp-juno-SR2-win32-x86_64.zip</file>
         <md5>release/ECLIPSE/juno/SR2/eclipse-rcp-juno-SR2-win32-x86_64.zip.md5</md5>
         <sha1>release/ECLIPSE/juno/SR2/eclipse-rcp-juno-SR2-win32-x86_64.zip.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="mac" eclipse-version="4.2.2" size="227MB">
         <description>Mac OS X (Cocoa)</description>
         <file>release/ECLIPSE/juno/SR2/eclipse-rcp-juno-SR2-macosx-cocoa.tar.gz</file>
         <md5>release/ECLIPSE/juno/SR2/eclipse-rcp-juno-SR2-macosx-cocoa.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/juno/SR2/eclipse-rcp-juno-SR2-macosx-cocoa.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="mac" eclipse-version="4.2.2" size="227MB">
         <description>Mac OS X (Cocoa, 64bit)</description>
         <file>release/ECLIPSE/juno/SR2/eclipse-rcp-juno-SR2-macosx-cocoa-x86_64.tar.gz</file>
         <md5>release/ECLIPSE/juno/SR2/eclipse-rcp-juno-SR2-macosx-cocoa-x86_64.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/juno/SR2/eclipse-rcp-juno-SR2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="linux" eclipse-version="4.2.2" size="228MB">
         <description>Linux (GTK)</description>
         <file>release/ECLIPSE/juno/SR2/eclipse-rcp-juno-SR2-linux-gtk.tar.gz</file>
         <md5>release/ECLIPSE/juno/SR2/eclipse-rcp-juno-SR2-linux-gtk.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/juno/SR2/eclipse-rcp-juno-SR2-linux-gtk.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="linux" eclipse-version="4.2.2" size="228MB">
         <description>Linux (GTK, 64bit)</description>
         <file>release/ECLIPSE/juno/SR2/eclipse-rcp-juno-SR2-linux-gtk-x86_64.tar.gz</file>
         <md5>release/ECLIPSE/juno/SR2/eclipse-rcp-juno-SR2-linux-gtk-x86_64.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/juno/SR2/eclipse-rcp-juno-SR2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
     </package>
   </product>
   <product name="Eclipse Indigo Package Downloads (based on Eclipse 3.7.2)">
-    <package name="Eclipse Classic 3.7.2 (Win32, 174MB)" icon="http://www.springsource.org/files/uploads/all/images/product/classic2-nobg.png">
+    <package name="Eclipse Classic 3.7.2 (Win32, 174MB)" icon="https://www.springsource.org/files/uploads/all/images/product/classic2-nobg.png">
       <description><![CDATA[The classic Eclipse download: the Eclipse Platform, Java Development Tools, and Plug-in Development Environment, including source and both user and programmer documentation.]]></description>
       <download os="windows" eclipse-version="3.7.2" size="175MB">
         <description>Windows</description>
         <file>release/ECLIPSE/indigo/SR2/eclipse-SDK-3.7.2-win32.zip</file>
         <md5>release/ECLIPSE/indigo/SR2/eclipse-SDK-3.7.2-win32.zip.md5</md5>
         <sha1>release/ECLIPSE/indigo/SR2/eclipse-SDK-3.7.2-win32.zip.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="windows" eclipse-version="3.7.2" size="175MB">
         <description>Windows (64bit)</description>
         <file>release/ECLIPSE/indigo/SR2/eclipse-SDK-3.7.2-win32-x86_64.zip</file>
         <md5>release/ECLIPSE/indigo/SR2/eclipse-SDK-3.7.2-win32-x86_64.zip.md5</md5>
         <sha1>release/ECLIPSE/indigo/SR2/eclipse-SDK-3.7.2-win32-x86_64.zip.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="mac" eclipse-version="3.7.2" size="173MB">
         <description>Mac OS X (Carbon)</description>
         <file>release/ECLIPSE/indigo/SR2/eclipse-SDK-3.7.2-macosx-carbon.tar.gz</file>
         <md5>release/ECLIPSE/indigo/SR2/eclipse-SDK-3.7.2-macosx-carbon.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/indigo/SR2/eclipse-SDK-3.7.2-macosx-carbon.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="mac" eclipse-version="3.7.2" size="174MB">
         <description>Mac OS X (Cocoa)</description>
         <file>release/ECLIPSE/indigo/SR2/eclipse-SDK-3.7.2-macosx-cocoa.tar.gz</file>
         <md5>release/ECLIPSE/indigo/SR2/eclipse-SDK-3.7.2-macosx-cocoa.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/indigo/SR2/eclipse-SDK-3.7.2-macosx-cocoa.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="mac" eclipse-version="3.7.2" size="173MB">
         <description>Mac OS X (Cocoa, 64bit)</description>
         <file>release/ECLIPSE/indigo/SR2/eclipse-SDK-3.7.2-macosx-cocoa-x86_64.tar.gz</file>
         <md5>release/ECLIPSE/indigo/SR2/eclipse-SDK-3.7.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/indigo/SR2/eclipse-SDK-3.7.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="linux" eclipse-version="3.7.2" size="174MB">
         <description>Linux (GTK)</description>
         <file>release/ECLIPSE/indigo/SR2/eclipse-SDK-3.7.2-linux-gtk.tar.gz</file>
         <md5>release/ECLIPSE/indigo/SR2/eclipse-SDK-3.7.2-linux-gtk.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/indigo/SR2/eclipse-SDK-3.7.2-linux-gtk.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="linux" eclipse-version="3.7.2" size="174MB">
         <description>Linux (GTK, 64bit)</description>
         <file>release/ECLIPSE/indigo/SR2/eclipse-SDK-3.7.2-linux-gtk-x86_64.tar.gz</file>
         <md5>release/ECLIPSE/indigo/SR2/eclipse-SDK-3.7.2-linux-gtk-x86_64.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/indigo/SR2/eclipse-SDK-3.7.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
     </package>
-    <package name="Eclipse IDE for Java EE Developers (Win32, 211MB)" icon="http://www.springsource.org/files/uploads/all/images/product/jee-nobg.png">
+    <package name="Eclipse IDE for Java EE Developers (Win32, 211MB)" icon="https://www.springsource.org/files/uploads/all/images/product/jee-nobg.png">
       <description><![CDATA[Tools for Java developers creating Java EE and Web applications, including a Java IDE, tools for Java EE, JPA, JSF, Mylyn and others.]]></description>
       <download os="windows" eclipse-version="3.7.2" size="213MB">
         <description>Windows</description>
         <file>release/ECLIPSE/indigo/SR2/eclipse-jee-indigo-SR2-win32.zip</file>
         <md5>release/ECLIPSE/indigo/SR2/eclipse-jee-indigo-SR2-win32.zip.md5</md5>
         <sha1>release/ECLIPSE/indigo/SR2/eclipse-jee-indigo-SR2-win32.zip.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="windows" eclipse-version="3.7.2" size="213MB">
         <description>Windows (64bit)</description>
         <file>release/ECLIPSE/indigo/SR2/eclipse-jee-indigo-SR2-win32-x86_64.zip</file>
         <md5>release/ECLIPSE/indigo/SR2/eclipse-jee-indigo-SR2-win32-x86_64.zip.md5</md5>
         <sha1>release/ECLIPSE/indigo/SR2/eclipse-jee-indigo-SR2-win32-x86_64.zip.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="mac" eclipse-version="3.7.2" size="211MB">
         <description>Mac OS X (Cocoa)</description>
         <file>release/ECLIPSE/indigo/SR2/eclipse-jee-indigo-SR2-macosx-cocoa.tar.gz</file>
         <md5>release/ECLIPSE/indigo/SR2/eclipse-jee-indigo-SR2-macosx-cocoa.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/indigo/SR2/eclipse-jee-indigo-SR2-macosx-cocoa.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="mac" eclipse-version="3.7.2" size="211MB">
         <description>Mac OS X (Cocoa, 64bit)</description>
         <file>release/ECLIPSE/indigo/SR2/eclipse-jee-indigo-SR2-macosx-cocoa-x86_64.tar.gz</file>
         <md5>release/ECLIPSE/indigo/SR2/eclipse-jee-indigo-SR2-macosx-cocoa-x86_64.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/indigo/SR2/eclipse-jee-indigo-SR2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="linux" eclipse-version="3.7.2" size="211MB">
         <description>Linux (GTK)</description>
         <file>release/ECLIPSE/indigo/SR2/eclipse-jee-indigo-SR2-linux-gtk.tar.gz</file>
         <md5>release/ECLIPSE/indigo/SR2/eclipse-jee-indigo-SR2-linux-gtk.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/indigo/SR2/eclipse-jee-indigo-SR2-linux-gtk.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="linux" eclipse-version="3.7.2" size="211MB">
         <description>Linux (GTK, 64bit)</description>
         <file>release/ECLIPSE/indigo/SR2/eclipse-jee-indigo-SR2-linux-gtk-x86_64.tar.gz</file>
         <md5>release/ECLIPSE/indigo/SR2/eclipse-jee-indigo-SR2-linux-gtk-x86_64.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/indigo/SR2/eclipse-jee-indigo-SR2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
     </package>
-    <package name="Eclipse IDE for Java Developers (Win32, 128MB)" icon="http://www.springsource.org/files/uploads/all/images/product/java-nobg.png">
+    <package name="Eclipse IDE for Java Developers (Win32, 128MB)" icon="https://www.springsource.org/files/uploads/all/images/product/java-nobg.png">
       <description><![CDATA[The essential tools for any Java developer, including a Java IDE, a CVS client, XML Editor and Mylyn.]]></description>
       <download os="windows" eclipse-version="3.7.2" size="129MB">
         <description>Windows</description>
         <file>release/ECLIPSE/indigo/SR2/eclipse-java-indigo-SR2-win32.zip</file>
         <md5>release/ECLIPSE/indigo/SR2/eclipse-java-indigo-SR2-win32.zip.md5</md5>
         <sha1>release/ECLIPSE/indigo/SR2/eclipse-java-indigo-SR2-win32.zip.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="windows" eclipse-version="3.7.2" size="129MB">
         <description>Windows (64bit)</description>
         <file>release/ECLIPSE/indigo/SR2/eclipse-java-indigo-SR2-win32-x86_64.zip</file>
         <md5>release/ECLIPSE/indigo/SR2/eclipse-java-indigo-SR2-win32-x86_64.zip.md5</md5>
         <sha1>release/ECLIPSE/indigo/SR2/eclipse-java-indigo-SR2-win32-x86_64.zip.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="mac" eclipse-version="3.7.2" size="128MB">
         <description>Mac OS X (Cocoa)</description>
         <file>release/ECLIPSE/indigo/SR2/eclipse-java-indigo-SR2-macosx-cocoa.tar.gz</file>
         <md5>release/ECLIPSE/indigo/SR2/eclipse-java-indigo-SR2-macosx-cocoa.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/indigo/SR2/eclipse-java-indigo-SR2-macosx-cocoa.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="mac" eclipse-version="3.7.2" size="128MB">
         <description>Mac OS X (Cocoa, 64bit)</description>
         <file>release/ECLIPSE/indigo/SR2/eclipse-java-indigo-SR2-macosx-cocoa-x86_64.tar.gz</file>
         <md5>release/ECLIPSE/indigo/SR2/eclipse-java-indigo-SR2-macosx-cocoa-x86_64.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/indigo/SR2/eclipse-java-indigo-SR2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="linux" eclipse-version="3.7.2" size="128MB">
         <description>Linux (GTK)</description>
         <file>release/ECLIPSE/indigo/SR2/eclipse-java-indigo-SR2-linux-gtk.tar.gz</file>
         <md5>release/ECLIPSE/indigo/SR2/eclipse-java-indigo-SR2-linux-gtk.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/indigo/SR2/eclipse-java-indigo-SR2-linux-gtk.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="linux" eclipse-version="3.7.2" size="128MB">
         <description>Linux (GTK, 64bit)</description>
         <file>release/ECLIPSE/indigo/SR2/eclipse-java-indigo-SR2-linux-gtk-x86_64.tar.gz</file>
         <md5>release/ECLIPSE/indigo/SR2/eclipse-java-indigo-SR2-linux-gtk-x86_64.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/indigo/SR2/eclipse-java-indigo-SR2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
     </package>
-    <package name="Eclipse RCP/Plug-in Developers (Win32, 181MB)" icon="http://www.springsource.org/files/uploads/all/images/product/rcp-nobg.png">
+    <package name="Eclipse RCP/Plug-in Developers (Win32, 181MB)" icon="https://www.springsource.org/files/uploads/all/images/product/rcp-nobg.png">
       <description><![CDATA[A complete set of tools for developers who want to create Eclipse plug-ins or Rich Client Applications. It includes a complete SDK, developer tools and source code, plus Mylyn, an XML editor and the Eclipse Communication Framework.]]></description>
       <download os="windows" eclipse-version="3.7.2" size="182MB">
         <description>Windows</description>
         <file>release/ECLIPSE/indigo/SR2/eclipse-rcp-indigo-SR2-win32.zip</file>
         <md5>release/ECLIPSE/indigo/SR2/eclipse-rcp-indigo-SR2-win32.zip.md5</md5>
         <sha1>release/ECLIPSE/indigo/SR2/eclipse-rcp-indigo-SR2-win32.zip.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="windows" eclipse-version="3.7.2" size="182MB">
         <description>Windows (64bit)</description>
         <file>release/ECLIPSE/indigo/SR2/eclipse-rcp-indigo-SR2-win32-x86_64.zip</file>
         <md5>release/ECLIPSE/indigo/SR2/eclipse-rcp-indigo-SR2-win32-x86_64.zip.md5</md5>
         <sha1>release/ECLIPSE/indigo/SR2/eclipse-rcp-indigo-SR2-win32-x86_64.zip.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="mac" eclipse-version="3.7.2" size="180MB">
         <description>Mac OS X (Cocoa)</description>
         <file>release/ECLIPSE/indigo/SR2/eclipse-rcp-indigo-SR2-macosx-cocoa.tar.gz</file>
         <md5>release/ECLIPSE/indigo/SR2/eclipse-rcp-indigo-SR2-macosx-cocoa.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/indigo/SR2/eclipse-rcp-indigo-SR2-macosx-cocoa.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="mac" eclipse-version="3.7.2" size="180MB">
         <description>Mac OS X (Cocoa, 64bit)</description>
         <file>release/ECLIPSE/indigo/SR2/eclipse-rcp-indigo-SR2-macosx-cocoa-x86_64.tar.gz</file>
         <md5>release/ECLIPSE/indigo/SR2/eclipse-rcp-indigo-SR2-macosx-cocoa-x86_64.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/indigo/SR2/eclipse-rcp-indigo-SR2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="linux" eclipse-version="3.7.2" size="181MB">
         <description>Linux (GTK)</description>
         <file>release/ECLIPSE/indigo/SR2/eclipse-rcp-indigo-SR2-linux-gtk.tar.gz</file>
         <md5>release/ECLIPSE/indigo/SR2/eclipse-rcp-indigo-SR2-linux-gtk.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/indigo/SR2/eclipse-rcp-indigo-SR2-linux-gtk.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="linux" eclipse-version="3.7.2" size="181MB">
         <description>Linux (GTK, 64bit)</description>
         <file>release/ECLIPSE/indigo/SR2/eclipse-rcp-indigo-SR2-linux-gtk-x86_64.tar.gz</file>
         <md5>release/ECLIPSE/indigo/SR2/eclipse-rcp-indigo-SR2-linux-gtk-x86_64.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/indigo/SR2/eclipse-rcp-indigo-SR2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
     </package>
   </product>
   <product name="Eclipse Helios Package Downloads (based on Eclipse 3.6.2)">
-    <package name="Eclipse Classic 3.6.2 (Win32, 171MB)" icon="http://www.springsource.org/files/uploads/all/images/product/classic2-nobg.png">
+    <package name="Eclipse Classic 3.6.2 (Win32, 171MB)" icon="https://www.springsource.org/files/uploads/all/images/product/classic2-nobg.png">
       <description><![CDATA[The classic Eclipse download: the Eclipse Platform, Java Development Tools, and Plug-in Development Environment, including source and both user and programmer documentation.]]></description>
       <download os="windows" eclipse-version="3.6.2" size="171MB">
         <description>Windows</description>
         <file>release/ECLIPSE/helios/SR2/eclipse-SDK-3.6.2-win32.zip</file>
         <md5>release/ECLIPSE/helios/SR2/eclipse-SDK-3.6.2-win32.zip.md5</md5>
         <sha1>release/ECLIPSE/helios/SR2/eclipse-SDK-3.6.2-win32.zip.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="windows" eclipse-version="3.6.2" size="171MB">
         <description>Windows (64bit)</description>
         <file>release/ECLIPSE/helios/SR2/eclipse-SDK-3.6.2-win32-x86_64.zip</file>
         <md5>release/ECLIPSE/helios/SR2/eclipse-SDK-3.6.2-win32-x86_64.zip.md5</md5>
         <sha1>release/ECLIPSE/helios/SR2/eclipse-SDK-3.6.2-win32-x86_64.zip.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="mac" eclipse-version="3.6.2" size="170MB">
         <description>Mac OS X (Carbon)</description>
         <file>release/ECLIPSE/helios/SR2/eclipse-SDK-3.6.2-macosx-carbon.tar.gz</file>
         <md5>release/ECLIPSE/helios/SR2/eclipse-SDK-3.6.2-macosx-carbon.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/helios/SR2/eclipse-SDK-3.6.2-macosx-carbon.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="mac" eclipse-version="3.6.2" size="170MB">
         <description>Mac OS X (Cocoa)</description>
         <file>release/ECLIPSE/helios/SR2/eclipse-SDK-3.6.2-macosx-cocoa.tar.gz</file>
         <md5>release/ECLIPSE/helios/SR2/eclipse-SDK-3.6.2-macosx-cocoa.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/helios/SR2/eclipse-SDK-3.6.2-macosx-cocoa.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="mac" eclipse-version="3.6.2" size="170MB">
         <description>Mac OS X (Cocoa, 64bit)</description>
         <file>release/ECLIPSE/helios/SR2/eclipse-SDK-3.6.2-macosx-cocoa-x86_64.tar.gz</file>
         <md5>release/ECLIPSE/helios/SR2/eclipse-SDK-3.6.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/helios/SR2/eclipse-SDK-3.6.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="linux" eclipse-version="3.6.2" size="170MB">
         <description>Linux (GTK)</description>
         <file>release/ECLIPSE/helios/SR2/eclipse-SDK-3.6.2-linux-gtk.tar.gz</file>
         <md5>release/ECLIPSE/helios/SR2/eclipse-SDK-3.6.2-linux-gtk.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/helios/SR2/eclipse-SDK-3.6.2-linux-gtk.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="linux" eclipse-version="3.6.2" size="171MB">
         <description>Linux (GTK, 64bit)</description>
         <file>release/ECLIPSE/helios/SR2/eclipse-SDK-3.6.2-linux-gtk-x86_64.tar.gz</file>
         <md5>release/ECLIPSE/helios/SR2/eclipse-SDK-3.6.2-linux-gtk-x86_64.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/helios/SR2/eclipse-SDK-3.6.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
     </package>
-    <package name="Eclipse IDE for Java EE Developers (Win32, 205MB)" icon="http://www.springsource.org/files/uploads/all/images/product/jee-nobg.png">
+    <package name="Eclipse IDE for Java EE Developers (Win32, 205MB)" icon="https://www.springsource.org/files/uploads/all/images/product/jee-nobg.png">
       <description><![CDATA[Tools for Java developers creating Java EE and Web applications, including a Java IDE, tools for Java EE, JPA, JSF, Mylyn and others.]]></description>
       <download os="windows" eclipse-version="3.6.2" size="206MB">
         <description>Windows</description>
         <file>release/ECLIPSE/helios/SR2/eclipse-jee-helios-SR2-win32.zip</file>
         <md5>release/ECLIPSE/helios/SR2/eclipse-jee-helios-SR2-win32.zip.md5</md5>
         <sha1>release/ECLIPSE/helios/SR2/eclipse-jee-helios-SR2-win32.zip.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="windows" eclipse-version="3.6.2" size="207MB">
         <description>Windows (64bit)</description>
         <file>release/ECLIPSE/helios/SR2/eclipse-jee-helios-SR2-win32-x86_64.zip</file>
         <md5>release/ECLIPSE/helios/SR2/eclipse-jee-helios-SR2-win32-x86_64.zip.md5</md5>
         <sha1>release/ECLIPSE/helios/SR2/eclipse-jee-helios-SR2-win32-x86_64.zip.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="mac" eclipse-version="3.6.2" size="205MB">
         <description>Mac OS X (Cocoa)</description>
         <file>release/ECLIPSE/helios/SR2/eclipse-jee-helios-SR2-macosx-cocoa.tar.gz</file>
         <md5>release/ECLIPSE/helios/SR2/eclipse-jee-helios-SR2-macosx-cocoa.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/helios/SR2/eclipse-jee-helios-SR2-macosx-cocoa.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="mac" eclipse-version="3.6.2" size="205MB">
         <description>Mac OS X (Cocoa, 64bit)</description>
         <file>release/ECLIPSE/helios/SR2/eclipse-jee-helios-SR2-macosx-cocoa-x86_64.tar.gz</file>
         <md5>release/ECLIPSE/helios/SR2/eclipse-jee-helios-SR2-macosx-cocoa-x86_64.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/helios/SR2/eclipse-jee-helios-SR2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="linux" eclipse-version="3.6.2" size="205MB">
         <description>Linux (GTK)</description>
         <file>release/ECLIPSE/helios/SR2/eclipse-jee-helios-SR2-linux-gtk.tar.gz</file>
         <md5>release/ECLIPSE/helios/SR2/eclipse-jee-helios-SR2-linux-gtk.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/helios/SR2/eclipse-jee-helios-SR2-linux-gtk.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="linux" eclipse-version="3.6.2" size="205MB">
         <description>Linux (GTK, 64bit)</description>
         <file>release/ECLIPSE/helios/SR2/eclipse-jee-helios-SR2-linux-gtk-x86_64.tar.gz</file>
         <md5>release/ECLIPSE/helios/SR2/eclipse-jee-helios-SR2-linux-gtk-x86_64.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/helios/SR2/eclipse-jee-helios-SR2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
     </package>
-    <package name="Eclipse IDE for Java Developers (Win32, 99MB)" icon="http://www.springsource.org/files/uploads/all/images/product/java-nobg.png">
+    <package name="Eclipse IDE for Java Developers (Win32, 99MB)" icon="https://www.springsource.org/files/uploads/all/images/product/java-nobg.png">
       <description><![CDATA[The essential tools for any Java developer, including a Java IDE, a CVS client, XML Editor and Mylyn.]]></description>
       <download os="windows" eclipse-version="3.6.2" size="99MB">
         <description>Windows</description>
         <file>release/ECLIPSE/helios/SR2/eclipse-java-helios-SR2-win32.zip</file>
         <md5>release/ECLIPSE/helios/SR2/eclipse-java-helios-SR2-win32.zip.md5</md5>
         <sha1>release/ECLIPSE/helios/SR2/eclipse-java-helios-SR2-win32.zip.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="windows" eclipse-version="3.6.2" size="99MB">
         <description>Windows (64bit)</description>
         <file>release/ECLIPSE/helios/SR2/eclipse-java-helios-SR2-win32-x86_64.zip</file>
         <md5>release/ECLIPSE/helios/SR2/eclipse-java-helios-SR2-win32-x86_64.zip.md5</md5>
         <sha1>release/ECLIPSE/helios/SR2/eclipse-java-helios-SR2-win32-x86_64.zip.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="mac" eclipse-version="3.6.2" size="98MB">
         <description>Mac OS X (Cocoa)</description>
         <file>release/ECLIPSE/helios/SR2/eclipse-java-helios-SR2-macosx-cocoa.tar.gz</file>
         <md5>release/ECLIPSE/helios/SR2/eclipse-java-helios-SR2-macosx-cocoa.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/helios/SR2/eclipse-java-helios-SR2-macosx-cocoa.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="mac" eclipse-version="3.6.2" size="98MB">
         <description>Mac OS X (Cocoa, 64bit)</description>
         <file>release/ECLIPSE/helios/SR2/eclipse-java-helios-SR2-macosx-cocoa-x86_64.tar.gz</file>
         <md5>release/ECLIPSE/helios/SR2/eclipse-java-helios-SR2-macosx-cocoa-x86_64.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/helios/SR2/eclipse-java-helios-SR2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="linux" eclipse-version="3.6.2" size="99MB">
         <description>Linux (GTK)</description>
         <file>release/ECLIPSE/helios/SR2/eclipse-java-helios-SR2-linux-gtk.tar.gz</file>
         <md5>release/ECLIPSE/helios/SR2/eclipse-java-helios-SR2-linux-gtk.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/helios/SR2/eclipse-java-helios-SR2-linux-gtk.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="linux" eclipse-version="3.6.2" size="99MB">
         <description>Linux (GTK, 64bit)</description>
         <file>release/ECLIPSE/helios/SR2/eclipse-java-helios-SR2-linux-gtk-x86_64.tar.gz</file>
         <md5>release/ECLIPSE/helios/SR2/eclipse-java-helios-SR2-linux-gtk-x86_64.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/helios/SR2/eclipse-java-helios-SR2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
     </package>
-    <package name="Eclipse RCP/Plug-in Developers (Win32, 188MB)" icon="http://www.springsource.org/files/uploads/all/images/product/rcp-nobg.png">
+    <package name="Eclipse RCP/Plug-in Developers (Win32, 188MB)" icon="https://www.springsource.org/files/uploads/all/images/product/rcp-nobg.png">
       <description><![CDATA[A complete set of tools for developers who want to create Eclipse plug-ins or Rich Client Applications. It includes a complete SDK, developer tools and source code, plus Mylyn, an XML editor and the Eclipse Communication Framework.]]></description>
       <download os="windows" eclipse-version="3.6.2" size="189MB">
         <description>Windows</description>
         <file>release/ECLIPSE/helios/SR2/eclipse-rcp-helios-SR2-win32.zip</file>
         <md5>release/ECLIPSE/helios/SR2/eclipse-rcp-helios-SR2-win32.zip.md5</md5>
         <sha1>release/ECLIPSE/helios/SR2/eclipse-rcp-helios-SR2-win32.zip.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="windows" eclipse-version="3.6.2" size="189MB">
         <description>Windows (64bit)</description>
         <file>release/ECLIPSE/helios/SR2/eclipse-rcp-helios-SR2-win32-x86_64.zip</file>
         <md5>release/ECLIPSE/helios/SR2/eclipse-rcp-helios-SR2-win32-x86_64.zip.md5</md5>
         <sha1>release/ECLIPSE/helios/SR2/eclipse-rcp-helios-SR2-win32-x86_64.zip.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="mac" eclipse-version="3.6.2" size="188MB">
         <description>Mac OS X (Cocoa)</description>
         <file>release/ECLIPSE/helios/SR2/eclipse-rcp-helios-SR2-macosx-cocoa.tar.gz</file>
         <md5>release/ECLIPSE/helios/SR2/eclipse-rcp-helios-SR2-macosx-cocoa.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/helios/SR2/eclipse-rcp-helios-SR2-macosx-cocoa.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="mac" eclipse-version="3.6.2" size="188MB">
         <description>Mac OS X (Cocoa, 64bit)</description>
         <file>release/ECLIPSE/helios/SR2/eclipse-rcp-helios-SR2-macosx-cocoa-x86_64.tar.gz</file>
         <md5>release/ECLIPSE/helios/SR2/eclipse-rcp-helios-SR2-macosx-cocoa-x86_64.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/helios/SR2/eclipse-rcp-helios-SR2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="linux" eclipse-version="3.6.2" size="188MB">
         <description>Linux (GTK)</description>
         <file>release/ECLIPSE/helios/SR2/eclipse-rcp-helios-SR2-linux-gtk.tar.gz</file>
         <md5>release/ECLIPSE/helios/SR2/eclipse-rcp-helios-SR2-linux-gtk.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/helios/SR2/eclipse-rcp-helios-SR2-linux-gtk.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="linux" eclipse-version="3.6.2" size="188MB">
         <description>Linux (GTK, 64bit)</description>
         <file>release/ECLIPSE/helios/SR2/eclipse-rcp-helios-SR2-linux-gtk-x86_64.tar.gz</file>
         <md5>release/ECLIPSE/helios/SR2/eclipse-rcp-helios-SR2-linux-gtk-x86_64.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/helios/SR2/eclipse-rcp-helios-SR2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
     </package>
   </product>
   <product name="Eclipse Galileo Package Downloads (based on Eclipse 3.5.2)">
-    <package name="Eclipse Classic 3.5.2 (Win32, 163MB)" icon="http://www.springsource.org/files/uploads/all/images/product/classic2-nobg.png">
+    <package name="Eclipse Classic 3.5.2 (Win32, 163MB)" icon="https://www.springsource.org/files/uploads/all/images/product/classic2-nobg.png">
       <description><![CDATA[The classic Eclipse download: the Eclipse Platform, Java Development Tools, and Plug-in Development Environment, including source and both user and programmer documentation.]]></description>
       <download os="windows" eclipse-version="3.5.2" size="163MB">
         <description>Windows</description>
         <file>release/ECLIPSE/galileo/SR2/eclipse-SDK-3.5.2-win32.zip</file>
         <md5>release/ECLIPSE/galileo/SR2/eclipse-SDK-3.5.2-win32.zip.md5</md5>
         <sha1>release/ECLIPSE/galileo/SR2/eclipse-SDK-3.5.2-win32.zip.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="windows" eclipse-version="3.5.2" size="163MB">
         <description>Windows (64bit)</description>
         <file>release/ECLIPSE/galileo/SR2/eclipse-SDK-3.5.2-win32-x86_64.zip</file>
         <md5>release/ECLIPSE/galileo/SR2/eclipse-SDK-3.5.2-win32-x86_64.zip.md5</md5>
         <sha1>release/ECLIPSE/galileo/SR2/eclipse-SDK-3.5.2-win32-x86_64.zip.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="mac" eclipse-version="3.5.2" size="162MB">
         <description>Mac OS X (Carbon)</description>
         <file>release/ECLIPSE/galileo/SR2/eclipse-SDK-3.5.2-macosx-carbon.tar.gz</file>
         <md5>release/ECLIPSE/galileo/SR2/eclipse-SDK-3.5.2-macosx-carbon.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/galileo/SR2/eclipse-SDK-3.5.2-macosx-carbon.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="mac" eclipse-version="3.5.2" size="162MB">
         <description>Mac OS X (Cocoa)</description>
         <file>release/ECLIPSE/galileo/SR2/eclipse-SDK-3.5.2-macosx-cocoa.tar.gz</file>
         <md5>release/ECLIPSE/galileo/SR2/eclipse-SDK-3.5.2-macosx-cocoa.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/galileo/SR2/eclipse-SDK-3.5.2-macosx-cocoa.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="mac" eclipse-version="3.5.2" size="162MB">
         <description>Mac OS X (Cocoa, 64bit)</description>
         <file>release/ECLIPSE/galileo/SR2/eclipse-SDK-3.5.2-macosx-cocoa-x86_64.tar.gz</file>
         <md5>release/ECLIPSE/galileo/SR2/eclipse-SDK-3.5.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/galileo/SR2/eclipse-SDK-3.5.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="linux" eclipse-version="3.5.2" size="163MB">
         <description>Linux (GTK)</description>
         <file>release/ECLIPSE/galileo/SR2/eclipse-SDK-3.5.2-linux-gtk.tar.gz</file>
         <md5>release/ECLIPSE/galileo/SR2/eclipse-SDK-3.5.2-linux-gtk.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/galileo/SR2/eclipse-SDK-3.5.2-linux-gtk.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="linux" eclipse-version="3.5.2" size="163MB">
         <description>Linux (GTK, 64bit)</description>
         <file>release/ECLIPSE/galileo/SR2/eclipse-SDK-3.5.2-linux-gtk-x86_64.tar.gz</file>
         <md5>release/ECLIPSE/galileo/SR2/eclipse-SDK-3.5.2-linux-gtk-x86_64.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/galileo/SR2/eclipse-SDK-3.5.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
     </package>
-    <package name="Eclipse IDE for Java EE Developers (Win32, 189MB)" icon="http://www.springsource.org/files/uploads/all/images/product/jee-nobg.png">
+    <package name="Eclipse IDE for Java EE Developers (Win32, 189MB)" icon="https://www.springsource.org/files/uploads/all/images/product/jee-nobg.png">
       <description><![CDATA[Tools for Java developers creating Java EE and Web applications, including a Java IDE, tools for Java EE, JPA, JSF, Mylyn and others.]]></description>
       <download os="windows" eclipse-version="3.5.2" size="190MB">
         <description>Windows</description>
         <file>release/ECLIPSE/galileo/SR2/eclipse-jee-galileo-SR2-win32.zip</file>
         <md5>release/ECLIPSE/galileo/SR2/eclipse-jee-galileo-SR2-win32.zip.md5</md5>
         <sha1>release/ECLIPSE/galileo/SR2/eclipse-jee-galileo-SR2-win32.zip.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="mac" eclipse-version="3.5.2" size="189MB">
         <description>Mac OS X (Carbon)</description>
         <file>release/ECLIPSE/galileo/SR2/eclipse-jee-galileo-SR2-macosx-carbon.tar.gz</file>
         <md5>release/ECLIPSE/galileo/SR2/eclipse-jee-galileo-SR2-macosx-carbon.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/galileo/SR2/eclipse-jee-galileo-SR2-macosx-carbon.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="mac" eclipse-version="3.5.2" size="189MB">
         <description>Mac OS X (Cocoa)</description>
         <file>release/ECLIPSE/galileo/SR2/eclipse-jee-galileo-SR2-macosx-cocoa.tar.gz</file>
         <md5>release/ECLIPSE/galileo/SR2/eclipse-jee-galileo-SR2-macosx-cocoa.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/galileo/SR2/eclipse-jee-galileo-SR2-macosx-cocoa.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="mac" eclipse-version="3.5.2" size="189MB">
         <description>Mac OS X (Cocoa, 64bit)</description>
         <file>release/ECLIPSE/galileo/SR2/eclipse-jee-galileo-SR2-macosx-cocoa-x86_64.tar.gz</file>
         <md5>release/ECLIPSE/galileo/SR2/eclipse-jee-galileo-SR2-macosx-cocoa-x86_64.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/galileo/SR2/eclipse-jee-galileo-SR2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="linux" eclipse-version="3.5.2" size="189MB">
         <description>Linux (GTK)</description>
         <file>release/ECLIPSE/galileo/SR2/eclipse-jee-galileo-SR2-linux-gtk.tar.gz</file>
         <md5>release/ECLIPSE/galileo/SR2/eclipse-jee-galileo-SR2-linux-gtk.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/galileo/SR2/eclipse-jee-galileo-SR2-linux-gtk.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="linux" eclipse-version="3.5.2" size="189MB">
         <description>Linux (GTK, 64bit)</description>
         <file>release/ECLIPSE/galileo/SR2/eclipse-jee-galileo-SR2-linux-gtk-x86_64.tar.gz</file>
         <md5>release/ECLIPSE/galileo/SR2/eclipse-jee-galileo-SR2-linux-gtk-x86_64.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/galileo/SR2/eclipse-jee-galileo-SR2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
     </package>
-    <package name="Eclipse IDE for Java Developers (Win32, 92MB)" icon="http://www.springsource.org/files/uploads/all/images/product/java-nobg.png">
+    <package name="Eclipse IDE for Java Developers (Win32, 92MB)" icon="https://www.springsource.org/files/uploads/all/images/product/java-nobg.png">
       <description><![CDATA[The essential tools for any Java developer, including a Java IDE, a CVS client, XML Editor and Mylyn.]]></description>
       <download os="windows" eclipse-version="3.5.2" size="93MB">
         <description>Windows</description>
         <file>release/ECLIPSE/galileo/SR2/eclipse-java-galileo-SR2-win32.zip</file>
         <md5>release/ECLIPSE/galileo/SR2/eclipse-java-galileo-SR2-win32.zip.md5</md5>
         <sha1>release/ECLIPSE/galileo/SR2/eclipse-java-galileo-SR2-win32.zip.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="mac" eclipse-version="3.5.2" size="92MB">
         <description>Mac OS X (Carbon)</description>
         <file>release/ECLIPSE/galileo/SR2/eclipse-java-galileo-SR2-macosx-carbon.tar.gz</file>
         <md5>release/ECLIPSE/galileo/SR2/eclipse-java-galileo-SR2-macosx-carbon.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/galileo/SR2/eclipse-java-galileo-SR2-macosx-carbon.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="mac" eclipse-version="3.5.2" size="92MB">
         <description>Mac OS X (Cocoa)</description>
         <file>release/ECLIPSE/galileo/SR2/eclipse-java-galileo-SR2-macosx-cocoa.tar.gz</file>
         <md5>release/ECLIPSE/galileo/SR2/eclipse-java-galileo-SR2-macosx-cocoa.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/galileo/SR2/eclipse-java-galileo-SR2-macosx-cocoa.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="mac" eclipse-version="3.5.2" size="92MB">
         <description>Mac OS X (Cocoa, 64bit)</description>
         <file>release/ECLIPSE/galileo/SR2/eclipse-java-galileo-SR2-macosx-cocoa-x86_64.tar.gz</file>
         <md5>release/ECLIPSE/galileo/SR2/eclipse-java-galileo-SR2-macosx-cocoa-x86_64.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/galileo/SR2/eclipse-java-galileo-SR2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="linux" eclipse-version="3.5.2" size="92MB">
         <description>Linux (GTK)</description>
         <file>release/ECLIPSE/galileo/SR2/eclipse-java-galileo-SR2-linux-gtk.tar.gz</file>
         <md5>release/ECLIPSE/galileo/SR2/eclipse-java-galileo-SR2-linux-gtk.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/galileo/SR2/eclipse-java-galileo-SR2-linux-gtk.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="linux" eclipse-version="3.5.2" size="92MB">
         <description>Linux (GTK, 64bit)</description>
         <file>release/ECLIPSE/galileo/SR2/eclipse-java-galileo-SR2-linux-gtk-x86_64.tar.gz</file>
         <md5>release/ECLIPSE/galileo/SR2/eclipse-java-galileo-SR2-linux-gtk-x86_64.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/galileo/SR2/eclipse-java-galileo-SR2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
     </package>
-    <package name="Eclipse RCP/Plug-in Developers (Win32, 183MB)" icon="http://www.springsource.org/files/uploads/all/images/product/rcp-nobg.png">
+    <package name="Eclipse RCP/Plug-in Developers (Win32, 183MB)" icon="https://www.springsource.org/files/uploads/all/images/product/rcp-nobg.png">
       <description><![CDATA[A complete set of tools for developers who want to create Eclipse plug-ins or Rich Client Applications. It includes a complete SDK, developer tools and source code, plus Mylyn, an XML editor and the Eclipse Communication Framework.]]></description>
       <download os="windows" eclipse-version="3.5.2" size="184MB">
         <description>Windows</description>
         <file>release/ECLIPSE/galileo/SR2/eclipse-rcp-galileo-SR2-win32.zip</file>
         <md5>release/ECLIPSE/galileo/SR2/eclipse-rcp-galileo-SR2-win32.zip.md5</md5>
         <sha1>release/ECLIPSE/galileo/SR2/eclipse-rcp-galileo-SR2-win32.zip.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="mac" eclipse-version="3.5.2" size="183MB">
         <description>Mac OS X (Carbon)</description>
         <file>release/ECLIPSE/galileo/SR2/eclipse-rcp-galileo-SR2-macosx-carbon.tar.gz</file>
         <md5>release/ECLIPSE/galileo/SR2/eclipse-rcp-galileo-SR2-macosx-carbon.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/galileo/SR2/eclipse-rcp-galileo-SR2-macosx-carbon.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="mac" eclipse-version="3.5.2" size="183MB">
         <description>Mac OS X (Cocoa)</description>
         <file>release/ECLIPSE/galileo/SR2/eclipse-rcp-galileo-SR2-macosx-cocoa.tar.gz</file>
         <md5>release/ECLIPSE/galileo/SR2/eclipse-rcp-galileo-SR2-macosx-cocoa.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/galileo/SR2/eclipse-rcp-galileo-SR2-macosx-cocoa.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="mac" eclipse-version="3.5.2" size="183MB">
         <description>Mac OS X (Cocoa, 64bit)</description>
         <file>release/ECLIPSE/galileo/SR2/eclipse-rcp-galileo-SR2-macosx-cocoa-x86_64.tar.gz</file>
         <md5>release/ECLIPSE/galileo/SR2/eclipse-rcp-galileo-SR2-macosx-cocoa-x86_64.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/galileo/SR2/eclipse-rcp-galileo-SR2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="linux" eclipse-version="3.5.2" size="183MB">
         <description>Linux (GTK)</description>
         <file>release/ECLIPSE/galileo/SR2/eclipse-rcp-galileo-SR2-linux-gtk.tar.gz</file>
         <md5>release/ECLIPSE/galileo/SR2/eclipse-rcp-galileo-SR2-linux-gtk.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/galileo/SR2/eclipse-rcp-galileo-SR2-linux-gtk.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
       <download os="linux" eclipse-version="3.5.2" size="183MB">
         <description>Linux (GTK, 64bit)</description>
         <file>release/ECLIPSE/galileo/SR2/eclipse-rcp-galileo-SR2-linux-gtk-x86_64.tar.gz</file>
         <md5>release/ECLIPSE/galileo/SR2/eclipse-rcp-galileo-SR2-linux-gtk-x86_64.tar.gz.md5</md5>
         <sha1>release/ECLIPSE/galileo/SR2/eclipse-rcp-galileo-SR2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-        <bucket>http://download.springsource.com/</bucket>
+        <bucket>https://download.springsource.com/</bucket>
       </download>
     </package>
   </product>

--- a/sagan-common/src/test-util/resources/fixtures/tools/sts_downloads.xml
+++ b/sagan-common/src/test-util/resources/fixtures/tools/sts_downloads.xml
@@ -1,55 +1,55 @@
 
 <downloads>
     <!-- Fake milestones for test purposes -->
-    <release name="Milestone Version - Spring Tool Suite 3.7.0.M1 - based on Eclipse Luna 4.4" whatsnew="http://static.springsource.org/sts/nan/v370/NewAndNoteworthy.html">
+    <release name="Milestone Version - Spring Tool Suite 3.7.0.M1 - based on Eclipse Luna 4.4" whatsnew="https://docs.spring.io/sts/nan/v370/NewAndNoteworthy.html">
         <download os="windows" version="3.7.0.M1" eclipse-version="4.4" size="369MB">
             <description>Windows</description>
             <file>milestone/STS/3.7.0.M1/dist/e4.4/spring-tool-suite-3.7.0.M1-e4.4-win32.zip</file>
             <md5>milestone/STS/3.7.0.M1/dist/e4.4/spring-tool-suite-3.7.0.M1-e4.4-win32.zip.md5</md5>
             <sha1>milestone/STS/3.7.0.M1/dist/e4.4/spring-tool-suite-3.7.0.M1-e4.4-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.7.0.M1" eclipse-version="4.4" size="369MB">
             <description>Windows (64bit)</description>
             <file>milestone/STS/3.7.0.M1/dist/e4.4/spring-tool-suite-3.7.0.M1-e4.4-win32-x86_64.zip</file>
             <md5>milestone/STS/3.7.0.M1/dist/e4.4/spring-tool-suite-3.7.0.M1-e4.4-win32-x86_64.zip.md5</md5>
             <sha1>milestone/STS/3.7.0.M1/dist/e4.4/spring-tool-suite-3.7.0.M1-e4.4-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.7.0.M1" eclipse-version="4.4" size="366MB">
             <description>Mac OS X (Cocoa)</description>
             <file>milestone/STS/3.7.0.M1/dist/e4.4/spring-tool-suite-3.7.0.M1-e4.4-macosx-cocoa.tar.gz</file>
             <md5>milestone/STS/3.7.0.M1/dist/e4.4/spring-tool-suite-3.7.0.M1-e4.4-macosx-cocoa.tar.gz.md5</md5>
             <sha1>milestone/STS/3.7.0.M1/dist/e4.4/spring-tool-suite-3.7.0.M1-e4.4-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.7.0.M1" eclipse-version="4.4" size="366MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>milestone/STS/3.7.0.M1/dist/e4.4/spring-tool-suite-3.7.0.M1-e4.4-macosx-cocoa-x86_64.tar.gz</file>
             <md5>milestone/STS/3.7.0.M1/dist/e4.4/spring-tool-suite-3.7.0.M1-e4.4-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>milestone/STS/3.7.0.M1/dist/e4.4/spring-tool-suite-3.7.0.M1-e4.4-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.7.0.M1" eclipse-version="4.4" size="366MB">
             <description>Linux (GTK)</description>
             <file>milestone/STS/3.7.0.M1/dist/e4.4/spring-tool-suite-3.7.0.M1-e4.4-linux-gtk.tar.gz</file>
             <md5>milestone/STS/3.7.0.M1/dist/e4.4/spring-tool-suite-3.7.0.M1-e4.4-linux-gtk.tar.gz.md5</md5>
             <sha1>milestone/STS/3.7.0.M1/dist/e4.4/spring-tool-suite-3.7.0.M1-e4.4-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.7.0.M1" eclipse-version="4.4" size="366MB">
             <description>Linux (GTK, 64bit)</description>
             <file>milestone/STS/3.7.0.M1/dist/e4.4/spring-tool-suite-3.7.0.M1-e4.4-linux-gtk-x86_64.tar.gz</file>
             <md5>milestone/STS/3.7.0.M1/dist/e4.4/spring-tool-suite-3.7.0.M1-e4.4-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>milestone/STS/3.7.0.M1/dist/e4.4/spring-tool-suite-3.7.0.M1-e4.4-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.7.0.M1" eclipse-version="4.3.x" size="178MB">
             <description>Update Site</description>
             <file>milestone/TOOLS/update/3.7.0.M1/e4.3/springsource-tool-suite-3.7.0.M1-e4.3-updatesite.zip</file>
             <md5>milestone/TOOLS/update/3.7.0.M1/e4.3/springsource-tool-suite-3.7.0.M1-e4.3-updatesite.zip.md5</md5>
             <sha1>milestone/TOOLS/update/3.7.0.M1/e4.3/springsource-tool-suite-3.7.0.M1-e4.3-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </release>
     <release name="Milestone Version - Groovy/Grails Tool Suite 3.7.0.M1 - based on Eclipse Luna 4.4">
@@ -58,5053 +58,5053 @@
             <file>milestone/STS/3.7.0.M1/dist/e4.4/groovy-grails-tool-suite-3.7.0.M1-e4.4-win32.zip</file>
             <md5>milestone/STS/3.7.0.M1/dist/e4.4/groovy-grails-tool-suite-3.7.0.M1-e4.4.2-win32.zip.md5</md5>
             <sha1>milestone/STS/3.7.0.M1/dist/e4.4/groovy-grails-tool-suite-3.7.0.M1-e4.4.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.7.0.M1" eclipse-version="4.4" size="369MB">
             <description>Windows (64bit)</description>
             <file>milestone/STS/3.7.0.M1/dist/e4.4/groovy-grails-tool-suite-3.7.0.M1-e4.4.2-win32-x86_64.zip</file>
             <md5>milestone/STS/3.7.0.M1/dist/e4.4/groovy-grails-tool-suite-3.7.0.M1-e4.4.2-win32-x86_64.zip.md5</md5>
             <sha1>milestone/STS/3.7.0.M1/dist/e4.4/groovy-grails-tool-suite-3.7.0.M1-e4.4.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.7.0.M1" eclipse-version="4.4" size="366MB">
             <description>Mac OS X (Cocoa)</description>
             <file>milestone/STS/3.7.0.M1/dist/e4.4/groovy-grails-tool-suite-3.7.0.M1-e4.4.2-macosx-cocoa.tar.gz</file>
             <md5>milestone/STS/3.7.0.M1/dist/e4.4/groovy-grails-tool-suite-3.7.0.M1-e4.4.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>milestone/STS/3.7.0.M1/dist/e4.4/groovy-grails-tool-suite-3.7.0.M1-e4.4.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.7.0.M1" eclipse-version="4.4" size="366MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>milestone/STS/3.7.0.M1/dist/e4.4/groovy-grails-tool-suite-3.7.0.M1-e4.4.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>milestone/STS/3.7.0.M1/dist/e4.4/groovy-grails-tool-suite-3.7.0.M1-e4.4.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>milestone/STS/3.7.0.M1/dist/e4.4/groovy-grails-tool-suite-3.7.0.M1-e4.4.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.7.0.M1" eclipse-version="4.4" size="366MB">
             <description>Linux (GTK)</description>
             <file>milestone/STS/3.7.0.M1/dist/e4.4/groovy-grails-tool-suite-3.7.0.M1-e4.4.2-linux-gtk.tar.gz</file>
             <md5>milestone/STS/3.7.0.M1/dist/e4.4/groovy-grails-tool-suite-3.7.0.M1-e4.4.2-linux-gtk.tar.gz.md5</md5>
             <sha1>milestone/STS/3.7.0.M1/dist/e4.4/groovy-grails-tool-suite-3.7.0.M1-e4.4.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.7.0.M1" eclipse-version="4.4" size="366MB">
             <description>Linux (GTK, 64bit)</description>
             <file>milestone/STS/3.7.0.M1/dist/e4.4/groovy-grails-tool-suite-3.7.0.M1-e4.4.2-linux-gtk-x86_64.tar.gz</file>
             <md5>milestone/STS/3.7.0.M1/dist/e4.4/groovy-grails-tool-suite-3.7.0.M1-e4.4.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>milestone/STS/3.7.0.M1/dist/e4.4/groovy-grails-tool-suite-3.7.0.M1-e4.4.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.7.0.M1" eclipse-version="4.4" size="178MB">
             <description>Update Site</description>
             <file>milestone/TOOLS/update/3.7.0.M1/e4.4/springsource-tool-suite-3.7.0.M1-e4.4-updatesite.zip</file>
             <md5>milestone/TOOLS/update/3.7.0.M1/e4.4/springsource-tool-suite-3.7.0.M1-e4.4-updatesite.zip.md5</md5>
             <sha1>milestone/TOOLS/update/3.7.0.M1/e4.4/springsource-tool-suite-3.7.0.M1-e4.4-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </release>
-    <release name="Spring Tool Suite 3.6.0.RELEASE - based on Eclipse Luna 4.4" whatsnew="http://static.springsource.org/sts/nan/v360/NewAndNoteworthy.html">
+    <release name="Spring Tool Suite 3.6.0.RELEASE - based on Eclipse Luna 4.4" whatsnew="https://docs.spring.io/sts/nan/v360/NewAndNoteworthy.html">
         <download os="windows" version="3.6.0.RELEASE" eclipse-version="4.4" size="368MB">
             <description>Windows</description>
             <file>release/STS/3.6.0/dist/e4.4/spring-tool-suite-3.6.0.RELEASE-e4.4-win32.zip</file>
             <md5>release/STS/3.6.0/dist/e4.4/spring-tool-suite-3.6.0.RELEASE-e4.4-win32.zip.md5</md5>
             <sha1>release/STS/3.6.0/dist/e4.4/spring-tool-suite-3.6.0.RELEASE-e4.4-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.6.0.RELEASE" eclipse-version="4.4" size="368MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.6.0/dist/e4.4/spring-tool-suite-3.6.0.RELEASE-e4.4-win32-x86_64.zip</file>
             <md5>release/STS/3.6.0/dist/e4.4/spring-tool-suite-3.6.0.RELEASE-e4.4-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/3.6.0/dist/e4.4/spring-tool-suite-3.6.0.RELEASE-e4.4-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.6.0.RELEASE" eclipse-version="4.4" size="365MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.6.0/dist/e4.4/spring-tool-suite-3.6.0.RELEASE-e4.4-macosx-cocoa.tar.gz</file>
             <md5>release/STS/3.6.0/dist/e4.4/spring-tool-suite-3.6.0.RELEASE-e4.4-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/3.6.0/dist/e4.4/spring-tool-suite-3.6.0.RELEASE-e4.4-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.6.0.RELEASE" eclipse-version="4.4" size="365MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.6.0/dist/e4.4/spring-tool-suite-3.6.0.RELEASE-e4.4-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/3.6.0/dist/e4.4/spring-tool-suite-3.6.0.RELEASE-e4.4-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.6.0/dist/e4.4/spring-tool-suite-3.6.0.RELEASE-e4.4-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.6.0.RELEASE" eclipse-version="4.4" size="365MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.6.0/dist/e4.4/spring-tool-suite-3.6.0.RELEASE-e4.4-linux-gtk.tar.gz</file>
             <md5>release/STS/3.6.0/dist/e4.4/spring-tool-suite-3.6.0.RELEASE-e4.4-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/3.6.0/dist/e4.4/spring-tool-suite-3.6.0.RELEASE-e4.4-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.6.0.RELEASE" eclipse-version="4.4" size="366MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.6.0/dist/e4.4/spring-tool-suite-3.6.0.RELEASE-e4.4-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/3.6.0/dist/e4.4/spring-tool-suite-3.6.0.RELEASE-e4.4-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.6.0/dist/e4.4/spring-tool-suite-3.6.0.RELEASE-e4.4-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.6.0.RELEASE" eclipse-version="4.4" size="123MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.6.0.RELEASE/e4.4/springsource-tool-suite-3.6.0.RELEASE-e4.4-updatesite.zip</file>
             <md5>release/TOOLS/update/3.6.0.RELEASE/e4.4/springsource-tool-suite-3.6.0.RELEASE-e4.4-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.6.0.RELEASE/e4.4/springsource-tool-suite-3.6.0.RELEASE-e4.4-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.6.0.RELEASE" eclipse-version="4.3.2" size="141MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.6.0.RELEASE/e4.3/springsource-tool-suite-3.6.0.RELEASE-e4.3.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.6.0.RELEASE/e4.3/springsource-tool-suite-3.6.0.RELEASE-e4.3.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.6.0.RELEASE/e4.3/springsource-tool-suite-3.6.0.RELEASE-e4.3.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.6.0.RELEASE" eclipse-version="4.2.2" size="121MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.6.0.RELEASE/e4.2/springsource-tool-suite-3.6.0.RELEASE-e4.2.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.6.0.RELEASE/e4.2/springsource-tool-suite-3.6.0.RELEASE-e4.2.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.6.0.RELEASE/e4.2/springsource-tool-suite-3.6.0.RELEASE-e4.2.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.6.0.RELEASE" eclipse-version="3.8.2" size="121MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.6.0.RELEASE/e3.8/springsource-tool-suite-3.6.0.RELEASE-e3.8.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.6.0.RELEASE/e3.8/springsource-tool-suite-3.6.0.RELEASE-e3.8.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.6.0.RELEASE/e3.8/springsource-tool-suite-3.6.0.RELEASE-e3.8.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.6.0.RELEASE" eclipse-version="3.7.2" size="123MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.6.0.RELEASE/e3.7/springsource-tool-suite-3.6.0.RELEASE-e3.7.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.6.0.RELEASE/e3.7/springsource-tool-suite-3.6.0.RELEASE-e3.7.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.6.0.RELEASE/e3.7/springsource-tool-suite-3.6.0.RELEASE-e3.7.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </release>
-    <release name="Groovy/Grails Tool Suite 3.6.0.RELEASE - based on Eclipse Luna 4.4" whatsnew="http://static.springsource.org/sts/nan/v360/NewAndNoteworthy.html">
+    <release name="Groovy/Grails Tool Suite 3.6.0.RELEASE - based on Eclipse Luna 4.4" whatsnew="https://docs.spring.io/sts/nan/v360/NewAndNoteworthy.html">
         <download os="windows" version="3.6.0.RELEASE" eclipse-version="4.4" size="500MB">
             <description>Windows</description>
             <file>release/STS/3.6.0/dist/e4.4/groovy-grails-tool-suite-3.6.0.RELEASE-e4.4-win32.zip</file>
             <md5>release/STS/3.6.0/dist/e4.4/groovy-grails-tool-suite-3.6.0.RELEASE-e4.4-win32.zip.md5</md5>
             <sha1>release/STS/3.6.0/dist/e4.4/groovy-grails-tool-suite-3.6.0.RELEASE-e4.4-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.6.0.RELEASE" eclipse-version="4.4" size="500MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.6.0/dist/e4.4/groovy-grails-tool-suite-3.6.0.RELEASE-e4.4-win32-x86_64.zip</file>
             <md5>release/STS/3.6.0/dist/e4.4/groovy-grails-tool-suite-3.6.0.RELEASE-e4.4-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/3.6.0/dist/e4.4/groovy-grails-tool-suite-3.6.0.RELEASE-e4.4-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.6.0.RELEASE" eclipse-version="4.4" size="494MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.6.0/dist/e4.4/groovy-grails-tool-suite-3.6.0.RELEASE-e4.4-macosx-cocoa.tar.gz</file>
             <md5>release/STS/3.6.0/dist/e4.4/groovy-grails-tool-suite-3.6.0.RELEASE-e4.4-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/3.6.0/dist/e4.4/groovy-grails-tool-suite-3.6.0.RELEASE-e4.4-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.6.0.RELEASE" eclipse-version="4.4" size="494MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.6.0/dist/e4.4/groovy-grails-tool-suite-3.6.0.RELEASE-e4.4-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/3.6.0/dist/e4.4/groovy-grails-tool-suite-3.6.0.RELEASE-e4.4-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.6.0/dist/e4.4/groovy-grails-tool-suite-3.6.0.RELEASE-e4.4-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.6.0.RELEASE" eclipse-version="4.4" size="494MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.6.0/dist/e4.4/groovy-grails-tool-suite-3.6.0.RELEASE-e4.4-linux-gtk.tar.gz</file>
             <md5>release/STS/3.6.0/dist/e4.4/groovy-grails-tool-suite-3.6.0.RELEASE-e4.4-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/3.6.0/dist/e4.4/groovy-grails-tool-suite-3.6.0.RELEASE-e4.4-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.6.0.RELEASE" eclipse-version="4.4" size="494MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.6.0/dist/e4.4/groovy-grails-tool-suite-3.6.0.RELEASE-e4.4-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/3.6.0/dist/e4.4/groovy-grails-tool-suite-3.6.0.RELEASE-e4.4-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.6.0/dist/e4.4/groovy-grails-tool-suite-3.6.0.RELEASE-e4.4-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.6.0.RELEASE" eclipse-version="4.4" size="123MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.6.0.RELEASE/e4.4/springsource-tool-suite-3.6.0.RELEASE-e4.4-updatesite.zip</file>
             <md5>release/TOOLS/update/3.6.0.RELEASE/e4.4/springsource-tool-suite-3.6.0.RELEASE-e4.4-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.6.0.RELEASE/e4.4/springsource-tool-suite-3.6.0.RELEASE-e4.4-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.6.0.RELEASE" eclipse-version="4.3.2" size="141MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.6.0.RELEASE/e4.3/springsource-tool-suite-3.6.0.RELEASE-e4.3.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.6.0.RELEASE/e4.3/springsource-tool-suite-3.6.0.RELEASE-e4.3.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.6.0.RELEASE/e4.3/springsource-tool-suite-3.6.0.RELEASE-e4.3.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.6.0.RELEASE" eclipse-version="4.2.2" size="121MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.6.0.RELEASE/e4.2/springsource-tool-suite-3.6.0.RELEASE-e4.2.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.6.0.RELEASE/e4.2/springsource-tool-suite-3.6.0.RELEASE-e4.2.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.6.0.RELEASE/e4.2/springsource-tool-suite-3.6.0.RELEASE-e4.2.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.6.0.RELEASE" eclipse-version="3.8.2" size="121MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.6.0.RELEASE/e3.8/springsource-tool-suite-3.6.0.RELEASE-e3.8.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.6.0.RELEASE/e3.8/springsource-tool-suite-3.6.0.RELEASE-e3.8.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.6.0.RELEASE/e3.8/springsource-tool-suite-3.6.0.RELEASE-e3.8.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.6.0.RELEASE" eclipse-version="3.7.2" size="123MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.6.0.RELEASE/e3.7/springsource-tool-suite-3.6.0.RELEASE-e3.7.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.6.0.RELEASE/e3.7/springsource-tool-suite-3.6.0.RELEASE-e3.7.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.6.0.RELEASE/e3.7/springsource-tool-suite-3.6.0.RELEASE-e3.7.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </release>
-    <other name="Spring Tool Suite 3.5.1.RELEASE - based on Eclipse Kepler 4.3.2" whatsnew="http://static.springsource.org/sts/nan/v351/NewAndNoteworthy.html">
+    <other name="Spring Tool Suite 3.5.1.RELEASE - based on Eclipse Kepler 4.3.2" whatsnew="https://docs.spring.io/sts/nan/v351/NewAndNoteworthy.html">
         <download os="windows" version="3.5.1.RELEASE" eclipse-version="4.3.2" size="361MB">
             <description>Windows</description>
             <file>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-win32-installer.exe</file>
             <md5>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.5.1.RELEASE" eclipse-version="4.3.2" size="360MB">
             <description>Windows</description>
             <file>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-win32.zip</file>
             <md5>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-win32.zip.md5</md5>
             <sha1>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.5.1.RELEASE" eclipse-version="4.3.2" size="361MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.5.1.RELEASE" eclipse-version="4.3.2" size="360MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-win32-x86_64.zip</file>
             <md5>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.1.RELEASE" eclipse-version="4.3.2" size="361MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.1.RELEASE" eclipse-version="4.3.2" size="357MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.1.RELEASE" eclipse-version="4.3.2" size="361MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.1.RELEASE" eclipse-version="4.3.2" size="357MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.1.RELEASE" eclipse-version="4.3.2" size="360MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-linux-gtk-installer.sh</file>
             <md5>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.1.RELEASE" eclipse-version="4.3.2" size="357MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-linux-gtk.tar.gz</file>
             <md5>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.1.RELEASE" eclipse-version="4.3.2" size="361MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.1.RELEASE" eclipse-version="4.3.2" size="357MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.1.RELEASE" eclipse-version="4.4" size="123MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.1.RELEASE/e4.4/springsource-tool-suite-3.5.1.RELEASE-e4.4-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.1.RELEASE/e4.4/springsource-tool-suite-3.5.1.RELEASE-e4.4-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.1.RELEASE/e4.4/springsource-tool-suite-3.5.1.RELEASE-e4.4-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.1.RELEASE" eclipse-version="4.3.2" size="141MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.1.RELEASE/e4.3/springsource-tool-suite-3.5.1.RELEASE-e4.3.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.1.RELEASE/e4.3/springsource-tool-suite-3.5.1.RELEASE-e4.3.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.1.RELEASE/e4.3/springsource-tool-suite-3.5.1.RELEASE-e4.3.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.1.RELEASE" eclipse-version="4.2.2" size="121MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.1.RELEASE/e4.2/springsource-tool-suite-3.5.1.RELEASE-e4.2.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.1.RELEASE/e4.2/springsource-tool-suite-3.5.1.RELEASE-e4.2.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.1.RELEASE/e4.2/springsource-tool-suite-3.5.1.RELEASE-e4.2.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.1.RELEASE" eclipse-version="3.8.2" size="121MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.1.RELEASE/e3.8/springsource-tool-suite-3.5.1.RELEASE-e3.8.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.1.RELEASE/e3.8/springsource-tool-suite-3.5.1.RELEASE-e3.8.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.1.RELEASE/e3.8/springsource-tool-suite-3.5.1.RELEASE-e3.8.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.1.RELEASE" eclipse-version="3.7.2" size="123MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.1.RELEASE/e3.7/springsource-tool-suite-3.5.1.RELEASE-e3.7.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.1.RELEASE/e3.7/springsource-tool-suite-3.5.1.RELEASE-e3.7.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.1.RELEASE/e3.7/springsource-tool-suite-3.5.1.RELEASE-e3.7.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Groovy/Grails Tool Suite 3.5.1.RELEASE - based on Eclipse Kepler 4.3.2" whatsnew="http://static.springsource.org/sts/nan/v351/NewAndNoteworthy.html">
+    <other name="Groovy/Grails Tool Suite 3.5.1.RELEASE - based on Eclipse Kepler 4.3.2" whatsnew="https://docs.spring.io/sts/nan/v351/NewAndNoteworthy.html">
         <download os="windows" version="3.5.1.RELEASE" eclipse-version="4.3.2" size="486MB">
             <description>Windows</description>
             <file>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-win32-installer.exe</file>
             <md5>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.5.1.RELEASE" eclipse-version="4.3.2" size="487MB">
             <description>Windows</description>
             <file>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-win32.zip</file>
             <md5>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-win32.zip.md5</md5>
             <sha1>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.5.1.RELEASE" eclipse-version="4.3.2" size="486MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.5.1.RELEASE" eclipse-version="4.3.2" size="487MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-win32-x86_64.zip</file>
             <md5>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.1.RELEASE" eclipse-version="4.3.2" size="486MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.1.RELEASE" eclipse-version="4.3.2" size="481MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.1.RELEASE" eclipse-version="4.3.2" size="486MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.1.RELEASE" eclipse-version="4.3.2" size="481MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.1.RELEASE" eclipse-version="4.3.2" size="486MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-linux-gtk-installer.sh</file>
             <md5>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.1.RELEASE" eclipse-version="4.3.2" size="481MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-linux-gtk.tar.gz</file>
             <md5>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.1.RELEASE" eclipse-version="4.3.2" size="486MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.1.RELEASE" eclipse-version="4.3.2" size="481MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.1.RELEASE" eclipse-version="4.4" size="123MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.1.RELEASE/e4.4/springsource-tool-suite-3.5.1.RELEASE-e4.4-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.1.RELEASE/e4.4/springsource-tool-suite-3.5.1.RELEASE-e4.4-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.1.RELEASE/e4.4/springsource-tool-suite-3.5.1.RELEASE-e4.4-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.1.RELEASE" eclipse-version="4.3.2" size="141MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.1.RELEASE/e4.3/springsource-tool-suite-3.5.1.RELEASE-e4.3.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.1.RELEASE/e4.3/springsource-tool-suite-3.5.1.RELEASE-e4.3.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.1.RELEASE/e4.3/springsource-tool-suite-3.5.1.RELEASE-e4.3.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.1.RELEASE" eclipse-version="4.2.2" size="121MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.1.RELEASE/e4.2/springsource-tool-suite-3.5.1.RELEASE-e4.2.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.1.RELEASE/e4.2/springsource-tool-suite-3.5.1.RELEASE-e4.2.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.1.RELEASE/e4.2/springsource-tool-suite-3.5.1.RELEASE-e4.2.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.1.RELEASE" eclipse-version="3.8.2" size="121MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.1.RELEASE/e3.8/springsource-tool-suite-3.5.1.RELEASE-e3.8.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.1.RELEASE/e3.8/springsource-tool-suite-3.5.1.RELEASE-e3.8.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.1.RELEASE/e3.8/springsource-tool-suite-3.5.1.RELEASE-e3.8.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.1.RELEASE" eclipse-version="3.7.2" size="123MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.1.RELEASE/e3.7/springsource-tool-suite-3.5.1.RELEASE-e3.7.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.1.RELEASE/e3.7/springsource-tool-suite-3.5.1.RELEASE-e3.7.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.1.RELEASE/e3.7/springsource-tool-suite-3.5.1.RELEASE-e3.7.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Spring Tool Suite 3.5.1.RELEASE - based on Eclipse Juno 3.8.2" whatsnew="http://static.springsource.org/sts/nan/v351/NewAndNoteworthy.html">
+    <other name="Spring Tool Suite 3.5.1.RELEASE - based on Eclipse Juno 3.8.2" whatsnew="https://docs.spring.io/sts/nan/v351/NewAndNoteworthy.html">
         <download os="windows" version="3.5.1.RELEASE" eclipse-version="3.8.2" size="349MB">
             <description>Windows</description>
             <file>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-win32-installer.exe</file>
             <md5>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.5.1.RELEASE" eclipse-version="3.8.2" size="348MB">
             <description>Windows</description>
             <file>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-win32.zip</file>
             <md5>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-win32.zip.md5</md5>
             <sha1>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.5.1.RELEASE" eclipse-version="3.8.2" size="349MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.5.1.RELEASE" eclipse-version="3.8.2" size="348MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-win32-x86_64.zip</file>
             <md5>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.1.RELEASE" eclipse-version="3.8.2" size="349MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.1.RELEASE" eclipse-version="3.8.2" size="345MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.1.RELEASE" eclipse-version="3.8.2" size="349MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.1.RELEASE" eclipse-version="3.8.2" size="345MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.1.RELEASE" eclipse-version="3.8.2" size="348MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-linux-gtk-installer.sh</file>
             <md5>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.1.RELEASE" eclipse-version="3.8.2" size="345MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-linux-gtk.tar.gz</file>
             <md5>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.1.RELEASE" eclipse-version="3.8.2" size="349MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.1.RELEASE" eclipse-version="3.8.2" size="346MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.1.RELEASE" eclipse-version="4.4" size="123MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.1.RELEASE/e4.4/springsource-tool-suite-3.5.1.RELEASE-e4.4-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.1.RELEASE/e4.4/springsource-tool-suite-3.5.1.RELEASE-e4.4-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.1.RELEASE/e4.4/springsource-tool-suite-3.5.1.RELEASE-e4.4-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.1.RELEASE" eclipse-version="4.3.2" size="141MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.1.RELEASE/e4.3/springsource-tool-suite-3.5.1.RELEASE-e4.3.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.1.RELEASE/e4.3/springsource-tool-suite-3.5.1.RELEASE-e4.3.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.1.RELEASE/e4.3/springsource-tool-suite-3.5.1.RELEASE-e4.3.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.1.RELEASE" eclipse-version="4.2.2" size="121MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.1.RELEASE/e4.2/springsource-tool-suite-3.5.1.RELEASE-e4.2.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.1.RELEASE/e4.2/springsource-tool-suite-3.5.1.RELEASE-e4.2.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.1.RELEASE/e4.2/springsource-tool-suite-3.5.1.RELEASE-e4.2.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.1.RELEASE" eclipse-version="3.8.2" size="121MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.1.RELEASE/e3.8/springsource-tool-suite-3.5.1.RELEASE-e3.8.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.1.RELEASE/e3.8/springsource-tool-suite-3.5.1.RELEASE-e3.8.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.1.RELEASE/e3.8/springsource-tool-suite-3.5.1.RELEASE-e3.8.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.1.RELEASE" eclipse-version="3.7.2" size="123MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.1.RELEASE/e3.7/springsource-tool-suite-3.5.1.RELEASE-e3.7.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.1.RELEASE/e3.7/springsource-tool-suite-3.5.1.RELEASE-e3.7.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.1.RELEASE/e3.7/springsource-tool-suite-3.5.1.RELEASE-e3.7.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Groovy/Grails Tool Suite 3.5.1.RELEASE - based on Eclipse Juno 3.8.2" whatsnew="http://static.springsource.org/sts/nan/v351/NewAndNoteworthy.html">
+    <other name="Groovy/Grails Tool Suite 3.5.1.RELEASE - based on Eclipse Juno 3.8.2" whatsnew="https://docs.spring.io/sts/nan/v351/NewAndNoteworthy.html">
         <download os="windows" version="3.5.1.RELEASE" eclipse-version="3.8.2" size="474MB">
             <description>Windows</description>
             <file>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-win32-installer.exe</file>
             <md5>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.5.1.RELEASE" eclipse-version="3.8.2" size="475MB">
             <description>Windows</description>
             <file>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-win32.zip</file>
             <md5>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-win32.zip.md5</md5>
             <sha1>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.5.1.RELEASE" eclipse-version="3.8.2" size="474MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.5.1.RELEASE" eclipse-version="3.8.2" size="475MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-win32-x86_64.zip</file>
             <md5>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.1.RELEASE" eclipse-version="3.8.2" size="474MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.1.RELEASE" eclipse-version="3.8.2" size="469MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.1.RELEASE" eclipse-version="3.8.2" size="474MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.1.RELEASE" eclipse-version="3.8.2" size="469MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.1.RELEASE" eclipse-version="3.8.2" size="474MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-linux-gtk-installer.sh</file>
             <md5>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.1.RELEASE" eclipse-version="3.8.2" size="469MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-linux-gtk.tar.gz</file>
             <md5>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.1.RELEASE" eclipse-version="3.8.2" size="474MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.1.RELEASE" eclipse-version="3.8.2" size="469MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.1.RELEASE" eclipse-version="4.4" size="123MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.1.RELEASE/e4.4/springsource-tool-suite-3.5.1.RELEASE-e4.4-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.1.RELEASE/e4.4/springsource-tool-suite-3.5.1.RELEASE-e4.4-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.1.RELEASE/e4.4/springsource-tool-suite-3.5.1.RELEASE-e4.4-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.1.RELEASE" eclipse-version="4.3.2" size="141MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.1.RELEASE/e4.3/springsource-tool-suite-3.5.1.RELEASE-e4.3.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.1.RELEASE/e4.3/springsource-tool-suite-3.5.1.RELEASE-e4.3.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.1.RELEASE/e4.3/springsource-tool-suite-3.5.1.RELEASE-e4.3.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.1.RELEASE" eclipse-version="4.2.2" size="121MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.1.RELEASE/e4.2/springsource-tool-suite-3.5.1.RELEASE-e4.2.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.1.RELEASE/e4.2/springsource-tool-suite-3.5.1.RELEASE-e4.2.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.1.RELEASE/e4.2/springsource-tool-suite-3.5.1.RELEASE-e4.2.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.1.RELEASE" eclipse-version="3.8.2" size="121MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.1.RELEASE/e3.8/springsource-tool-suite-3.5.1.RELEASE-e3.8.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.1.RELEASE/e3.8/springsource-tool-suite-3.5.1.RELEASE-e3.8.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.1.RELEASE/e3.8/springsource-tool-suite-3.5.1.RELEASE-e3.8.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.1.RELEASE" eclipse-version="3.7.2" size="123MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.1.RELEASE/e3.7/springsource-tool-suite-3.5.1.RELEASE-e3.7.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.1.RELEASE/e3.7/springsource-tool-suite-3.5.1.RELEASE-e3.7.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.1.RELEASE/e3.7/springsource-tool-suite-3.5.1.RELEASE-e3.7.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Spring Tool Suite 3.5.0.RELEASE - based on Eclipse Kepler 4.3.2" whatsnew="http://static.springsource.org/sts/nan/v350/NewAndNoteworthy.html">
+    <other name="Spring Tool Suite 3.5.0.RELEASE - based on Eclipse Kepler 4.3.2" whatsnew="https://docs.spring.io/sts/nan/v350/NewAndNoteworthy.html">
         <download os="windows" version="3.5.0.RELEASE" eclipse-version="4.3.2" size="361MB">
             <description>Windows</description>
             <file>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-win32-installer.exe</file>
             <md5>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.5.0.RELEASE" eclipse-version="4.3.2" size="360MB">
             <description>Windows</description>
             <file>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-win32.zip</file>
             <md5>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-win32.zip.md5</md5>
             <sha1>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.5.0.RELEASE" eclipse-version="4.3.2" size="361MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.5.0.RELEASE" eclipse-version="4.3.2" size="360MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-win32-x86_64.zip</file>
             <md5>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.0.RELEASE" eclipse-version="4.3.2" size="361MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.0.RELEASE" eclipse-version="4.3.2" size="358MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.0.RELEASE" eclipse-version="4.3.2" size="361MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.0.RELEASE" eclipse-version="4.3.2" size="358MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.0.RELEASE" eclipse-version="4.3.2" size="361MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-linux-gtk-installer.sh</file>
             <md5>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.0.RELEASE" eclipse-version="4.3.2" size="358MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-linux-gtk.tar.gz</file>
             <md5>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.0.RELEASE" eclipse-version="4.3.2" size="361MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.0.RELEASE" eclipse-version="4.3.2" size="358MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.0.RELEASE" eclipse-version="4.3.2" size="130MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.0.RELEASE/e4.3/springsource-tool-suite-3.5.0.RELEASE-e4.3.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.0.RELEASE/e4.3/springsource-tool-suite-3.5.0.RELEASE-e4.3.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.0.RELEASE/e4.3/springsource-tool-suite-3.5.0.RELEASE-e4.3.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.0.RELEASE" eclipse-version="4.2.2" size="110MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.0.RELEASE/e4.2/springsource-tool-suite-3.5.0.RELEASE-e4.2.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.0.RELEASE/e4.2/springsource-tool-suite-3.5.0.RELEASE-e4.2.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.0.RELEASE/e4.2/springsource-tool-suite-3.5.0.RELEASE-e4.2.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.0.RELEASE" eclipse-version="3.8.2" size="110MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.0.RELEASE/e3.8/springsource-tool-suite-3.5.0.RELEASE-e3.8.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.0.RELEASE/e3.8/springsource-tool-suite-3.5.0.RELEASE-e3.8.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.0.RELEASE/e3.8/springsource-tool-suite-3.5.0.RELEASE-e3.8.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.0.RELEASE" eclipse-version="3.7.2" size="112MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.0.RELEASE/e3.7/springsource-tool-suite-3.5.0.RELEASE-e3.7.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.0.RELEASE/e3.7/springsource-tool-suite-3.5.0.RELEASE-e3.7.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.0.RELEASE/e3.7/springsource-tool-suite-3.5.0.RELEASE-e3.7.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Groovy/Grails Tool Suite 3.5.0.RELEASE - based on Eclipse Kepler 4.3.2" whatsnew="http://static.springsource.org/sts/nan/v350/NewAndNoteworthy.html">
+    <other name="Groovy/Grails Tool Suite 3.5.0.RELEASE - based on Eclipse Kepler 4.3.2" whatsnew="https://docs.spring.io/sts/nan/v350/NewAndNoteworthy.html">
         <download os="windows" version="3.5.0.RELEASE" eclipse-version="4.3.2" size="488MB">
             <description>Windows</description>
             <file>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-win32-installer.exe</file>
             <md5>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.5.0.RELEASE" eclipse-version="4.3.2" size="489MB">
             <description>Windows</description>
             <file>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-win32.zip</file>
             <md5>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-win32.zip.md5</md5>
             <sha1>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.5.0.RELEASE" eclipse-version="4.3.2" size="488MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.5.0.RELEASE" eclipse-version="4.3.2" size="489MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-win32-x86_64.zip</file>
             <md5>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.0.RELEASE" eclipse-version="4.3.2" size="488MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.0.RELEASE" eclipse-version="4.3.2" size="482MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.0.RELEASE" eclipse-version="4.3.2" size="488MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.0.RELEASE" eclipse-version="4.3.2" size="482MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.0.RELEASE" eclipse-version="4.3.2" size="487MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-linux-gtk-installer.sh</file>
             <md5>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.0.RELEASE" eclipse-version="4.3.2" size="482MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-linux-gtk.tar.gz</file>
             <md5>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.0.RELEASE" eclipse-version="4.3.2" size="487MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.0.RELEASE" eclipse-version="4.3.2" size="482MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.0.RELEASE" eclipse-version="4.3.2" size="130MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.0.RELEASE/e4.3/springsource-tool-suite-3.5.0.RELEASE-e4.3.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.0.RELEASE/e4.3/springsource-tool-suite-3.5.0.RELEASE-e4.3.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.0.RELEASE/e4.3/springsource-tool-suite-3.5.0.RELEASE-e4.3.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.0.RELEASE" eclipse-version="4.2.2" size="110MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.0.RELEASE/e4.2/springsource-tool-suite-3.5.0.RELEASE-e4.2.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.0.RELEASE/e4.2/springsource-tool-suite-3.5.0.RELEASE-e4.2.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.0.RELEASE/e4.2/springsource-tool-suite-3.5.0.RELEASE-e4.2.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.0.RELEASE" eclipse-version="3.8.2" size="110MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.0.RELEASE/e3.8/springsource-tool-suite-3.5.0.RELEASE-e3.8.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.0.RELEASE/e3.8/springsource-tool-suite-3.5.0.RELEASE-e3.8.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.0.RELEASE/e3.8/springsource-tool-suite-3.5.0.RELEASE-e3.8.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.0.RELEASE" eclipse-version="3.7.2" size="112MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.0.RELEASE/e3.7/springsource-tool-suite-3.5.0.RELEASE-e3.7.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.0.RELEASE/e3.7/springsource-tool-suite-3.5.0.RELEASE-e3.7.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.0.RELEASE/e3.7/springsource-tool-suite-3.5.0.RELEASE-e3.7.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Spring Tool Suite 3.5.0.RELEASE - based on Eclipse Juno 3.8.2" whatsnew="http://static.springsource.org/sts/nan/v350/NewAndNoteworthy.html">
+    <other name="Spring Tool Suite 3.5.0.RELEASE - based on Eclipse Juno 3.8.2" whatsnew="https://docs.spring.io/sts/nan/v350/NewAndNoteworthy.html">
         <download os="windows" version="3.5.0.RELEASE" eclipse-version="3.8.2" size="349MB">
             <description>Windows</description>
             <file>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-win32-installer.exe</file>
             <md5>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.5.0.RELEASE" eclipse-version="3.8.2" size="348MB">
             <description>Windows</description>
             <file>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-win32.zip</file>
             <md5>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-win32.zip.md5</md5>
             <sha1>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.5.0.RELEASE" eclipse-version="3.8.2" size="349MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.5.0.RELEASE" eclipse-version="3.8.2" size="348MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-win32-x86_64.zip</file>
             <md5>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.0.RELEASE" eclipse-version="3.8.2" size="349MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.0.RELEASE" eclipse-version="3.8.2" size="345MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.0.RELEASE" eclipse-version="3.8.2" size="349MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.0.RELEASE" eclipse-version="3.8.2" size="345MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.0.RELEASE" eclipse-version="3.8.2" size="348MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-linux-gtk-installer.sh</file>
             <md5>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.0.RELEASE" eclipse-version="3.8.2" size="345MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-linux-gtk.tar.gz</file>
             <md5>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.0.RELEASE" eclipse-version="3.8.2" size="348MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.0.RELEASE" eclipse-version="3.8.2" size="345MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.0.RELEASE" eclipse-version="4.3.2" size="130MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.0.RELEASE/e4.3/springsource-tool-suite-3.5.0.RELEASE-e4.3.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.0.RELEASE/e4.3/springsource-tool-suite-3.5.0.RELEASE-e4.3.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.0.RELEASE/e4.3/springsource-tool-suite-3.5.0.RELEASE-e4.3.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.0.RELEASE" eclipse-version="4.2.2" size="110MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.0.RELEASE/e4.2/springsource-tool-suite-3.5.0.RELEASE-e4.2.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.0.RELEASE/e4.2/springsource-tool-suite-3.5.0.RELEASE-e4.2.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.0.RELEASE/e4.2/springsource-tool-suite-3.5.0.RELEASE-e4.2.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.0.RELEASE" eclipse-version="3.8.2" size="110MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.0.RELEASE/e3.8/springsource-tool-suite-3.5.0.RELEASE-e3.8.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.0.RELEASE/e3.8/springsource-tool-suite-3.5.0.RELEASE-e3.8.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.0.RELEASE/e3.8/springsource-tool-suite-3.5.0.RELEASE-e3.8.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.0.RELEASE" eclipse-version="3.7.2" size="112MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.0.RELEASE/e3.7/springsource-tool-suite-3.5.0.RELEASE-e3.7.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.0.RELEASE/e3.7/springsource-tool-suite-3.5.0.RELEASE-e3.7.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.0.RELEASE/e3.7/springsource-tool-suite-3.5.0.RELEASE-e3.7.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Groovy/Grails Tool Suite 3.5.0.RELEASE - based on Eclipse Juno 3.8.2" whatsnew="http://static.springsource.org/sts/nan/v350/NewAndNoteworthy.html">
+    <other name="Groovy/Grails Tool Suite 3.5.0.RELEASE - based on Eclipse Juno 3.8.2" whatsnew="https://docs.spring.io/sts/nan/v350/NewAndNoteworthy.html">
         <download os="windows" version="3.5.0.RELEASE" eclipse-version="3.8.2" size="475MB">
             <description>Windows</description>
             <file>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-win32-installer.exe</file>
             <md5>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.5.0.RELEASE" eclipse-version="3.8.2" size="476MB">
             <description>Windows</description>
             <file>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-win32.zip</file>
             <md5>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-win32.zip.md5</md5>
             <sha1>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.5.0.RELEASE" eclipse-version="3.8.2" size="475MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.5.0.RELEASE" eclipse-version="3.8.2" size="476MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-win32-x86_64.zip</file>
             <md5>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.0.RELEASE" eclipse-version="3.8.2" size="475MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.0.RELEASE" eclipse-version="3.8.2" size="470MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.0.RELEASE" eclipse-version="3.8.2" size="475MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.0.RELEASE" eclipse-version="3.8.2" size="470MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.0.RELEASE" eclipse-version="3.8.2" size="475MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-linux-gtk-installer.sh</file>
             <md5>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.0.RELEASE" eclipse-version="3.8.2" size="470MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-linux-gtk.tar.gz</file>
             <md5>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.0.RELEASE" eclipse-version="3.8.2" size="475MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.0.RELEASE" eclipse-version="3.8.2" size="470MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.0.RELEASE" eclipse-version="4.3.2" size="130MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.0.RELEASE/e4.3/springsource-tool-suite-3.5.0.RELEASE-e4.3.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.0.RELEASE/e4.3/springsource-tool-suite-3.5.0.RELEASE-e4.3.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.0.RELEASE/e4.3/springsource-tool-suite-3.5.0.RELEASE-e4.3.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.0.RELEASE" eclipse-version="4.2.2" size="110MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.0.RELEASE/e4.2/springsource-tool-suite-3.5.0.RELEASE-e4.2.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.0.RELEASE/e4.2/springsource-tool-suite-3.5.0.RELEASE-e4.2.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.0.RELEASE/e4.2/springsource-tool-suite-3.5.0.RELEASE-e4.2.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.0.RELEASE" eclipse-version="3.8.2" size="110MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.0.RELEASE/e3.8/springsource-tool-suite-3.5.0.RELEASE-e3.8.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.0.RELEASE/e3.8/springsource-tool-suite-3.5.0.RELEASE-e3.8.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.0.RELEASE/e3.8/springsource-tool-suite-3.5.0.RELEASE-e3.8.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.0.RELEASE" eclipse-version="3.7.2" size="112MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.0.RELEASE/e3.7/springsource-tool-suite-3.5.0.RELEASE-e3.7.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.0.RELEASE/e3.7/springsource-tool-suite-3.5.0.RELEASE-e3.7.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.0.RELEASE/e3.7/springsource-tool-suite-3.5.0.RELEASE-e3.7.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Spring Tool Suite 3.4.0.RELEASE - based on Eclipse Kepler 4.3.1" whatsnew="http://static.springsource.org/sts/nan/v340/NewAndNoteworthy.html">
+    <other name="Spring Tool Suite 3.4.0.RELEASE - based on Eclipse Kepler 4.3.1" whatsnew="https://docs.spring.io/sts/nan/v340/NewAndNoteworthy.html">
         <download os="windows" version="3.4.0.RELEASE" eclipse-version="4.3.1" size="380MB">
             <description>Windows</description>
             <file>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-win32-installer.exe</file>
             <md5>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-win32-installer.exe.md5</md5>
             <sha1>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.4.0.RELEASE" eclipse-version="4.3.1" size="379MB">
             <description>Windows</description>
             <file>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-win32.zip</file>
             <md5>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-win32.zip.md5</md5>
             <sha1>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.4.0.RELEASE" eclipse-version="4.3.1" size="380MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-win32-x86_64-installer.exe</file>
             <md5>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.4.0.RELEASE" eclipse-version="4.3.1" size="379MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-win32-x86_64.zip</file>
             <md5>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.4.0.RELEASE" eclipse-version="4.3.1" size="380MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.4.0.RELEASE" eclipse-version="4.3.1" size="376MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-macosx-cocoa.tar.gz</file>
             <md5>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.4.0.RELEASE" eclipse-version="4.3.1" size="379MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.4.0.RELEASE" eclipse-version="4.3.1" size="376MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.4.0.RELEASE" eclipse-version="4.3.1" size="379MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-linux-gtk-installer.sh</file>
             <md5>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.4.0.RELEASE" eclipse-version="4.3.1" size="376MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-linux-gtk.tar.gz</file>
             <md5>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.4.0.RELEASE" eclipse-version="4.3.1" size="379MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.4.0.RELEASE" eclipse-version="4.3.1" size="376MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.4.0.RELEASE" eclipse-version="4.3.1" size="167MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.4.0.RELEASE/e4.3/springsource-tool-suite-3.4.0.RELEASE-e4.3.1-updatesite.zip</file>
             <md5>release/TOOLS/update/3.4.0.RELEASE/e4.3/springsource-tool-suite-3.4.0.RELEASE-e4.3.1-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.4.0.RELEASE/e4.3/springsource-tool-suite-3.4.0.RELEASE-e4.3.1-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.4.0.RELEASE" eclipse-version="4.2.2" size="164MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.4.0.RELEASE/e4.2/springsource-tool-suite-3.4.0.RELEASE-e4.2.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.4.0.RELEASE/e4.2/springsource-tool-suite-3.4.0.RELEASE-e4.2.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.4.0.RELEASE/e4.2/springsource-tool-suite-3.4.0.RELEASE-e4.2.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.4.0.RELEASE" eclipse-version="3.8.2" size="161MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.4.0.RELEASE/e3.8/springsource-tool-suite-3.4.0.RELEASE-e3.8.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.4.0.RELEASE/e3.8/springsource-tool-suite-3.4.0.RELEASE-e3.8.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.4.0.RELEASE/e3.8/springsource-tool-suite-3.4.0.RELEASE-e3.8.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.4.0.RELEASE" eclipse-version="3.7.2" size="161MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.4.0.RELEASE/e3.7/springsource-tool-suite-3.4.0.RELEASE-e3.7.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.4.0.RELEASE/e3.7/springsource-tool-suite-3.4.0.RELEASE-e3.7.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.4.0.RELEASE/e3.7/springsource-tool-suite-3.4.0.RELEASE-e3.7.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Groovy/Grails Tool Suite 3.4.0.RELEASE - based on Eclipse Kepler 4.3.1" whatsnew="http://static.springsource.org/sts/nan/v340/NewAndNoteworthy.html">
+    <other name="Groovy/Grails Tool Suite 3.4.0.RELEASE - based on Eclipse Kepler 4.3.1" whatsnew="https://docs.spring.io/sts/nan/v340/NewAndNoteworthy.html">
         <download os="windows" version="3.4.0.RELEASE" eclipse-version="4.3.1" size="477MB">
             <description>Windows</description>
             <file>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-win32-installer.exe</file>
             <md5>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-win32-installer.exe.md5</md5>
             <sha1>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.4.0.RELEASE" eclipse-version="4.3.1" size="478MB">
             <description>Windows</description>
             <file>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-win32.zip</file>
             <md5>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-win32.zip.md5</md5>
             <sha1>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.4.0.RELEASE" eclipse-version="4.3.1" size="477MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-win32-x86_64-installer.exe</file>
             <md5>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.4.0.RELEASE" eclipse-version="4.3.1" size="478MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-win32-x86_64.zip</file>
             <md5>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.4.0.RELEASE" eclipse-version="4.3.1" size="477MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.4.0.RELEASE" eclipse-version="4.3.1" size="472MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-macosx-cocoa.tar.gz</file>
             <md5>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.4.0.RELEASE" eclipse-version="4.3.1" size="477MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.4.0.RELEASE" eclipse-version="4.3.1" size="472MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.4.0.RELEASE" eclipse-version="4.3.1" size="477MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-linux-gtk-installer.sh</file>
             <md5>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.4.0.RELEASE" eclipse-version="4.3.1" size="472MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-linux-gtk.tar.gz</file>
             <md5>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.4.0.RELEASE" eclipse-version="4.3.1" size="477MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.4.0.RELEASE" eclipse-version="4.3.1" size="472MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.4.0.RELEASE" eclipse-version="4.3.1" size="167MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.4.0.RELEASE/e4.3/springsource-tool-suite-3.4.0.RELEASE-e4.3.1-updatesite.zip</file>
             <md5>release/TOOLS/update/3.4.0.RELEASE/e4.3/springsource-tool-suite-3.4.0.RELEASE-e4.3.1-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.4.0.RELEASE/e4.3/springsource-tool-suite-3.4.0.RELEASE-e4.3.1-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.4.0.RELEASE" eclipse-version="4.2.2" size="164MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.4.0.RELEASE/e4.2/springsource-tool-suite-3.4.0.RELEASE-e4.2.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.4.0.RELEASE/e4.2/springsource-tool-suite-3.4.0.RELEASE-e4.2.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.4.0.RELEASE/e4.2/springsource-tool-suite-3.4.0.RELEASE-e4.2.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.4.0.RELEASE" eclipse-version="3.8.2" size="161MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.4.0.RELEASE/e3.8/springsource-tool-suite-3.4.0.RELEASE-e3.8.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.4.0.RELEASE/e3.8/springsource-tool-suite-3.4.0.RELEASE-e3.8.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.4.0.RELEASE/e3.8/springsource-tool-suite-3.4.0.RELEASE-e3.8.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.4.0.RELEASE" eclipse-version="3.7.2" size="161MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.4.0.RELEASE/e3.7/springsource-tool-suite-3.4.0.RELEASE-e3.7.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.4.0.RELEASE/e3.7/springsource-tool-suite-3.4.0.RELEASE-e3.7.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.4.0.RELEASE/e3.7/springsource-tool-suite-3.4.0.RELEASE-e3.7.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Spring Tool Suite 3.4.0.RELEASE - based on Eclipse Juno 3.8.2" whatsnew="http://static.springsource.org/sts/nan/v340/NewAndNoteworthy.html">
+    <other name="Spring Tool Suite 3.4.0.RELEASE - based on Eclipse Juno 3.8.2" whatsnew="https://docs.spring.io/sts/nan/v340/NewAndNoteworthy.html">
         <download os="windows" version="3.4.0.RELEASE" eclipse-version="3.8.2" size="372MB">
             <description>Windows</description>
             <file>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-win32-installer.exe</file>
             <md5>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.4.0.RELEASE" eclipse-version="3.8.2" size="371MB">
             <description>Windows</description>
             <file>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-win32.zip</file>
             <md5>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-win32.zip.md5</md5>
             <sha1>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.4.0.RELEASE" eclipse-version="3.8.2" size="372MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.4.0.RELEASE" eclipse-version="3.8.2" size="371MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-win32-x86_64.zip</file>
             <md5>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.4.0.RELEASE" eclipse-version="3.8.2" size="371MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.4.0.RELEASE" eclipse-version="3.8.2" size="368MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.4.0.RELEASE" eclipse-version="3.8.2" size="371MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.4.0.RELEASE" eclipse-version="3.8.2" size="368MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.4.0.RELEASE" eclipse-version="3.8.2" size="371MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-linux-gtk-installer.sh</file>
             <md5>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.4.0.RELEASE" eclipse-version="3.8.2" size="368MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-linux-gtk.tar.gz</file>
             <md5>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.4.0.RELEASE" eclipse-version="3.8.2" size="371MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.4.0.RELEASE" eclipse-version="3.8.2" size="368MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.4.0.RELEASE" eclipse-version="4.3.1" size="167MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.4.0.RELEASE/e4.3/springsource-tool-suite-3.4.0.RELEASE-e4.3.1-updatesite.zip</file>
             <md5>release/TOOLS/update/3.4.0.RELEASE/e4.3/springsource-tool-suite-3.4.0.RELEASE-e4.3.1-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.4.0.RELEASE/e4.3/springsource-tool-suite-3.4.0.RELEASE-e4.3.1-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.4.0.RELEASE" eclipse-version="4.2.2" size="164MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.4.0.RELEASE/e4.2/springsource-tool-suite-3.4.0.RELEASE-e4.2.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.4.0.RELEASE/e4.2/springsource-tool-suite-3.4.0.RELEASE-e4.2.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.4.0.RELEASE/e4.2/springsource-tool-suite-3.4.0.RELEASE-e4.2.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.4.0.RELEASE" eclipse-version="3.8.2" size="161MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.4.0.RELEASE/e3.8/springsource-tool-suite-3.4.0.RELEASE-e3.8.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.4.0.RELEASE/e3.8/springsource-tool-suite-3.4.0.RELEASE-e3.8.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.4.0.RELEASE/e3.8/springsource-tool-suite-3.4.0.RELEASE-e3.8.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.4.0.RELEASE" eclipse-version="3.7.2" size="161MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.4.0.RELEASE/e3.7/springsource-tool-suite-3.4.0.RELEASE-e3.7.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.4.0.RELEASE/e3.7/springsource-tool-suite-3.4.0.RELEASE-e3.7.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.4.0.RELEASE/e3.7/springsource-tool-suite-3.4.0.RELEASE-e3.7.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Groovy/Grails Tool Suite 3.4.0.RELEASE - based on Eclipse Juno 3.8.2" whatsnew="http://static.springsource.org/sts/nan/v340/NewAndNoteworthy.html">
+    <other name="Groovy/Grails Tool Suite 3.4.0.RELEASE - based on Eclipse Juno 3.8.2" whatsnew="https://docs.spring.io/sts/nan/v340/NewAndNoteworthy.html">
         <download os="windows" version="3.4.0.RELEASE" eclipse-version="3.8.2" size="469MB">
             <description>Windows</description>
             <file>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-win32-installer.exe</file>
             <md5>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.4.0.RELEASE" eclipse-version="3.8.2" size="471MB">
             <description>Windows</description>
             <file>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-win32.zip</file>
             <md5>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-win32.zip.md5</md5>
             <sha1>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.4.0.RELEASE" eclipse-version="3.8.2" size="469MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.4.0.RELEASE" eclipse-version="3.8.2" size="471MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-win32-x86_64.zip</file>
             <md5>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.4.0.RELEASE" eclipse-version="3.8.2" size="469MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.4.0.RELEASE" eclipse-version="3.8.2" size="464MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.4.0.RELEASE" eclipse-version="3.8.2" size="469MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.4.0.RELEASE" eclipse-version="3.8.2" size="464MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.4.0.RELEASE" eclipse-version="3.8.2" size="469MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-linux-gtk-installer.sh</file>
             <md5>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.4.0.RELEASE" eclipse-version="3.8.2" size="465MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-linux-gtk.tar.gz</file>
             <md5>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.4.0.RELEASE" eclipse-version="3.8.2" size="469MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.4.0.RELEASE" eclipse-version="3.8.2" size="465MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.4.0.RELEASE" eclipse-version="4.3.1" size="167MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.4.0.RELEASE/e4.3/springsource-tool-suite-3.4.0.RELEASE-e4.3.1-updatesite.zip</file>
             <md5>release/TOOLS/update/3.4.0.RELEASE/e4.3/springsource-tool-suite-3.4.0.RELEASE-e4.3.1-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.4.0.RELEASE/e4.3/springsource-tool-suite-3.4.0.RELEASE-e4.3.1-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.4.0.RELEASE" eclipse-version="4.2.2" size="164MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.4.0.RELEASE/e4.2/springsource-tool-suite-3.4.0.RELEASE-e4.2.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.4.0.RELEASE/e4.2/springsource-tool-suite-3.4.0.RELEASE-e4.2.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.4.0.RELEASE/e4.2/springsource-tool-suite-3.4.0.RELEASE-e4.2.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.4.0.RELEASE" eclipse-version="3.8.2" size="161MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.4.0.RELEASE/e3.8/springsource-tool-suite-3.4.0.RELEASE-e3.8.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.4.0.RELEASE/e3.8/springsource-tool-suite-3.4.0.RELEASE-e3.8.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.4.0.RELEASE/e3.8/springsource-tool-suite-3.4.0.RELEASE-e3.8.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.4.0.RELEASE" eclipse-version="3.7.2" size="161MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.4.0.RELEASE/e3.7/springsource-tool-suite-3.4.0.RELEASE-e3.7.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.4.0.RELEASE/e3.7/springsource-tool-suite-3.4.0.RELEASE-e3.7.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.4.0.RELEASE/e3.7/springsource-tool-suite-3.4.0.RELEASE-e3.7.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Spring Tool Suite 3.3.0.RELEASE - based on Eclipse Kepler 4.3" whatsnew="http://static.springsource.org/sts/nan/v330/NewAndNoteworthy.html">
+    <other name="Spring Tool Suite 3.3.0.RELEASE - based on Eclipse Kepler 4.3" whatsnew="https://docs.spring.io/sts/nan/v330/NewAndNoteworthy.html">
         <download os="windows" version="3.3.0.RELEASE" eclipse-version="4.3" size="373MB">
             <description>Windows</description>
             <file>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-win32-installer.exe</file>
             <md5>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-win32-installer.exe.md5</md5>
             <sha1>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.3.0.RELEASE" eclipse-version="4.3" size="372MB">
             <description>Windows</description>
             <file>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-win32.zip</file>
             <md5>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-win32.zip.md5</md5>
             <sha1>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.3.0.RELEASE" eclipse-version="4.3" size="373MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-win32-x86_64-installer.exe</file>
             <md5>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.3.0.RELEASE" eclipse-version="4.3" size="372MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-win32-x86_64.zip</file>
             <md5>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.3.0.RELEASE" eclipse-version="4.3" size="373MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.3.0.RELEASE" eclipse-version="4.3" size="369MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa.tar.gz</file>
             <md5>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.3.0.RELEASE" eclipse-version="4.3" size="373MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.3.0.RELEASE" eclipse-version="4.3" size="369MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.3.0.RELEASE" eclipse-version="4.3" size="372MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk-installer.sh</file>
             <md5>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.3.0.RELEASE" eclipse-version="4.3" size="369MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk.tar.gz</file>
             <md5>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.3.0.RELEASE" eclipse-version="4.3" size="372MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.3.0.RELEASE" eclipse-version="4.3" size="369MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.3.0.RELEASE" eclipse-version="4.3" size="172MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.3.0.RELEASE/e4.3/springsource-tool-suite-3.3.0.RELEASE-e4.3-updatesite.zip</file>
             <md5>release/TOOLS/update/3.3.0.RELEASE/e4.3/springsource-tool-suite-3.3.0.RELEASE-e4.3-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.3.0.RELEASE/e4.3/springsource-tool-suite-3.3.0.RELEASE-e4.3-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.3.0.RELEASE" eclipse-version="4.2.2" size="169MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.3.0.RELEASE/e4.2/springsource-tool-suite-3.3.0.RELEASE-e4.2.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.3.0.RELEASE/e4.2/springsource-tool-suite-3.3.0.RELEASE-e4.2.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.3.0.RELEASE/e4.2/springsource-tool-suite-3.3.0.RELEASE-e4.2.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="166MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.3.0.RELEASE/e3.8/springsource-tool-suite-3.3.0.RELEASE-e3.8.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.3.0.RELEASE/e3.8/springsource-tool-suite-3.3.0.RELEASE-e3.8.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.3.0.RELEASE/e3.8/springsource-tool-suite-3.3.0.RELEASE-e3.8.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.3.0.RELEASE" eclipse-version="3.7.2" size="166MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.3.0.RELEASE/e3.7/springsource-tool-suite-3.3.0.RELEASE-e3.7.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.3.0.RELEASE/e3.7/springsource-tool-suite-3.3.0.RELEASE-e3.7.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.3.0.RELEASE/e3.7/springsource-tool-suite-3.3.0.RELEASE-e3.7.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Groovy/Grails Tool Suite 3.3.0.RELEASE - based on Eclipse Kepler 4.3" whatsnew="http://static.springsource.org/sts/nan/v330/NewAndNoteworthy.html">
+    <other name="Groovy/Grails Tool Suite 3.3.0.RELEASE - based on Eclipse Kepler 4.3" whatsnew="https://docs.spring.io/sts/nan/v330/NewAndNoteworthy.html">
         <download os="windows" version="3.3.0.RELEASE" eclipse-version="4.3" size="468MB">
             <description>Windows</description>
             <file>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-win32-installer.exe</file>
             <md5>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-win32-installer.exe.md5</md5>
             <sha1>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.3.0.RELEASE" eclipse-version="4.3" size="469MB">
             <description>Windows</description>
             <file>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-win32.zip</file>
             <md5>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-win32.zip.md5</md5>
             <sha1>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.3.0.RELEASE" eclipse-version="4.3" size="468MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-win32-x86_64-installer.exe</file>
             <md5>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.3.0.RELEASE" eclipse-version="4.3" size="469MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-win32-x86_64.zip</file>
             <md5>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.3.0.RELEASE" eclipse-version="4.3" size="468MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.3.0.RELEASE" eclipse-version="4.3" size="464MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa.tar.gz</file>
             <md5>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.3.0.RELEASE" eclipse-version="4.3" size="468MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.3.0.RELEASE" eclipse-version="4.3" size="463MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.3.0.RELEASE" eclipse-version="4.3" size="468MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk-installer.sh</file>
             <md5>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.3.0.RELEASE" eclipse-version="4.3" size="463MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk.tar.gz</file>
             <md5>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.3.0.RELEASE" eclipse-version="4.3" size="468MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.3.0.RELEASE" eclipse-version="4.3" size="463MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.3.0.RELEASE" eclipse-version="4.3" size="172MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.3.0.RELEASE/e4.3/springsource-tool-suite-3.3.0.RELEASE-e4.3-updatesite.zip</file>
             <md5>release/TOOLS/update/3.3.0.RELEASE/e4.3/springsource-tool-suite-3.3.0.RELEASE-e4.3-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.3.0.RELEASE/e4.3/springsource-tool-suite-3.3.0.RELEASE-e4.3-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.3.0.RELEASE" eclipse-version="4.2.2" size="169MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.3.0.RELEASE/e4.2/springsource-tool-suite-3.3.0.RELEASE-e4.2.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.3.0.RELEASE/e4.2/springsource-tool-suite-3.3.0.RELEASE-e4.2.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.3.0.RELEASE/e4.2/springsource-tool-suite-3.3.0.RELEASE-e4.2.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="166MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.3.0.RELEASE/e3.8/springsource-tool-suite-3.3.0.RELEASE-e3.8.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.3.0.RELEASE/e3.8/springsource-tool-suite-3.3.0.RELEASE-e3.8.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.3.0.RELEASE/e3.8/springsource-tool-suite-3.3.0.RELEASE-e3.8.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.3.0.RELEASE" eclipse-version="3.7.2" size="166MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.3.0.RELEASE/e3.7/springsource-tool-suite-3.3.0.RELEASE-e3.7.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.3.0.RELEASE/e3.7/springsource-tool-suite-3.3.0.RELEASE-e3.7.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.3.0.RELEASE/e3.7/springsource-tool-suite-3.3.0.RELEASE-e3.7.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Spring Tool Suite 3.3.0.RELEASE - based on Eclipse Juno 3.8.2" whatsnew="http://static.springsource.org/sts/nan/v330/NewAndNoteworthy.html">
+    <other name="Spring Tool Suite 3.3.0.RELEASE - based on Eclipse Juno 3.8.2" whatsnew="https://docs.spring.io/sts/nan/v330/NewAndNoteworthy.html">
         <download os="windows" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="368MB">
             <description>Windows</description>
             <file>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-win32-installer.exe</file>
             <md5>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="367MB">
             <description>Windows</description>
             <file>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-win32.zip</file>
             <md5>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-win32.zip.md5</md5>
             <sha1>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="368MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="367MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-win32-x86_64.zip</file>
             <md5>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="368MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="364MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="368MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="364MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="368MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk-installer.sh</file>
             <md5>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="364MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk.tar.gz</file>
             <md5>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="368MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="365MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.3.0.RELEASE" eclipse-version="4.3" size="172MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.3.0.RELEASE/e4.3/springsource-tool-suite-3.3.0.RELEASE-e4.3-updatesite.zip</file>
             <md5>release/TOOLS/update/3.3.0.RELEASE/e4.3/springsource-tool-suite-3.3.0.RELEASE-e4.3-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.3.0.RELEASE/e4.3/springsource-tool-suite-3.3.0.RELEASE-e4.3-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.3.0.RELEASE" eclipse-version="4.2.2" size="169MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.3.0.RELEASE/e4.2/springsource-tool-suite-3.3.0.RELEASE-e4.2.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.3.0.RELEASE/e4.2/springsource-tool-suite-3.3.0.RELEASE-e4.2.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.3.0.RELEASE/e4.2/springsource-tool-suite-3.3.0.RELEASE-e4.2.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="166MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.3.0.RELEASE/e3.8/springsource-tool-suite-3.3.0.RELEASE-e3.8.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.3.0.RELEASE/e3.8/springsource-tool-suite-3.3.0.RELEASE-e3.8.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.3.0.RELEASE/e3.8/springsource-tool-suite-3.3.0.RELEASE-e3.8.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.3.0.RELEASE" eclipse-version="3.7.2" size="166MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.3.0.RELEASE/e3.7/springsource-tool-suite-3.3.0.RELEASE-e3.7.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.3.0.RELEASE/e3.7/springsource-tool-suite-3.3.0.RELEASE-e3.7.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.3.0.RELEASE/e3.7/springsource-tool-suite-3.3.0.RELEASE-e3.7.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Groovy/Grails Tool Suite 3.3.0.RELEASE - based on Eclipse Juno 3.8.2" whatsnew="http://static.springsource.org/sts/nan/v330/NewAndNoteworthy.html">
+    <other name="Groovy/Grails Tool Suite 3.3.0.RELEASE - based on Eclipse Juno 3.8.2" whatsnew="https://docs.spring.io/sts/nan/v330/NewAndNoteworthy.html">
         <download os="windows" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="464MB">
             <description>Windows</description>
             <file>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-win32-installer.exe</file>
             <md5>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="464MB">
             <description>Windows</description>
             <file>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-win32.zip</file>
             <md5>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-win32.zip.md5</md5>
             <sha1>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="464MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="464MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-win32-x86_64.zip</file>
             <md5>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="463MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="459MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="463MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="458MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="463MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk-installer.sh</file>
             <md5>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="459MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk.tar.gz</file>
             <md5>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="463MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="459MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.3.0.RELEASE" eclipse-version="4.3" size="172MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.3.0.RELEASE/e4.3/springsource-tool-suite-3.3.0.RELEASE-e4.3-updatesite.zip</file>
             <md5>release/TOOLS/update/3.3.0.RELEASE/e4.3/springsource-tool-suite-3.3.0.RELEASE-e4.3-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.3.0.RELEASE/e4.3/springsource-tool-suite-3.3.0.RELEASE-e4.3-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.3.0.RELEASE" eclipse-version="4.2.2" size="169MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.3.0.RELEASE/e4.2/springsource-tool-suite-3.3.0.RELEASE-e4.2.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.3.0.RELEASE/e4.2/springsource-tool-suite-3.3.0.RELEASE-e4.2.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.3.0.RELEASE/e4.2/springsource-tool-suite-3.3.0.RELEASE-e4.2.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="166MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.3.0.RELEASE/e3.8/springsource-tool-suite-3.3.0.RELEASE-e3.8.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.3.0.RELEASE/e3.8/springsource-tool-suite-3.3.0.RELEASE-e3.8.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.3.0.RELEASE/e3.8/springsource-tool-suite-3.3.0.RELEASE-e3.8.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.3.0.RELEASE" eclipse-version="3.7.2" size="166MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.3.0.RELEASE/e3.7/springsource-tool-suite-3.3.0.RELEASE-e3.7.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.3.0.RELEASE/e3.7/springsource-tool-suite-3.3.0.RELEASE-e3.7.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.3.0.RELEASE/e3.7/springsource-tool-suite-3.3.0.RELEASE-e3.7.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Spring Tool Suite 3.2.0.RELEASE - based on Eclipse Juno 3.8.2" whatsnew="http://static.springsource.org/sts/nan/v320/NewAndNoteworthy.html">
+    <other name="Spring Tool Suite 3.2.0.RELEASE - based on Eclipse Juno 3.8.2" whatsnew="https://docs.spring.io/sts/nan/v320/NewAndNoteworthy.html">
         <download os="windows" version="3.2.0.RELEASE" eclipse-version="3.8.2" size="364MB">
             <description>Windows</description>
             <file>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-win32-installer.exe</file>
             <md5>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.2.0.RELEASE" eclipse-version="3.8.2" size="363MB">
             <description>Windows</description>
             <file>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-win32.zip</file>
             <md5>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-win32.zip.md5</md5>
             <sha1>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.2.0.RELEASE" eclipse-version="3.8.2" size="364MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.2.0.RELEASE" eclipse-version="3.8.2" size="363MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-win32-x86_64.zip</file>
             <md5>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.2.0.RELEASE" eclipse-version="3.8.2" size="364MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.2.0.RELEASE" eclipse-version="3.8.2" size="360MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.2.0.RELEASE" eclipse-version="3.8.2" size="364MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.2.0.RELEASE" eclipse-version="3.8.2" size="360MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.2.0.RELEASE" eclipse-version="3.8.2" size="364MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-linux-gtk-installer.sh</file>
             <md5>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.2.0.RELEASE" eclipse-version="3.8.2" size="360MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-linux-gtk.tar.gz</file>
             <md5>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.2.0.RELEASE" eclipse-version="3.8.2" size="364MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.2.0.RELEASE" eclipse-version="3.8.2" size="361MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.2.0.RELEASE" eclipse-version="4.3" size="185MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.2.0.RELEASE/e4.3/springsource-tool-suite-3.2.0.RELEASE-e4.3-updatesite.zip</file>
             <md5>release/TOOLS/update/3.2.0.RELEASE/e4.3/springsource-tool-suite-3.2.0.RELEASE-e4.3-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.2.0.RELEASE/e4.3/springsource-tool-suite-3.2.0.RELEASE-e4.3-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.2.0.RELEASE" eclipse-version="4.2.2" size="182MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.2.0.RELEASE/e4.2/springsource-tool-suite-3.2.0.RELEASE-e4.2.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.2.0.RELEASE/e4.2/springsource-tool-suite-3.2.0.RELEASE-e4.2.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.2.0.RELEASE/e4.2/springsource-tool-suite-3.2.0.RELEASE-e4.2.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.2.0.RELEASE" eclipse-version="3.8.2" size="179MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.2.0.RELEASE/e3.8/springsource-tool-suite-3.2.0.RELEASE-e3.8.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.2.0.RELEASE/e3.8/springsource-tool-suite-3.2.0.RELEASE-e3.8.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.2.0.RELEASE/e3.8/springsource-tool-suite-3.2.0.RELEASE-e3.8.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.2.0.RELEASE" eclipse-version="3.7.2" size="176MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.2.0.RELEASE/e3.7/springsource-tool-suite-3.2.0.RELEASE-e3.7.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.2.0.RELEASE/e3.7/springsource-tool-suite-3.2.0.RELEASE-e3.7.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.2.0.RELEASE/e3.7/springsource-tool-suite-3.2.0.RELEASE-e3.7.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Groovy/Grails Tool Suite 3.2.0.RELEASE - based on Eclipse Juno 3.8.2" whatsnew="http://static.springsource.org/sts/nan/v320/NewAndNoteworthy.html">
+    <other name="Groovy/Grails Tool Suite 3.2.0.RELEASE - based on Eclipse Juno 3.8.2" whatsnew="https://docs.spring.io/sts/nan/v320/NewAndNoteworthy.html">
         <download os="windows" version="3.2.0.RELEASE" eclipse-version="3.8.2" size="461MB">
             <description>Windows</description>
             <file>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-win32-installer.exe</file>
             <md5>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.2.0.RELEASE" eclipse-version="3.8.2" size="462MB">
             <description>Windows</description>
             <file>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-win32.zip</file>
             <md5>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-win32.zip.md5</md5>
             <sha1>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.2.0.RELEASE" eclipse-version="3.8.2" size="461MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.2.0.RELEASE" eclipse-version="3.8.2" size="462MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-win32-x86_64.zip</file>
             <md5>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.2.0.RELEASE" eclipse-version="3.8.2" size="461MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.2.0.RELEASE" eclipse-version="3.8.2" size="456MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.2.0.RELEASE" eclipse-version="3.8.2" size="460MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.2.0.RELEASE" eclipse-version="3.8.2" size="455MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.2.0.RELEASE" eclipse-version="3.8.2" size="460MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-linux-gtk-installer.sh</file>
             <md5>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.2.0.RELEASE" eclipse-version="3.8.2" size="456MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-linux-gtk.tar.gz</file>
             <md5>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.2.0.RELEASE" eclipse-version="3.8.2" size="461MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.2.0.RELEASE" eclipse-version="3.8.2" size="456MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.2.0.RELEASE" eclipse-version="4.3" size="185MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.2.0.RELEASE/e4.3/springsource-tool-suite-3.2.0.RELEASE-e4.3-updatesite.zip</file>
             <md5>release/TOOLS/update/3.2.0.RELEASE/e4.3/springsource-tool-suite-3.2.0.RELEASE-e4.3-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.2.0.RELEASE/e4.3/springsource-tool-suite-3.2.0.RELEASE-e4.3-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.2.0.RELEASE" eclipse-version="4.2.2" size="182MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.2.0.RELEASE/e4.2/springsource-tool-suite-3.2.0.RELEASE-e4.2.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.2.0.RELEASE/e4.2/springsource-tool-suite-3.2.0.RELEASE-e4.2.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.2.0.RELEASE/e4.2/springsource-tool-suite-3.2.0.RELEASE-e4.2.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.2.0.RELEASE" eclipse-version="3.8.2" size="179MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.2.0.RELEASE/e3.8/springsource-tool-suite-3.2.0.RELEASE-e3.8.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.2.0.RELEASE/e3.8/springsource-tool-suite-3.2.0.RELEASE-e3.8.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.2.0.RELEASE/e3.8/springsource-tool-suite-3.2.0.RELEASE-e3.8.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.2.0.RELEASE" eclipse-version="3.7.2" size="176MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.2.0.RELEASE/e3.7/springsource-tool-suite-3.2.0.RELEASE-e3.7.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.2.0.RELEASE/e3.7/springsource-tool-suite-3.2.0.RELEASE-e3.7.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.2.0.RELEASE/e3.7/springsource-tool-suite-3.2.0.RELEASE-e3.7.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Spring Tool Suite 3.2.0.RELEASE - based on Eclipse Juno 4.2.2" whatsnew="http://static.springsource.org/sts/nan/v320/NewAndNoteworthy.html">
+    <other name="Spring Tool Suite 3.2.0.RELEASE - based on Eclipse Juno 4.2.2" whatsnew="https://docs.spring.io/sts/nan/v320/NewAndNoteworthy.html">
         <download os="windows" version="3.2.0.RELEASE" eclipse-version="4.2.2" size="367MB">
             <description>Windows</description>
             <file>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-win32-installer.exe</file>
             <md5>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.2.0.RELEASE" eclipse-version="4.2.2" size="366MB">
             <description>Windows</description>
             <file>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-win32.zip</file>
             <md5>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-win32.zip.md5</md5>
             <sha1>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.2.0.RELEASE" eclipse-version="4.2.2" size="367MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.2.0.RELEASE" eclipse-version="4.2.2" size="366MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-win32-x86_64.zip</file>
             <md5>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.2.0.RELEASE" eclipse-version="4.2.2" size="366MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.2.0.RELEASE" eclipse-version="4.2.2" size="363MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.2.0.RELEASE" eclipse-version="4.2.2" size="366MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.2.0.RELEASE" eclipse-version="4.2.2" size="362MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.2.0.RELEASE" eclipse-version="4.2.2" size="366MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-linux-gtk-installer.sh</file>
             <md5>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.2.0.RELEASE" eclipse-version="4.2.2" size="363MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-linux-gtk.tar.gz</file>
             <md5>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.2.0.RELEASE" eclipse-version="4.2.2" size="366MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.2.0.RELEASE" eclipse-version="4.2.2" size="363MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.2.0.RELEASE" eclipse-version="4.3" size="185MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.2.0.RELEASE/e4.3/springsource-tool-suite-3.2.0.RELEASE-e4.3-updatesite.zip</file>
             <md5>release/TOOLS/update/3.2.0.RELEASE/e4.3/springsource-tool-suite-3.2.0.RELEASE-e4.3-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.2.0.RELEASE/e4.3/springsource-tool-suite-3.2.0.RELEASE-e4.3-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.2.0.RELEASE" eclipse-version="4.2.2" size="182MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.2.0.RELEASE/e4.2/springsource-tool-suite-3.2.0.RELEASE-e4.2.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.2.0.RELEASE/e4.2/springsource-tool-suite-3.2.0.RELEASE-e4.2.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.2.0.RELEASE/e4.2/springsource-tool-suite-3.2.0.RELEASE-e4.2.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.2.0.RELEASE" eclipse-version="3.8.2" size="179MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.2.0.RELEASE/e3.8/springsource-tool-suite-3.2.0.RELEASE-e3.8.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.2.0.RELEASE/e3.8/springsource-tool-suite-3.2.0.RELEASE-e3.8.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.2.0.RELEASE/e3.8/springsource-tool-suite-3.2.0.RELEASE-e3.8.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.2.0.RELEASE" eclipse-version="3.7.2" size="176MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.2.0.RELEASE/e3.7/springsource-tool-suite-3.2.0.RELEASE-e3.7.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.2.0.RELEASE/e3.7/springsource-tool-suite-3.2.0.RELEASE-e3.7.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.2.0.RELEASE/e3.7/springsource-tool-suite-3.2.0.RELEASE-e3.7.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Groovy/Grails Tool Suite 3.2.0.RELEASE - based on Eclipse Juno 4.2.2" whatsnew="http://static.springsource.org/sts/nan/v320/NewAndNoteworthy.html">
+    <other name="Groovy/Grails Tool Suite 3.2.0.RELEASE - based on Eclipse Juno 4.2.2" whatsnew="https://docs.spring.io/sts/nan/v320/NewAndNoteworthy.html">
         <download os="windows" version="3.2.0.RELEASE" eclipse-version="4.2.2" size="463MB">
             <description>Windows</description>
             <file>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-win32-installer.exe</file>
             <md5>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.2.0.RELEASE" eclipse-version="4.2.2" size="464MB">
             <description>Windows</description>
             <file>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-win32.zip</file>
             <md5>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-win32.zip.md5</md5>
             <sha1>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.2.0.RELEASE" eclipse-version="4.2.2" size="463MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.2.0.RELEASE" eclipse-version="4.2.2" size="464MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-win32-x86_64.zip</file>
             <md5>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.2.0.RELEASE" eclipse-version="4.2.2" size="463MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.2.0.RELEASE" eclipse-version="4.2.2" size="458MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.2.0.RELEASE" eclipse-version="4.2.2" size="463MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.2.0.RELEASE" eclipse-version="4.2.2" size="458MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.2.0.RELEASE" eclipse-version="4.2.2" size="463MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-linux-gtk-installer.sh</file>
             <md5>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.2.0.RELEASE" eclipse-version="4.2.2" size="458MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-linux-gtk.tar.gz</file>
             <md5>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.2.0.RELEASE" eclipse-version="4.2.2" size="463MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.2.0.RELEASE" eclipse-version="4.2.2" size="458MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.2.0.RELEASE" eclipse-version="4.3" size="185MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.2.0.RELEASE/e4.3/springsource-tool-suite-3.2.0.RELEASE-e4.3-updatesite.zip</file>
             <md5>release/TOOLS/update/3.2.0.RELEASE/e4.3/springsource-tool-suite-3.2.0.RELEASE-e4.3-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.2.0.RELEASE/e4.3/springsource-tool-suite-3.2.0.RELEASE-e4.3-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.2.0.RELEASE" eclipse-version="4.2.2" size="182MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.2.0.RELEASE/e4.2/springsource-tool-suite-3.2.0.RELEASE-e4.2.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.2.0.RELEASE/e4.2/springsource-tool-suite-3.2.0.RELEASE-e4.2.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.2.0.RELEASE/e4.2/springsource-tool-suite-3.2.0.RELEASE-e4.2.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.2.0.RELEASE" eclipse-version="3.8.2" size="179MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.2.0.RELEASE/e3.8/springsource-tool-suite-3.2.0.RELEASE-e3.8.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.2.0.RELEASE/e3.8/springsource-tool-suite-3.2.0.RELEASE-e3.8.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.2.0.RELEASE/e3.8/springsource-tool-suite-3.2.0.RELEASE-e3.8.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.2.0.RELEASE" eclipse-version="3.7.2" size="176MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.2.0.RELEASE/e3.7/springsource-tool-suite-3.2.0.RELEASE-e3.7.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.2.0.RELEASE/e3.7/springsource-tool-suite-3.2.0.RELEASE-e3.7.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.2.0.RELEASE/e3.7/springsource-tool-suite-3.2.0.RELEASE-e3.7.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Spring Tool Suite 3.1.0.RELEASE - based on Eclipse Juno 3.8.1" whatsnew="http://static.springsource.org/sts/nan/v310/NewAndNoteworthy.html">
+    <other name="Spring Tool Suite 3.1.0.RELEASE - based on Eclipse Juno 3.8.1" whatsnew="https://docs.spring.io/sts/nan/v310/NewAndNoteworthy.html">
         <download os="windows" version="3.1.0.RELEASE" eclipse-version="3.8" size="358MB">
             <description>Windows</description>
             <file>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-win32-installer.exe</file>
             <md5>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-win32-installer.exe.md5</md5>
             <sha1>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.1.0.RELEASE" eclipse-version="3.8" size="357MB">
             <description>Windows</description>
             <file>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-win32.zip</file>
             <md5>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-win32.zip.md5</md5>
             <sha1>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.1.0.RELEASE" eclipse-version="3.8" size="358MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-win32-x86_64-installer.exe</file>
             <md5>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.1.0.RELEASE" eclipse-version="3.8" size="357MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-win32-x86_64.zip</file>
             <md5>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.1.0.RELEASE" eclipse-version="3.8" size="358MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.1.0.RELEASE" eclipse-version="3.8" size="353MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-macosx-cocoa.tar.gz</file>
             <md5>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.1.0.RELEASE" eclipse-version="3.8" size="357MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.1.0.RELEASE" eclipse-version="3.8" size="353MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.1.0.RELEASE" eclipse-version="3.8" size="357MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-linux-gtk-installer.sh</file>
             <md5>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.1.0.RELEASE" eclipse-version="3.8" size="354MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-linux-gtk.tar.gz</file>
             <md5>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.1.0.RELEASE" eclipse-version="3.8" size="357MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.1.0.RELEASE" eclipse-version="3.8" size="354MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.1.0.RELEASE" eclipse-version="4.2" size="180MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.1.0.RELEASE/e4.2/springsource-tool-suite-3.1.0.RELEASE-e4.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.1.0.RELEASE/e4.2/springsource-tool-suite-3.1.0.RELEASE-e4.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.1.0.RELEASE/e4.2/springsource-tool-suite-3.1.0.RELEASE-e4.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.1.0.RELEASE" eclipse-version="3.8" size="178MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.1.0.RELEASE/e3.8/springsource-tool-suite-3.1.0.RELEASE-e3.8-updatesite.zip</file>
             <md5>release/TOOLS/update/3.1.0.RELEASE/e3.8/springsource-tool-suite-3.1.0.RELEASE-e3.8-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.1.0.RELEASE/e3.8/springsource-tool-suite-3.1.0.RELEASE-e3.8-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.1.0.RELEASE" eclipse-version="3.7" size="175MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.1.0.RELEASE/e3.7/springsource-tool-suite-3.1.0.RELEASE-e3.7-updatesite.zip</file>
             <md5>release/TOOLS/update/3.1.0.RELEASE/e3.7/springsource-tool-suite-3.1.0.RELEASE-e3.7-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.1.0.RELEASE/e3.7/springsource-tool-suite-3.1.0.RELEASE-e3.7-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Groovy/Grails Tool Suite 3.1.0.RELEASE - based on Eclipse Juno 3.8.1" whatsnew="http://static.springsource.org/sts/nan/v310/NewAndNoteworthy.html">
+    <other name="Groovy/Grails Tool Suite 3.1.0.RELEASE - based on Eclipse Juno 3.8.1" whatsnew="https://docs.spring.io/sts/nan/v310/NewAndNoteworthy.html">
         <download os="windows" version="3.1.0.RELEASE" eclipse-version="3.8" size="400MB">
             <description>Windows</description>
             <file>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-win32-installer.exe</file>
             <md5>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-win32-installer.exe.md5</md5>
             <sha1>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.1.0.RELEASE" eclipse-version="3.8" size="401MB">
             <description>Windows</description>
             <file>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-win32.zip</file>
             <md5>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-win32.zip.md5</md5>
             <sha1>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.1.0.RELEASE" eclipse-version="3.8" size="400MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-win32-x86_64-installer.exe</file>
             <md5>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.1.0.RELEASE" eclipse-version="3.8" size="401MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-win32-x86_64.zip</file>
             <md5>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.1.0.RELEASE" eclipse-version="3.8" size="399MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.1.0.RELEASE" eclipse-version="3.8" size="395MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-macosx-cocoa.tar.gz</file>
             <md5>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.1.0.RELEASE" eclipse-version="3.8" size="400MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.1.0.RELEASE" eclipse-version="3.8" size="395MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.1.0.RELEASE" eclipse-version="3.8" size="399MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-linux-gtk-installer.sh</file>
             <md5>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.1.0.RELEASE" eclipse-version="3.8" size="395MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-linux-gtk.tar.gz</file>
             <md5>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.1.0.RELEASE" eclipse-version="3.8" size="399MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.1.0.RELEASE" eclipse-version="3.8" size="395MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.1.0.RELEASE" eclipse-version="4.2" size="180MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.1.0.RELEASE/e4.2/springsource-tool-suite-3.1.0.RELEASE-e4.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.1.0.RELEASE/e4.2/springsource-tool-suite-3.1.0.RELEASE-e4.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.1.0.RELEASE/e4.2/springsource-tool-suite-3.1.0.RELEASE-e4.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.1.0.RELEASE" eclipse-version="3.8" size="178MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.1.0.RELEASE/e3.8/springsource-tool-suite-3.1.0.RELEASE-e3.8-updatesite.zip</file>
             <md5>release/TOOLS/update/3.1.0.RELEASE/e3.8/springsource-tool-suite-3.1.0.RELEASE-e3.8-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.1.0.RELEASE/e3.8/springsource-tool-suite-3.1.0.RELEASE-e3.8-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.1.0.RELEASE" eclipse-version="3.7" size="175MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.1.0.RELEASE/e3.7/springsource-tool-suite-3.1.0.RELEASE-e3.7-updatesite.zip</file>
             <md5>release/TOOLS/update/3.1.0.RELEASE/e3.7/springsource-tool-suite-3.1.0.RELEASE-e3.7-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.1.0.RELEASE/e3.7/springsource-tool-suite-3.1.0.RELEASE-e3.7-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Spring Tool Suite 3.1.0.RELEASE - based on Eclipse Juno 4.2.1" whatsnew="http://static.springsource.org/sts/nan/v310/NewAndNoteworthy.html">
+    <other name="Spring Tool Suite 3.1.0.RELEASE - based on Eclipse Juno 4.2.1" whatsnew="https://docs.spring.io/sts/nan/v310/NewAndNoteworthy.html">
         <download os="windows" version="3.1.0.RELEASE" eclipse-version="4.2" size="361MB">
             <description>Windows</description>
             <file>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-win32-installer.exe</file>
             <md5>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.1.0.RELEASE" eclipse-version="4.2" size="359MB">
             <description>Windows</description>
             <file>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-win32.zip</file>
             <md5>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-win32.zip.md5</md5>
             <sha1>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.1.0.RELEASE" eclipse-version="4.2" size="361MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.1.0.RELEASE" eclipse-version="4.2" size="359MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-win32-x86_64.zip</file>
             <md5>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.1.0.RELEASE" eclipse-version="4.2" size="360MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.1.0.RELEASE" eclipse-version="4.2" size="356MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.1.0.RELEASE" eclipse-version="4.2" size="360MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.1.0.RELEASE" eclipse-version="4.2" size="356MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.1.0.RELEASE" eclipse-version="4.2" size="360MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-linux-gtk-installer.sh</file>
             <md5>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.1.0.RELEASE" eclipse-version="4.2" size="356MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-linux-gtk.tar.gz</file>
             <md5>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.1.0.RELEASE" eclipse-version="4.2" size="360MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.1.0.RELEASE" eclipse-version="4.2" size="357MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.1.0.RELEASE" eclipse-version="4.2" size="180MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.1.0.RELEASE/e4.2/springsource-tool-suite-3.1.0.RELEASE-e4.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.1.0.RELEASE/e4.2/springsource-tool-suite-3.1.0.RELEASE-e4.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.1.0.RELEASE/e4.2/springsource-tool-suite-3.1.0.RELEASE-e4.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.1.0.RELEASE" eclipse-version="3.8" size="178MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.1.0.RELEASE/e3.8/springsource-tool-suite-3.1.0.RELEASE-e3.8-updatesite.zip</file>
             <md5>release/TOOLS/update/3.1.0.RELEASE/e3.8/springsource-tool-suite-3.1.0.RELEASE-e3.8-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.1.0.RELEASE/e3.8/springsource-tool-suite-3.1.0.RELEASE-e3.8-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.1.0.RELEASE" eclipse-version="3.7" size="175MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.1.0.RELEASE/e3.7/springsource-tool-suite-3.1.0.RELEASE-e3.7-updatesite.zip</file>
             <md5>release/TOOLS/update/3.1.0.RELEASE/e3.7/springsource-tool-suite-3.1.0.RELEASE-e3.7-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.1.0.RELEASE/e3.7/springsource-tool-suite-3.1.0.RELEASE-e3.7-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Groovy/Grails Tool Suite 3.1.0.RELEASE - based on Eclipse Juno 4.2.1" whatsnew="http://static.springsource.org/sts/nan/v310/NewAndNoteworthy.html">
+    <other name="Groovy/Grails Tool Suite 3.1.0.RELEASE - based on Eclipse Juno 4.2.1" whatsnew="https://docs.spring.io/sts/nan/v310/NewAndNoteworthy.html">
         <download os="windows" version="3.1.0.RELEASE" eclipse-version="4.2" size="403MB">
             <description>Windows</description>
             <file>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-win32-installer.exe</file>
             <md5>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.1.0.RELEASE" eclipse-version="4.2" size="403MB">
             <description>Windows</description>
             <file>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-win32.zip</file>
             <md5>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-win32.zip.md5</md5>
             <sha1>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.1.0.RELEASE" eclipse-version="4.2" size="403MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.1.0.RELEASE" eclipse-version="4.2" size="403MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-win32-x86_64.zip</file>
             <md5>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.1.0.RELEASE" eclipse-version="4.2" size="403MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.1.0.RELEASE" eclipse-version="4.2" size="398MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.1.0.RELEASE" eclipse-version="4.2" size="402MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.1.0.RELEASE" eclipse-version="4.2" size="397MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.1.0.RELEASE" eclipse-version="4.2" size="402MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-linux-gtk-installer.sh</file>
             <md5>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.1.0.RELEASE" eclipse-version="4.2" size="398MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-linux-gtk.tar.gz</file>
             <md5>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.1.0.RELEASE" eclipse-version="4.2" size="402MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.1.0.RELEASE" eclipse-version="4.2" size="398MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.1.0.RELEASE" eclipse-version="4.2" size="180MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.1.0.RELEASE/e4.2/springsource-tool-suite-3.1.0.RELEASE-e4.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.1.0.RELEASE/e4.2/springsource-tool-suite-3.1.0.RELEASE-e4.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.1.0.RELEASE/e4.2/springsource-tool-suite-3.1.0.RELEASE-e4.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.1.0.RELEASE" eclipse-version="3.8" size="178MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.1.0.RELEASE/e3.8/springsource-tool-suite-3.1.0.RELEASE-e3.8-updatesite.zip</file>
             <md5>release/TOOLS/update/3.1.0.RELEASE/e3.8/springsource-tool-suite-3.1.0.RELEASE-e3.8-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.1.0.RELEASE/e3.8/springsource-tool-suite-3.1.0.RELEASE-e3.8-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.1.0.RELEASE" eclipse-version="3.7" size="175MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.1.0.RELEASE/e3.7/springsource-tool-suite-3.1.0.RELEASE-e3.7-updatesite.zip</file>
             <md5>release/TOOLS/update/3.1.0.RELEASE/e3.7/springsource-tool-suite-3.1.0.RELEASE-e3.7-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.1.0.RELEASE/e3.7/springsource-tool-suite-3.1.0.RELEASE-e3.7-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Previous Version - Spring Tool Suite 3.0.0.RELEASE" whatsnew="http://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-3.0.0.RELEASE.pdf">
+    <other name="Previous Version - Spring Tool Suite 3.0.0.RELEASE" whatsnew="https://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-3.0.0.RELEASE.pdf">
         <download os="windows" version="3.0.0.RELEASE" eclipse-version="4.2" size="359MB">
             <description>Windows</description>
             <file>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-win32-installer.exe</file>
             <md5>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.0.0.RELEASE" eclipse-version="4.2" size="358MB">
             <description>Windows</description>
             <file>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-win32.zip</file>
             <md5>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-win32.zip.md5</md5>
             <sha1>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.0.0.RELEASE" eclipse-version="4.2" size="359MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.0.0.RELEASE" eclipse-version="4.2" size="358MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-win32-x86_64.zip</file>
             <md5>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.0.0.RELEASE" eclipse-version="4.2" size="359MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.0.0.RELEASE" eclipse-version="4.2" size="355MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.0.0.RELEASE" eclipse-version="4.2" size="359MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.0.0.RELEASE" eclipse-version="4.2" size="355MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.0.0.RELEASE" eclipse-version="4.2" size="359MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-linux-gtk-installer.sh</file>
             <md5>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.0.0.RELEASE" eclipse-version="4.2" size="356MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-linux-gtk.tar.gz</file>
             <md5>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.0.0.RELEASE" eclipse-version="4.2" size="359MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.0.0.RELEASE" eclipse-version="4.2" size="356MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.0.0.RELEASE" eclipse-version="4.2" size="182MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.0.0.RELEASE/e4.2/springsource-tool-suite-3.0.0.RELEASE-e4.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.0.0.RELEASE/e4.2/springsource-tool-suite-3.0.0.RELEASE-e4.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.0.0.RELEASE/e4.2/springsource-tool-suite-3.0.0.RELEASE-e4.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.0.0.RELEASE" eclipse-version="3.7" size="177MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.0.0.RELEASE/e3.7/springsource-tool-suite-3.0.0.RELEASE-e3.7-updatesite.zip</file>
             <md5>release/TOOLS/update/3.0.0.RELEASE/e3.7/springsource-tool-suite-3.0.0.RELEASE-e3.7-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.0.0.RELEASE/e3.7/springsource-tool-suite-3.0.0.RELEASE-e3.7-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Previous Version - Groovy/Grails Tool Suite 3.0.0.RELEASE" whatsnew="http://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-3.0.0.RELEASE.pdf">
+    <other name="Previous Version - Groovy/Grails Tool Suite 3.0.0.RELEASE" whatsnew="https://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-3.0.0.RELEASE.pdf">
         <download os="windows" version="3.0.0.RELEASE" eclipse-version="4.2" size="401MB">
             <description>Windows</description>
             <file>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-win32-installer.exe</file>
             <md5>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.0.0.RELEASE" eclipse-version="4.2" size="401MB">
             <description>Windows</description>
             <file>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-win32.zip</file>
             <md5>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-win32.zip.md5</md5>
             <sha1>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.0.0.RELEASE" eclipse-version="4.2" size="400MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.0.0.RELEASE" eclipse-version="4.2" size="401MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-win32-x86_64.zip</file>
             <md5>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.0.0.RELEASE" eclipse-version="4.2" size="400MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.0.0.RELEASE" eclipse-version="4.2" size="396MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.0.0.RELEASE" eclipse-version="4.2" size="400MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.0.0.RELEASE" eclipse-version="4.2" size="396MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.0.0.RELEASE" eclipse-version="4.2" size="400MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-linux-gtk-installer.sh</file>
             <md5>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.0.0.RELEASE" eclipse-version="4.2" size="396MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-linux-gtk.tar.gz</file>
             <md5>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.0.0.RELEASE" eclipse-version="4.2" size="400MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.0.0.RELEASE" eclipse-version="4.2" size="396MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.0.0.RELEASE" eclipse-version="4.2" size="182MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.0.0.RELEASE/e4.2/springsource-tool-suite-3.0.0.RELEASE-e4.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.0.0.RELEASE/e4.2/springsource-tool-suite-3.0.0.RELEASE-e4.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.0.0.RELEASE/e4.2/springsource-tool-suite-3.0.0.RELEASE-e4.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.0.0.RELEASE" eclipse-version="3.7" size="177MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.0.0.RELEASE/e3.7/springsource-tool-suite-3.0.0.RELEASE-e3.7-updatesite.zip</file>
             <md5>release/TOOLS/update/3.0.0.RELEASE/e3.7/springsource-tool-suite-3.0.0.RELEASE-e3.7-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.0.0.RELEASE/e3.7/springsource-tool-suite-3.0.0.RELEASE-e3.7-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Previous Version - 2.9.2.RELEASE" whatsnew="http://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.9.2.RELEASE.pdf">
+    <other name="Previous Version - 2.9.2.RELEASE" whatsnew="https://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.9.2.RELEASE.pdf">
         <download os="windows" version="2.9.2.RELEASE" eclipse-version="3.7.2" size="352MB">
             <description>Windows</description>
             <file>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-win32-installer.exe</file>
             <md5>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.9.2.RELEASE" eclipse-version="3.7.2" size="351MB">
             <description>Windows</description>
             <file>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-win32.zip</file>
             <md5>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-win32.zip.md5</md5>
             <sha1>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.9.2.RELEASE" eclipse-version="3.7.2" size="352MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.9.2.RELEASE" eclipse-version="3.7.2" size="351MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-win32-x86_64.zip</file>
             <md5>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.9.2.RELEASE" eclipse-version="3.7.2" size="352MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-macosx-carbon-installer.dmg</file>
             <md5>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-macosx-carbon-installer.dmg.md5</md5>
             <sha1>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-macosx-carbon-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.9.2.RELEASE" eclipse-version="3.7.2" size="348MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-macosx-carbon.tar.gz</file>
             <md5>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-macosx-carbon.tar.gz.md5</md5>
             <sha1>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-macosx-carbon.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.9.2.RELEASE" eclipse-version="3.7.2" size="352MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.9.2.RELEASE" eclipse-version="3.7.2" size="348MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.9.2.RELEASE" eclipse-version="3.7.2" size="352MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.9.2.RELEASE" eclipse-version="3.7.2" size="348MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.9.2.RELEASE" eclipse-version="3.7.2" size="352MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-linux-gtk-installer.sh</file>
             <md5>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.9.2.RELEASE" eclipse-version="3.7.2" size="348MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-linux-gtk.tar.gz</file>
             <md5>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.9.2.RELEASE" eclipse-version="3.7.2" size="352MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.9.2.RELEASE" eclipse-version="3.7.2" size="348MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.9.2.RELEASE" eclipse-version="3.7.2" size="252MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.9.2.RELEASE/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-updatesite.zip</file>
             <md5>release/TOOLS/update/2.9.2.RELEASE/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.9.2.RELEASE/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.9.2.RELEASE" eclipse-version="3.6" size="206MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.9.2.RELEASE/e3.6/springsource-tool-suite-2.9.2.RELEASE-e3.6-updatesite.zip</file>
             <md5>release/TOOLS/update/2.9.2.RELEASE/e3.6/springsource-tool-suite-2.9.2.RELEASE-e3.6-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.9.2.RELEASE/e3.6/springsource-tool-suite-2.9.2.RELEASE-e3.6-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Previous Version - 2.9.1.RELEASE" whatsnew="http://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.9.2.RELEASE.pdf">
+    <other name="Previous Version - 2.9.1.RELEASE" whatsnew="https://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.9.2.RELEASE.pdf">
         <download os="windows" version="2.9.1.RELEASE" eclipse-version="3.7.2" size="347MB">
             <description>Windows</description>
             <file>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-win32-installer.exe</file>
             <md5>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.9.1.RELEASE" eclipse-version="3.7.2" size="346MB">
             <description>Windows</description>
             <file>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-win32.zip</file>
             <md5>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-win32.zip.md5</md5>
             <sha1>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.9.1.RELEASE" eclipse-version="3.7.2" size="347MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.9.1.RELEASE" eclipse-version="3.7.2" size="346MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-win32-x86_64.zip</file>
             <md5>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.9.1.RELEASE" eclipse-version="3.7.2" size="347MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-macosx-carbon-installer.dmg</file>
             <md5>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-macosx-carbon-installer.dmg.md5</md5>
             <sha1>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-macosx-carbon-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.9.1.RELEASE" eclipse-version="3.7.2" size="343MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-macosx-carbon.tar.gz</file>
             <md5>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-macosx-carbon.tar.gz.md5</md5>
             <sha1>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-macosx-carbon.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.9.1.RELEASE" eclipse-version="3.7.2" size="347MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.9.1.RELEASE" eclipse-version="3.7.2" size="343MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.9.1.RELEASE" eclipse-version="3.7.2" size="347MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.9.1.RELEASE" eclipse-version="3.7.2" size="343MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.9.1.RELEASE" eclipse-version="3.7.2" size="346MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-linux-gtk-installer.sh</file>
             <md5>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.9.1.RELEASE" eclipse-version="3.7.2" size="343MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-linux-gtk.tar.gz</file>
             <md5>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.9.1.RELEASE" eclipse-version="3.7.2" size="347MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.9.1.RELEASE" eclipse-version="3.7.2" size="343MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.9.1.RELEASE" eclipse-version="3.7.2" size="252MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.9.1.RELEASE/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-updatesite.zip</file>
             <md5>release/TOOLS/update/2.9.1.RELEASE/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.9.1.RELEASE/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.9.1.RELEASE" eclipse-version="3.6" size="206MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.9.1.RELEASE/e3.6/springsource-tool-suite-2.9.1.RELEASE-e3.6-updatesite.zip</file>
             <md5>release/TOOLS/update/2.9.1.RELEASE/e3.6/springsource-tool-suite-2.9.1.RELEASE-e3.6-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.9.1.RELEASE/e3.6/springsource-tool-suite-2.9.1.RELEASE-e3.6-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Previous Version - 2.9.0.RELEASE" whatsnew="http://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.9.2.RELEASE.pdf">
+    <other name="Previous Version - 2.9.0.RELEASE" whatsnew="https://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.9.2.RELEASE.pdf">
         <download os="windows" version="2.9.0.RELEASE" eclipse-version="3.7.2" size="347MB">
             <description>Windows</description>
             <file>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-win32-installer.exe</file>
             <md5>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.9.0.RELEASE" eclipse-version="3.7.2" size="346MB">
             <description>Windows</description>
             <file>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-win32.zip</file>
             <md5>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-win32.zip.md5</md5>
             <sha1>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.9.0.RELEASE" eclipse-version="3.7.2" size="347MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.9.0.RELEASE" eclipse-version="3.7.2" size="346MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-win32-x86_64.zip</file>
             <md5>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.9.0.RELEASE" eclipse-version="3.7.2" size="347MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-macosx-carbon-installer.dmg</file>
             <md5>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-macosx-carbon-installer.dmg.md5</md5>
             <sha1>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-macosx-carbon-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.9.0.RELEASE" eclipse-version="3.7.2" size="343MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-macosx-carbon.tar.gz</file>
             <md5>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-macosx-carbon.tar.gz.md5</md5>
             <sha1>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-macosx-carbon.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.9.0.RELEASE" eclipse-version="3.7.2" size="347MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.9.0.RELEASE" eclipse-version="3.7.2" size="343MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.9.0.RELEASE" eclipse-version="3.7.2" size="347MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.9.0.RELEASE" eclipse-version="3.7.2" size="343MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.9.0.RELEASE" eclipse-version="3.7.2" size="346MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-linux-gtk-installer.sh</file>
             <md5>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.9.0.RELEASE" eclipse-version="3.7.2" size="343MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-linux-gtk.tar.gz</file>
             <md5>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.9.0.RELEASE" eclipse-version="3.7.2" size="347MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.9.0.RELEASE" eclipse-version="3.7.2" size="343MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.9.0.RELEASE" eclipse-version="3.7.2" size="252MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.9.0.RELEASE/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-updatesite.zip</file>
             <md5>release/TOOLS/update/2.9.0.RELEASE/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.9.0.RELEASE/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.9.0.RELEASE" eclipse-version="3.6" size="206MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.9.0.RELEASE/e3.6/springsource-tool-suite-2.9.0.RELEASE-e3.6-updatesite.zip</file>
             <md5>release/TOOLS/update/2.9.0.RELEASE/e3.6/springsource-tool-suite-2.9.0.RELEASE-e3.6-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.9.0.RELEASE/e3.6/springsource-tool-suite-2.9.0.RELEASE-e3.6-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Previous Version - 2.8.1.RELEASE" whatsnew="http://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.8.1.RELEASE.pdf">
+    <other name="Previous Version - 2.8.1.RELEASE" whatsnew="https://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.8.1.RELEASE.pdf">
         <download os="windows" version="2.8.1.RELEASE" eclipse-version="3.7.1" size="358MB">
             <description>Windows</description>
             <file>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-win32-installer.exe</file>
             <md5>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-win32-installer.exe.md5</md5>
             <sha1>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.8.1.RELEASE" eclipse-version="3.7.1" size="357MB">
             <description>Windows</description>
             <file>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-win32.zip</file>
             <md5>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-win32.zip.md5</md5>
             <sha1>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.8.1.RELEASE" eclipse-version="3.7.1" size="358MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-win32-x86_64-installer.exe</file>
             <md5>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.8.1.RELEASE" eclipse-version="3.7.1" size="357MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-win32-x86_64.zip</file>
             <md5>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.8.1.RELEASE" eclipse-version="3.7.1" size="358MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-macosx-carbon-installer.dmg</file>
             <md5>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-macosx-carbon-installer.dmg.md5</md5>
             <sha1>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-macosx-carbon-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.8.1.RELEASE" eclipse-version="3.7.1" size="354MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-macosx-carbon.tar.gz</file>
             <md5>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-macosx-carbon.tar.gz.md5</md5>
             <sha1>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-macosx-carbon.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.8.1.RELEASE" eclipse-version="3.7.1" size="358MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.8.1.RELEASE" eclipse-version="3.7.1" size="355MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-macosx-cocoa.tar.gz</file>
             <md5>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.8.1.RELEASE" eclipse-version="3.7.1" size="358MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.8.1.RELEASE" eclipse-version="3.7.1" size="355MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.8.1.RELEASE" eclipse-version="3.7.1" size="358MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-linux-gtk-installer.sh</file>
             <md5>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.8.1.RELEASE" eclipse-version="3.7.1" size="355MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-linux-gtk.tar.gz</file>
             <md5>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.8.1.RELEASE" eclipse-version="3.7.1" size="358MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.8.1.RELEASE" eclipse-version="3.7.1" size="355MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.8.1.RELEASE" eclipse-version="3.7.1" size="183MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.8.1.RELEASE/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-updatesite.zip</file>
             <md5>release/TOOLS/update/2.8.1.RELEASE/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.8.1.RELEASE/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.8.1.RELEASE" eclipse-version="3.6" size="205MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.8.1.RELEASE/e3.6/springsource-tool-suite-2.8.1.RELEASE-e3.6-updatesite.zip</file>
             <md5>release/TOOLS/update/2.8.1.RELEASE/e3.6/springsource-tool-suite-2.8.1.RELEASE-e3.6-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.8.1.RELEASE/e3.6/springsource-tool-suite-2.8.1.RELEASE-e3.6-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Previous Version - 2.8.0.RELEASE" whatsnew="http://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.8.1.RELEASE.pdf">
+    <other name="Previous Version - 2.8.0.RELEASE" whatsnew="https://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.8.1.RELEASE.pdf">
         <download os="windows" version="2.8.0.RELEASE" eclipse-version="3.7.1" size="358MB">
             <description>Windows</description>
             <file>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-win32-installer.exe</file>
             <md5>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-win32-installer.exe.md5</md5>
             <sha1>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.8.0.RELEASE" eclipse-version="3.7.1" size="357MB">
             <description>Windows</description>
             <file>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-win32.zip</file>
             <md5>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-win32.zip.md5</md5>
             <sha1>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.8.0.RELEASE" eclipse-version="3.7.1" size="358MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-win32-x86_64-installer.exe</file>
             <md5>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.8.0.RELEASE" eclipse-version="3.7.1" size="357MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-win32-x86_64.zip</file>
             <md5>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.8.0.RELEASE" eclipse-version="3.7.1" size="358MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-macosx-carbon-installer.dmg</file>
             <md5>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-macosx-carbon-installer.dmg.md5</md5>
             <sha1>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-macosx-carbon-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.8.0.RELEASE" eclipse-version="3.7.1" size="354MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-macosx-carbon.tar.gz</file>
             <md5>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-macosx-carbon.tar.gz.md5</md5>
             <sha1>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-macosx-carbon.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.8.0.RELEASE" eclipse-version="3.7.1" size="358MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.8.0.RELEASE" eclipse-version="3.7.1" size="354MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-macosx-cocoa.tar.gz</file>
             <md5>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.8.0.RELEASE" eclipse-version="3.7.1" size="358MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.8.0.RELEASE" eclipse-version="3.7.1" size="354MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.8.0.RELEASE" eclipse-version="3.7.1" size="358MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-linux-gtk-installer.sh</file>
             <md5>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.8.0.RELEASE" eclipse-version="3.7.1" size="354MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-linux-gtk.tar.gz</file>
             <md5>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.8.0.RELEASE" eclipse-version="3.7.1" size="358MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.8.0.RELEASE" eclipse-version="3.7.1" size="355MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.8.0.RELEASE" eclipse-version="3.7.1" size="183MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.8.0.RELEASE/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-updatesite.zip</file>
             <md5>release/TOOLS/update/2.8.0.RELEASE/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.8.0.RELEASE/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.8.0.RELEASE" eclipse-version="3.6" size="205MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.8.0.RELEASE/e3.6/springsource-tool-suite-2.8.0.RELEASE-e3.6-updatesite.zip</file>
             <md5>release/TOOLS/update/2.8.0.RELEASE/e3.6/springsource-tool-suite-2.8.0.RELEASE-e3.6-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.8.0.RELEASE/e3.6/springsource-tool-suite-2.8.0.RELEASE-e3.6-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Previous Version - 2.7.2.RELEASE" whatsnew="http://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.7.2.RELEASE.pdf">
+    <other name="Previous Version - 2.7.2.RELEASE" whatsnew="https://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.7.2.RELEASE.pdf">
         <download os="windows" version="2.7.2.RELEASE" eclipse-version="3.7" size="360MB">
             <description>Windows</description>
             <file>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-win32-installer.exe</file>
             <md5>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-win32-installer.exe.md5</md5>
             <sha1>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.7.2.RELEASE" eclipse-version="3.7" size="359MB">
             <description>Windows</description>
             <file>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-win32.zip</file>
             <md5>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-win32.zip.md5</md5>
             <sha1>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.7.2.RELEASE" eclipse-version="3.7" size="360MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-win32-x86_64-installer.exe</file>
             <md5>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.7.2.RELEASE" eclipse-version="3.7" size="359MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-win32-x86_64.zip</file>
             <md5>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.7.2.RELEASE" eclipse-version="3.7" size="360MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-macosx-carbon-installer.dmg</file>
             <md5>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-macosx-carbon-installer.dmg.md5</md5>
             <sha1>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-macosx-carbon-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.7.2.RELEASE" eclipse-version="3.7" size="357MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-macosx-carbon.tar.gz</file>
             <md5>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-macosx-carbon.tar.gz.md5</md5>
             <sha1>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-macosx-carbon.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.7.2.RELEASE" eclipse-version="3.7" size="361MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.7.2.RELEASE" eclipse-version="3.7" size="357MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-macosx-cocoa.tar.gz</file>
             <md5>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.7.2.RELEASE" eclipse-version="3.7" size="361MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.7.2.RELEASE" eclipse-version="3.7" size="357MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.7.2.RELEASE" eclipse-version="3.7" size="360MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-linux-gtk-installer.sh</file>
             <md5>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.7.2.RELEASE" eclipse-version="3.7" size="357MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-linux-gtk.tar.gz</file>
             <md5>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.7.2.RELEASE" eclipse-version="3.7" size="360MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.7.2.RELEASE" eclipse-version="3.7" size="357MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.7.2.RELEASE" eclipse-version="3.7" size="160MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.7.2.RELEASE/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-updatesite.zip</file>
             <md5>release/TOOLS/update/2.7.2.RELEASE/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.7.2.RELEASE/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.7.2.RELEASE" eclipse-version="3.6" size="223MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.7.2.RELEASE/e3.6/springsource-tool-suite-2.7.2.RELEASE-e3.6-updatesite.zip</file>
             <md5>release/TOOLS/update/2.7.2.RELEASE/e3.6/springsource-tool-suite-2.7.2.RELEASE-e3.6-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.7.2.RELEASE/e3.6/springsource-tool-suite-2.7.2.RELEASE-e3.6-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Previous Version - 2.7.1.RELEASE" whatsnew="http://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.7.2.RELEASE.pdf">
+    <other name="Previous Version - 2.7.1.RELEASE" whatsnew="https://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.7.2.RELEASE.pdf">
         <download os="windows" version="2.7.1.RELEASE" eclipse-version="3.7" size="361MB">
             <description>Windows</description>
             <file>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-win32-installer.exe</file>
             <md5>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-win32-installer.exe.md5</md5>
             <sha1>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.7.1.RELEASE" eclipse-version="3.7" size="360MB">
             <description>Windows</description>
             <file>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-win32.zip</file>
             <md5>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-win32.zip.md5</md5>
             <sha1>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.7.1.RELEASE" eclipse-version="3.7" size="361MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-win32-x86_64-installer.exe</file>
             <md5>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.7.1.RELEASE" eclipse-version="3.7" size="359MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-win32-x86_64.zip</file>
             <md5>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.7.1.RELEASE" eclipse-version="3.7" size="361MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-macosx-carbon-installer.dmg</file>
             <md5>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-macosx-carbon-installer.dmg.md5</md5>
             <sha1>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-macosx-carbon-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.7.1.RELEASE" eclipse-version="3.7" size="357MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-macosx-carbon.tar.gz</file>
             <md5>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-macosx-carbon.tar.gz.md5</md5>
             <sha1>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-macosx-carbon.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.7.1.RELEASE" eclipse-version="3.7" size="361MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.7.1.RELEASE" eclipse-version="3.7" size="357MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-macosx-cocoa.tar.gz</file>
             <md5>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.7.1.RELEASE" eclipse-version="3.7" size="361MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.7.1.RELEASE" eclipse-version="3.7" size="357MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.7.1.RELEASE" eclipse-version="3.7" size="360MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-linux-gtk-installer.sh</file>
             <md5>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.7.1.RELEASE" eclipse-version="3.7" size="357MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-linux-gtk.tar.gz</file>
             <md5>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.7.1.RELEASE" eclipse-version="3.7" size="360MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.7.1.RELEASE" eclipse-version="3.7" size="357MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.7.1.RELEASE" eclipse-version="3.7" size="160MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.7.1.RELEASE/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-updatesite.zip</file>
             <md5>release/TOOLS/update/2.7.1.RELEASE/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.7.1.RELEASE/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.7.1.RELEASE" eclipse-version="3.6" size="223MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.7.1.RELEASE/e3.6/springsource-tool-suite-2.7.1.RELEASE-e3.6-updatesite.zip</file>
             <md5>release/TOOLS/update/2.7.1.RELEASE/e3.6/springsource-tool-suite-2.7.1.RELEASE-e3.6-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.7.1.RELEASE/e3.6/springsource-tool-suite-2.7.1.RELEASE-e3.6-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Previous Version - 2.7.0.RELEASE" whatsnew="http://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.7.2.RELEASE.pdf">
+    <other name="Previous Version - 2.7.0.RELEASE" whatsnew="https://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.7.2.RELEASE.pdf">
         <download os="windows" version="2.7.0.RELEASE" eclipse-version="3.7" size="361MB">
             <description>Windows</description>
             <file>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-win32-installer.exe</file>
             <md5>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-win32-installer.exe.md5</md5>
             <sha1>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.7.0.RELEASE" eclipse-version="3.7" size="360MB">
             <description>Windows</description>
             <file>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-win32.zip</file>
             <md5>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-win32.zip.md5</md5>
             <sha1>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.7.0.RELEASE" eclipse-version="3.7" size="361MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-win32-x86_64-installer.exe</file>
             <md5>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.7.0.RELEASE" eclipse-version="3.7" size="359MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-win32-x86_64.zip</file>
             <md5>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.7.0.RELEASE" eclipse-version="3.7" size="360MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-macosx-carbon-installer.dmg</file>
             <md5>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-macosx-carbon-installer.dmg.md5</md5>
             <sha1>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-macosx-carbon-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.7.0.RELEASE" eclipse-version="3.7" size="357MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-macosx-carbon.tar.gz</file>
             <md5>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-macosx-carbon.tar.gz.md5</md5>
             <sha1>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-macosx-carbon.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.7.0.RELEASE" eclipse-version="3.7" size="361MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.7.0.RELEASE" eclipse-version="3.7" size="357MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-macosx-cocoa.tar.gz</file>
             <md5>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.7.0.RELEASE" eclipse-version="3.7" size="361MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.7.0.RELEASE" eclipse-version="3.7" size="357MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.7.0.RELEASE" eclipse-version="3.7" size="360MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-linux-gtk-installer.sh</file>
             <md5>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.7.0.RELEASE" eclipse-version="3.7" size="357MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-linux-gtk.tar.gz</file>
             <md5>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.7.0.RELEASE" eclipse-version="3.7" size="360MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.7.0.RELEASE" eclipse-version="3.7" size="357MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.7.0.RELEASE" eclipse-version="3.7" size="160MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.7.0.RELEASE/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-updatesite.zip</file>
             <md5>release/TOOLS/update/2.7.0.RELEASE/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.7.0.RELEASE/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.7.0.RELEASE" eclipse-version="3.6" size="223MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.7.0.RELEASE/e3.6/springsource-tool-suite-2.7.0.RELEASE-e3.6-updatesite.zip</file>
             <md5>release/TOOLS/update/2.7.0.RELEASE/e3.6/springsource-tool-suite-2.7.0.RELEASE-e3.6-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.7.0.RELEASE/e3.6/springsource-tool-suite-2.7.0.RELEASE-e3.6-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Previous Version - 2.6.1.SR1" whatsnew="http://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.6.1.SR1.pdf">
+    <other name="Previous Version - 2.6.1.SR1" whatsnew="https://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.6.1.SR1.pdf">
         <download os="windows" version="2.6.1.SR1" eclipse-version="3.6.2" size="347MB">
             <description>Windows</description>
             <file>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-win32-installer.exe</file>
             <md5>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.6.1.SR1" eclipse-version="3.6.2" size="346MB">
             <description>Windows</description>
             <file>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-win32.zip</file>
             <md5>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-win32.zip.md5</md5>
             <sha1>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.6.1.SR1" eclipse-version="3.6.2" size="347MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.6.1.SR1" eclipse-version="3.6.2" size="346MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-win32-x86_64.zip</file>
             <md5>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.6.1.SR1" eclipse-version="3.6.2" size="347MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-macosx-carbon-installer.dmg</file>
             <md5>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-macosx-carbon-installer.dmg.md5</md5>
             <sha1>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-macosx-carbon-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.6.1.SR1" eclipse-version="3.6.2" size="344MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-macosx-carbon.tar.gz</file>
             <md5>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-macosx-carbon.tar.gz.md5</md5>
             <sha1>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-macosx-carbon.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.6.1.SR1" eclipse-version="3.6.2" size="348MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.6.1.SR1" eclipse-version="3.6.2" size="344MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.6.1.SR1" eclipse-version="3.6.2" size="348MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.6.1.SR1" eclipse-version="3.6.2" size="344MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.6.1.SR1" eclipse-version="3.6.2" size="347MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-linux-gtk-installer.sh</file>
             <md5>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.6.1.SR1" eclipse-version="3.6.2" size="344MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-linux-gtk.tar.gz</file>
             <md5>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.6.1.SR1" eclipse-version="3.6.2" size="347MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.6.1.SR1" eclipse-version="3.6.2" size="344MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.6.1.RELEASE" eclipse-version="3.6" size="241MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.6.1.RELEASE/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6-updatesite.zip</file>
             <md5>release/TOOLS/update/2.6.1.RELEASE/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.6.1.RELEASE/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.6.1.RELEASE" eclipse-version="3.5" size="175MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.6.1.RELEASE/e3.5/springsource-tool-suite-2.6.1.RELEASE-e3.5-updatesite.zip</file>
             <md5>release/TOOLS/update/2.6.1.RELEASE/e3.5/springsource-tool-suite-2.6.1.RELEASE-e3.5-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.6.1.RELEASE/e3.5/springsource-tool-suite-2.6.1.RELEASE-e3.5-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Previous Version - 2.6.1" whatsnew="http://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.6.1.SR1.pdf">
+    <other name="Previous Version - 2.6.1" whatsnew="https://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.6.1.SR1.pdf">
         <download os="windows" version="2.6.1.RELEASE" eclipse-version="3.6.2" size="346MB">
             <description>Windows</description>
             <file>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-win32-installer.exe</file>
             <md5>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.6.1.RELEASE" eclipse-version="3.6.2" size="345MB">
             <description>Windows</description>
             <file>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-win32.zip</file>
             <md5>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-win32.zip.md5</md5>
             <sha1>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.6.1.RELEASE" eclipse-version="3.6.2" size="346MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.6.1.RELEASE" eclipse-version="3.6.2" size="345MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-win32-x86_64.zip</file>
             <md5>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.6.1.RELEASE" eclipse-version="3.6.2" size="347MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-macosx-carbon-installer.dmg</file>
             <md5>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-macosx-carbon-installer.dmg.md5</md5>
             <sha1>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-macosx-carbon-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.6.1.RELEASE" eclipse-version="3.6.2" size="343MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-macosx-carbon.tar.gz</file>
             <md5>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-macosx-carbon.tar.gz.md5</md5>
             <sha1>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-macosx-carbon.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.6.1.RELEASE" eclipse-version="3.6.2" size="347MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.6.1.RELEASE" eclipse-version="3.6.2" size="343MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.6.1.RELEASE" eclipse-version="3.6.2" size="346MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.6.1.RELEASE" eclipse-version="3.6.2" size="343MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.6.1.RELEASE" eclipse-version="3.6.2" size="346MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-linux-gtk-installer.sh</file>
             <md5>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.6.1.RELEASE" eclipse-version="3.6.2" size="343MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-linux-gtk.tar.gz</file>
             <md5>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.6.1.RELEASE" eclipse-version="3.6.2" size="346MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.6.1.RELEASE" eclipse-version="3.6.2" size="343MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.6.1.RELEASE" eclipse-version="3.6" size="241MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.6.1.RELEASE/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6-updatesite.zip</file>
             <md5>release/TOOLS/update/2.6.1.RELEASE/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.6.1.RELEASE/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.6.1.RELEASE" eclipse-version="3.5" size="175MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.6.1.RELEASE/e3.5/springsource-tool-suite-2.6.1.RELEASE-e3.5-updatesite.zip</file>
             <md5>release/TOOLS/update/2.6.1.RELEASE/e3.5/springsource-tool-suite-2.6.1.RELEASE-e3.5-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.6.1.RELEASE/e3.5/springsource-tool-suite-2.6.1.RELEASE-e3.5-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Previous Version - 2.6.0.SR1" whatsnew="http://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.6.1.SR1.pdf">
+    <other name="Previous Version - 2.6.0.SR1" whatsnew="https://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.6.1.SR1.pdf">
         <download os="windows" version="2.6.0.SR1" eclipse-version="3.6.2" size="339MB">
             <description>Windows</description>
             <file>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-win32-installer.exe</file>
             <md5>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.6.0.SR1" eclipse-version="3.6.2" size="338MB">
             <description>Windows</description>
             <file>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-win32.zip</file>
             <md5>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-win32.zip.md5</md5>
             <sha1>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.6.0.SR1" eclipse-version="3.6.2" size="339MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.6.0.SR1" eclipse-version="3.6.2" size="338MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-win32-x86_64.zip</file>
             <md5>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.6.0.SR1" eclipse-version="3.6.2" size="339MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-macosx-carbon-installer.dmg</file>
             <md5>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-macosx-carbon-installer.dmg.md5</md5>
             <sha1>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-macosx-carbon-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.6.0.SR1" eclipse-version="3.6.2" size="335MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-macosx-carbon.tar.gz</file>
             <md5>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-macosx-carbon.tar.gz.md5</md5>
             <sha1>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-macosx-carbon.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.6.0.SR1" eclipse-version="3.6.2" size="339MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.6.0.SR1" eclipse-version="3.6.2" size="336MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.6.0.SR1" eclipse-version="3.6.2" size="339MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.6.0.SR1" eclipse-version="3.6.2" size="336MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.6.0.SR1" eclipse-version="3.6.2" size="339MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-linux-gtk-installer.sh</file>
             <md5>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.6.0.SR1" eclipse-version="3.6.2" size="336MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-linux-gtk.tar.gz</file>
             <md5>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.6.0.SR1" eclipse-version="3.6.2" size="339MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.6.0.SR1" eclipse-version="3.6.2" size="336MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Previous Version - 2.6.0.RELEASE" whatsnew="http://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.6.1.SR1.pdf">
+    <other name="Previous Version - 2.6.0.RELEASE" whatsnew="https://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.6.1.SR1.pdf">
         <download os="windows" version="2.6.0.RELEASE" eclipse-version="3.6.2" size="186MB">
             <description>Windows</description>
             <file>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-win32-installer.exe</file>
             <md5>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.6.0.RELEASE" eclipse-version="3.6.2" size="336MB">
             <description>Windows</description>
             <file>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-win32.zip</file>
             <md5>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-win32.zip.md5</md5>
             <sha1>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.6.0.RELEASE" eclipse-version="3.6.2" size="186MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.6.0.RELEASE" eclipse-version="3.6.2" size="336MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-win32-x86_64.zip</file>
             <md5>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.6.0.RELEASE" eclipse-version="3.6.2" size="186MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-macosx-carbon-installer.dmg</file>
             <md5>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-macosx-carbon-installer.dmg.md5</md5>
             <sha1>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-macosx-carbon-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.6.0.RELEASE" eclipse-version="3.6.2" size="334MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-macosx-carbon.tar.gz</file>
             <md5>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-macosx-carbon.tar.gz.md5</md5>
             <sha1>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-macosx-carbon.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.6.0.RELEASE" eclipse-version="3.6.2" size="186MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.6.0.RELEASE" eclipse-version="3.6.2" size="334MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.6.0.RELEASE" eclipse-version="3.6.2" size="186MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.6.0.RELEASE" eclipse-version="3.6.2" size="334MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.6.0.RELEASE" eclipse-version="3.6.2" size="185MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-linux-gtk-installer.sh</file>
             <md5>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.6.0.RELEASE" eclipse-version="3.6.2" size="334MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-linux-gtk.tar.gz</file>
             <md5>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.6.0.RELEASE" eclipse-version="3.6.2" size="186MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.6.0.RELEASE" eclipse-version="3.6.2" size="334MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.6.0.RELEASE" eclipse-version="3.6" size="253MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.6.0.RELEASE/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6-updatesite.zip</file>
             <md5>release/TOOLS/update/2.6.0.RELEASE/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.6.0.RELEASE/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.6.0.RELEASE" eclipse-version="3.5" size="187MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.6.0.RELEASE/e3.5/springsource-tool-suite-2.6.0.RELEASE-e3.5-updatesite.zip</file>
             <md5>release/TOOLS/update/2.6.0.RELEASE/e3.5/springsource-tool-suite-2.6.0.RELEASE-e3.5-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.6.0.RELEASE/e3.5/springsource-tool-suite-2.6.0.RELEASE-e3.5-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Previous Version - 2.5.2.SR1" whatsnew="http://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.5.2.SR1.pdf">
+    <other name="Previous Version - 2.5.2.SR1" whatsnew="https://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.5.2.SR1.pdf">
         <download os="windows" version="2.5.2.SR1" eclipse-version="3.6.2" size="192MB">
             <description>Windows</description>
             <file>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-win32-installer.exe</file>
             <md5>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.5.2.SR1" eclipse-version="3.6.2" size="349MB">
             <description>Windows</description>
             <file>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-win32.zip</file>
             <md5>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-win32.zip.md5</md5>
             <sha1>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.5.2.SR1" eclipse-version="3.6.2" size="192MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.5.2.SR1" eclipse-version="3.6.2" size="349MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-win32-x86_64.zip</file>
             <md5>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.5.2.SR1" eclipse-version="3.6.2" size="192MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-macosx-carbon-installer.dmg</file>
             <md5>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-macosx-carbon-installer.dmg.md5</md5>
             <sha1>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-macosx-carbon-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.5.2.SR1" eclipse-version="3.6.2" size="346MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-macosx-carbon.tar.gz</file>
             <md5>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-macosx-carbon.tar.gz.md5</md5>
             <sha1>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-macosx-carbon.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.5.2.SR1" eclipse-version="3.6.2" size="192MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.5.2.SR1" eclipse-version="3.6.2" size="346MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.5.2.SR1" eclipse-version="3.6.2" size="192MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.5.2.SR1" eclipse-version="3.6.2" size="346MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.5.2.SR1" eclipse-version="3.6.2" size="191MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-linux-gtk-installer.sh</file>
             <md5>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.5.2.SR1" eclipse-version="3.6.2" size="346MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-linux-gtk.tar.gz</file>
             <md5>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.5.2.SR1" eclipse-version="3.6.2" size="191MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.5.2.SR1" eclipse-version="3.6.2" size="347MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.5.2.SR1" eclipse-version="3.6" size="252MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.5.2.SR1/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6-updatesite.zip</file>
             <md5>release/TOOLS/update/2.5.2.SR1/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.5.2.SR1/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.5.2.SR1" eclipse-version="3.5" size="186MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.5.2.SR1/e3.5/springsource-tool-suite-2.5.2.SR1-e3.5-updatesite.zip</file>
             <md5>release/TOOLS/update/2.5.2.SR1/e3.5/springsource-tool-suite-2.5.2.SR1-e3.5-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.5.2.SR1/e3.5/springsource-tool-suite-2.5.2.SR1-e3.5-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Previous Version - 2.5.2.RELEASE" whatsnew="http://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.5.2.SR1.pdf">
+    <other name="Previous Version - 2.5.2.RELEASE" whatsnew="https://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.5.2.SR1.pdf">
         <download os="windows" version="2.5.2.RELEASE" eclipse-version="3.6.1" size="190MB">
             <description>Windows</description>
             <file>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-win32-installer.exe</file>
             <md5>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-win32-installer.exe.md5</md5>
             <sha1>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.5.2.RELEASE" eclipse-version="3.6.1" size="346MB">
             <description>Windows</description>
             <file>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-win32.zip</file>
             <md5>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-win32.zip.md5</md5>
             <sha1>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.5.2.RELEASE" eclipse-version="3.6.1" size="190MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-win32-x86_64-installer.exe</file>
             <md5>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.5.2.RELEASE" eclipse-version="3.6.1" size="345MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-win32-x86_64.zip</file>
             <md5>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.5.2.RELEASE" eclipse-version="3.6.1" size="190MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-macosx-carbon-installer.dmg</file>
             <md5>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-macosx-carbon-installer.dmg.md5</md5>
             <sha1>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-macosx-carbon-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.5.2.RELEASE" eclipse-version="3.6.1" size="343MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-macosx-carbon.tar.gz</file>
             <md5>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-macosx-carbon.tar.gz.md5</md5>
             <sha1>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-macosx-carbon.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.5.2.RELEASE" eclipse-version="3.6.1" size="190MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.5.2.RELEASE" eclipse-version="3.6.1" size="343MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-macosx-cocoa.tar.gz</file>
             <md5>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.5.2.RELEASE" eclipse-version="3.6.1" size="190MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.5.2.RELEASE" eclipse-version="3.6.1" size="343MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.5.2.RELEASE" eclipse-version="3.6.1" size="190MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-linux-gtk-installer.sh</file>
             <md5>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.5.2.RELEASE" eclipse-version="3.6.1" size="343MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-linux-gtk.tar.gz</file>
             <md5>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.5.2.RELEASE" eclipse-version="3.6.1" size="190MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.5.2.RELEASE" eclipse-version="3.6.1" size="343MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.5.2.RELEASE" eclipse-version="3.6" size="169MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.5.2.RELEASE/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6-updatesite.zip</file>
             <md5>release/TOOLS/update/2.5.2.RELEASE/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.5.2.RELEASE/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.5.2.RELEASE" eclipse-version="3.5" size="165MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.5.2.RELEASE/e3.5/springsource-tool-suite-2.5.2.RELEASE-e3.5-updatesite.zip</file>
             <md5>release/TOOLS/update/2.5.2.RELEASE/e3.5/springsource-tool-suite-2.5.2.RELEASE-e3.5-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.5.2.RELEASE/e3.5/springsource-tool-suite-2.5.2.RELEASE-e3.5-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Previous Version - 2.5.1.RELEASE" whatsnew="http://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.5.2.SR1.pdf">
+    <other name="Previous Version - 2.5.1.RELEASE" whatsnew="https://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.5.2.SR1.pdf">
         <download os="windows" version="2.5.1.RELEASE" eclipse-version="3.6.1" size="193MB">
             <description>Windows</description>
             <file>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-win32-installer.exe</file>
             <md5>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-win32-installer.exe.md5</md5>
             <sha1>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.5.1.RELEASE" eclipse-version="3.6.1" size="350MB">
             <description>Windows</description>
             <file>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-win32.zip</file>
             <md5>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-win32.zip.md5</md5>
             <sha1>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.5.1.RELEASE" eclipse-version="3.6.1" size="193MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-win32-x86_64-installer.exe</file>
             <md5>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.5.1.RELEASE" eclipse-version="3.6.1" size="350MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-win32-x86_64.zip</file>
             <md5>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.5.1.RELEASE" eclipse-version="3.6.1" size="194MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-macosx-carbon-installer.dmg</file>
             <md5>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-macosx-carbon-installer.dmg.md5</md5>
             <sha1>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-macosx-carbon-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.5.1.RELEASE" eclipse-version="3.6.1" size="348MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-macosx-carbon.tar.gz</file>
             <md5>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-macosx-carbon.tar.gz.md5</md5>
             <sha1>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-macosx-carbon.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.5.1.RELEASE" eclipse-version="3.6.1" size="194MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.5.1.RELEASE" eclipse-version="3.6.1" size="348MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-macosx-cocoa.tar.gz</file>
             <md5>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.5.1.RELEASE" eclipse-version="3.6.1" size="193MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.5.1.RELEASE" eclipse-version="3.6.1" size="348MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.5.1.RELEASE" eclipse-version="3.6.1" size="193MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-linux-gtk-installer.sh</file>
             <md5>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.5.1.RELEASE" eclipse-version="3.6.1" size="348MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-linux-gtk.tar.gz</file>
             <md5>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.5.1.RELEASE" eclipse-version="3.6.1" size="193MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.5.1.RELEASE" eclipse-version="3.6.1" size="348MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.5.1.RELEASE" eclipse-version="3.6" size="171MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.5.1.RELEASE/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6-updatesite.zip</file>
             <md5>release/TOOLS/update/2.5.1.RELEASE/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.5.1.RELEASE/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.5.1.RELEASE" eclipse-version="3.5" size="167MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.5.1.RELEASE/e3.5/springsource-tool-suite-2.5.1.RELEASE-e3.5-updatesite.zip</file>
             <md5>release/TOOLS/update/2.5.1.RELEASE/e3.5/springsource-tool-suite-2.5.1.RELEASE-e3.5-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.5.1.RELEASE/e3.5/springsource-tool-suite-2.5.1.RELEASE-e3.5-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Previous Version - 2.5.0.RELEASE" whatsnew="http://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.5.2.SR1.pdf">
+    <other name="Previous Version - 2.5.0.RELEASE" whatsnew="https://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.5.2.SR1.pdf">
         <download os="windows" version="2.5.0.RELEASE" eclipse-version="3.6.1" size="194MB">
             <description>Windows</description>
             <file>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-win32-installer.exe</file>
             <md5>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-win32-installer.exe.md5</md5>
             <sha1>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.5.0.RELEASE" eclipse-version="3.6.1" size="355MB">
             <description>Windows</description>
             <file>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-win32.zip</file>
             <md5>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-win32.zip.md5</md5>
             <sha1>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.5.0.RELEASE" eclipse-version="3.6.1" size="194MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-win32-x86_64-installer.exe</file>
             <md5>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.5.0.RELEASE" eclipse-version="3.6.1" size="355MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-win32-x86_64.zip</file>
             <md5>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.5.0.RELEASE" eclipse-version="3.6.1" size="194MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-macosx-carbon-installer.dmg</file>
             <md5>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-macosx-carbon-installer.dmg.md5</md5>
             <sha1>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-macosx-carbon-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.5.0.RELEASE" eclipse-version="3.6.1" size="352MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-macosx-carbon.tar.gz</file>
             <md5>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-macosx-carbon.tar.gz.md5</md5>
             <sha1>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-macosx-carbon.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.5.0.RELEASE" eclipse-version="3.6.1" size="194MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.5.0.RELEASE" eclipse-version="3.6.1" size="353MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-macosx-cocoa.tar.gz</file>
             <md5>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.5.0.RELEASE" eclipse-version="3.6.1" size="194MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.5.0.RELEASE" eclipse-version="3.6.1" size="352MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.5.0.RELEASE" eclipse-version="3.6.1" size="194MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-linux-gtk-installer.sh</file>
             <md5>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.5.0.RELEASE" eclipse-version="3.6.1" size="352MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-linux-gtk.tar.gz</file>
             <md5>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.5.0.RELEASE" eclipse-version="3.6.1" size="194MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.5.0.RELEASE" eclipse-version="3.6.1" size="353MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.5.0.RELEASE" eclipse-version="3.6" size="174MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.5.0.RELEASE/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6-updatesite.zip</file>
             <md5>release/TOOLS/update/2.5.0.RELEASE/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.5.0.RELEASE/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.5.0.RELEASE" eclipse-version="3.5" size="170MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.5.0.RELEASE/e3.5/springsource-tool-suite-2.5.0.RELEASE-e3.5-updatesite.zip</file>
             <md5>release/TOOLS/update/2.5.0.RELEASE/e3.5/springsource-tool-suite-2.5.0.RELEASE-e3.5-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.5.0.RELEASE/e3.5/springsource-tool-suite-2.5.0.RELEASE-e3.5-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Previous Version - 2.3.2.RELEASE" whatsnew="http://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.3.2.RELEASE.pdf">
+    <other name="Previous Version - 2.3.2.RELEASE" whatsnew="https://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.3.2.RELEASE.pdf">
         <download os="windows" version="2.3.2.RELEASE" eclipse-version="3.5.2" size="174MB">
             <description>Windows</description>
             <file>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-win32-installer.exe</file>
             <md5>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.3.2.RELEASE" eclipse-version="3.5.2" size="318MB">
             <description>Windows</description>
             <file>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-win32.zip</file>
             <md5>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-win32.zip.md5</md5>
             <sha1>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.3.2.RELEASE" eclipse-version="3.5.2" size="174MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.3.2.RELEASE" eclipse-version="3.5.2" size="318MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-win32-x86_64.zip</file>
             <md5>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.3.2.RELEASE" eclipse-version="3.5.2" size="174MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-macosx-carbon-installer.dmg</file>
             <md5>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-macosx-carbon-installer.dmg.md5</md5>
             <sha1>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-macosx-carbon-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.3.2.RELEASE" eclipse-version="3.5.2" size="315MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-macosx-carbon.tar.gz</file>
             <md5>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-macosx-carbon.tar.gz.md5</md5>
             <sha1>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-macosx-carbon.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.3.2.RELEASE" eclipse-version="3.5.2" size="174MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.3.2.RELEASE" eclipse-version="3.5.2" size="315MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.3.2.RELEASE" eclipse-version="3.5.2" size="174MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.3.2.RELEASE" eclipse-version="3.5.2" size="315MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.3.2.RELEASE" eclipse-version="3.5.2" size="173MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-linux-gtk-installer.sh</file>
             <md5>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.3.2.RELEASE" eclipse-version="3.5.2" size="315MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-linux-gtk.tar.gz</file>
             <md5>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.3.2.RELEASE" eclipse-version="3.5.2" size="173MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.3.2.RELEASE" eclipse-version="3.5.2" size="315MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
 </downloads>

--- a/sagan-common/src/test-util/resources/fixtures/tools/sts_downloads_without_milestones.xml
+++ b/sagan-common/src/test-util/resources/fixtures/tools/sts_downloads_without_milestones.xml
@@ -1,5007 +1,5007 @@
 
 <downloads>
-    <release name="Spring Tool Suite 3.6.0.RELEASE - based on Eclipse Luna 4.4" whatsnew="http://static.springsource.org/sts/nan/v360/NewAndNoteworthy.html">
+    <release name="Spring Tool Suite 3.6.0.RELEASE - based on Eclipse Luna 4.4" whatsnew="https://docs.spring.io/sts/nan/v360/NewAndNoteworthy.html">
         <download os="windows" version="3.6.0.RELEASE" eclipse-version="4.4" size="368MB">
             <description>Windows</description>
             <file>release/STS/3.6.0/dist/e4.4/spring-tool-suite-3.6.0.RELEASE-e4.4-win32.zip</file>
             <md5>release/STS/3.6.0/dist/e4.4/spring-tool-suite-3.6.0.RELEASE-e4.4-win32.zip.md5</md5>
             <sha1>release/STS/3.6.0/dist/e4.4/spring-tool-suite-3.6.0.RELEASE-e4.4-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.6.0.RELEASE" eclipse-version="4.4" size="368MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.6.0/dist/e4.4/spring-tool-suite-3.6.0.RELEASE-e4.4-win32-x86_64.zip</file>
             <md5>release/STS/3.6.0/dist/e4.4/spring-tool-suite-3.6.0.RELEASE-e4.4-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/3.6.0/dist/e4.4/spring-tool-suite-3.6.0.RELEASE-e4.4-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.6.0.RELEASE" eclipse-version="4.4" size="365MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.6.0/dist/e4.4/spring-tool-suite-3.6.0.RELEASE-e4.4-macosx-cocoa.tar.gz</file>
             <md5>release/STS/3.6.0/dist/e4.4/spring-tool-suite-3.6.0.RELEASE-e4.4-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/3.6.0/dist/e4.4/spring-tool-suite-3.6.0.RELEASE-e4.4-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.6.0.RELEASE" eclipse-version="4.4" size="365MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.6.0/dist/e4.4/spring-tool-suite-3.6.0.RELEASE-e4.4-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/3.6.0/dist/e4.4/spring-tool-suite-3.6.0.RELEASE-e4.4-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.6.0/dist/e4.4/spring-tool-suite-3.6.0.RELEASE-e4.4-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.6.0.RELEASE" eclipse-version="4.4" size="365MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.6.0/dist/e4.4/spring-tool-suite-3.6.0.RELEASE-e4.4-linux-gtk.tar.gz</file>
             <md5>release/STS/3.6.0/dist/e4.4/spring-tool-suite-3.6.0.RELEASE-e4.4-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/3.6.0/dist/e4.4/spring-tool-suite-3.6.0.RELEASE-e4.4-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.6.0.RELEASE" eclipse-version="4.4" size="366MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.6.0/dist/e4.4/spring-tool-suite-3.6.0.RELEASE-e4.4-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/3.6.0/dist/e4.4/spring-tool-suite-3.6.0.RELEASE-e4.4-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.6.0/dist/e4.4/spring-tool-suite-3.6.0.RELEASE-e4.4-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.6.0.RELEASE" eclipse-version="4.4" size="123MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.6.0.RELEASE/e4.4/springsource-tool-suite-3.6.0.RELEASE-e4.4-updatesite.zip</file>
             <md5>release/TOOLS/update/3.6.0.RELEASE/e4.4/springsource-tool-suite-3.6.0.RELEASE-e4.4-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.6.0.RELEASE/e4.4/springsource-tool-suite-3.6.0.RELEASE-e4.4-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.6.0.RELEASE" eclipse-version="4.3.2" size="141MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.6.0.RELEASE/e4.3/springsource-tool-suite-3.6.0.RELEASE-e4.3.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.6.0.RELEASE/e4.3/springsource-tool-suite-3.6.0.RELEASE-e4.3.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.6.0.RELEASE/e4.3/springsource-tool-suite-3.6.0.RELEASE-e4.3.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.6.0.RELEASE" eclipse-version="4.2.2" size="121MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.6.0.RELEASE/e4.2/springsource-tool-suite-3.6.0.RELEASE-e4.2.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.6.0.RELEASE/e4.2/springsource-tool-suite-3.6.0.RELEASE-e4.2.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.6.0.RELEASE/e4.2/springsource-tool-suite-3.6.0.RELEASE-e4.2.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.6.0.RELEASE" eclipse-version="3.8.2" size="121MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.6.0.RELEASE/e3.8/springsource-tool-suite-3.6.0.RELEASE-e3.8.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.6.0.RELEASE/e3.8/springsource-tool-suite-3.6.0.RELEASE-e3.8.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.6.0.RELEASE/e3.8/springsource-tool-suite-3.6.0.RELEASE-e3.8.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.6.0.RELEASE" eclipse-version="3.7.2" size="123MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.6.0.RELEASE/e3.7/springsource-tool-suite-3.6.0.RELEASE-e3.7.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.6.0.RELEASE/e3.7/springsource-tool-suite-3.6.0.RELEASE-e3.7.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.6.0.RELEASE/e3.7/springsource-tool-suite-3.6.0.RELEASE-e3.7.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </release>
-    <release name="Groovy/Grails Tool Suite 3.6.0.RELEASE - based on Eclipse Luna 4.4" whatsnew="http://static.springsource.org/sts/nan/v360/NewAndNoteworthy.html">
+    <release name="Groovy/Grails Tool Suite 3.6.0.RELEASE - based on Eclipse Luna 4.4" whatsnew="https://docs.spring.io/sts/nan/v360/NewAndNoteworthy.html">
         <download os="windows" version="3.6.0.RELEASE" eclipse-version="4.4" size="500MB">
             <description>Windows</description>
             <file>release/STS/3.6.0/dist/e4.4/groovy-grails-tool-suite-3.6.0.RELEASE-e4.4-win32.zip</file>
             <md5>release/STS/3.6.0/dist/e4.4/groovy-grails-tool-suite-3.6.0.RELEASE-e4.4-win32.zip.md5</md5>
             <sha1>release/STS/3.6.0/dist/e4.4/groovy-grails-tool-suite-3.6.0.RELEASE-e4.4-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.6.0.RELEASE" eclipse-version="4.4" size="500MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.6.0/dist/e4.4/groovy-grails-tool-suite-3.6.0.RELEASE-e4.4-win32-x86_64.zip</file>
             <md5>release/STS/3.6.0/dist/e4.4/groovy-grails-tool-suite-3.6.0.RELEASE-e4.4-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/3.6.0/dist/e4.4/groovy-grails-tool-suite-3.6.0.RELEASE-e4.4-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.6.0.RELEASE" eclipse-version="4.4" size="494MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.6.0/dist/e4.4/groovy-grails-tool-suite-3.6.0.RELEASE-e4.4-macosx-cocoa.tar.gz</file>
             <md5>release/STS/3.6.0/dist/e4.4/groovy-grails-tool-suite-3.6.0.RELEASE-e4.4-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/3.6.0/dist/e4.4/groovy-grails-tool-suite-3.6.0.RELEASE-e4.4-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.6.0.RELEASE" eclipse-version="4.4" size="494MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.6.0/dist/e4.4/groovy-grails-tool-suite-3.6.0.RELEASE-e4.4-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/3.6.0/dist/e4.4/groovy-grails-tool-suite-3.6.0.RELEASE-e4.4-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.6.0/dist/e4.4/groovy-grails-tool-suite-3.6.0.RELEASE-e4.4-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.6.0.RELEASE" eclipse-version="4.4" size="494MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.6.0/dist/e4.4/groovy-grails-tool-suite-3.6.0.RELEASE-e4.4-linux-gtk.tar.gz</file>
             <md5>release/STS/3.6.0/dist/e4.4/groovy-grails-tool-suite-3.6.0.RELEASE-e4.4-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/3.6.0/dist/e4.4/groovy-grails-tool-suite-3.6.0.RELEASE-e4.4-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.6.0.RELEASE" eclipse-version="4.4" size="494MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.6.0/dist/e4.4/groovy-grails-tool-suite-3.6.0.RELEASE-e4.4-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/3.6.0/dist/e4.4/groovy-grails-tool-suite-3.6.0.RELEASE-e4.4-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.6.0/dist/e4.4/groovy-grails-tool-suite-3.6.0.RELEASE-e4.4-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.6.0.RELEASE" eclipse-version="4.4" size="123MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.6.0.RELEASE/e4.4/springsource-tool-suite-3.6.0.RELEASE-e4.4-updatesite.zip</file>
             <md5>release/TOOLS/update/3.6.0.RELEASE/e4.4/springsource-tool-suite-3.6.0.RELEASE-e4.4-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.6.0.RELEASE/e4.4/springsource-tool-suite-3.6.0.RELEASE-e4.4-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.6.0.RELEASE" eclipse-version="4.3.2" size="141MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.6.0.RELEASE/e4.3/springsource-tool-suite-3.6.0.RELEASE-e4.3.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.6.0.RELEASE/e4.3/springsource-tool-suite-3.6.0.RELEASE-e4.3.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.6.0.RELEASE/e4.3/springsource-tool-suite-3.6.0.RELEASE-e4.3.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.6.0.RELEASE" eclipse-version="4.2.2" size="121MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.6.0.RELEASE/e4.2/springsource-tool-suite-3.6.0.RELEASE-e4.2.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.6.0.RELEASE/e4.2/springsource-tool-suite-3.6.0.RELEASE-e4.2.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.6.0.RELEASE/e4.2/springsource-tool-suite-3.6.0.RELEASE-e4.2.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.6.0.RELEASE" eclipse-version="3.8.2" size="121MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.6.0.RELEASE/e3.8/springsource-tool-suite-3.6.0.RELEASE-e3.8.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.6.0.RELEASE/e3.8/springsource-tool-suite-3.6.0.RELEASE-e3.8.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.6.0.RELEASE/e3.8/springsource-tool-suite-3.6.0.RELEASE-e3.8.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.6.0.RELEASE" eclipse-version="3.7.2" size="123MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.6.0.RELEASE/e3.7/springsource-tool-suite-3.6.0.RELEASE-e3.7.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.6.0.RELEASE/e3.7/springsource-tool-suite-3.6.0.RELEASE-e3.7.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.6.0.RELEASE/e3.7/springsource-tool-suite-3.6.0.RELEASE-e3.7.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </release>
-    <other name="Spring Tool Suite 3.5.1.RELEASE - based on Eclipse Kepler 4.3.2" whatsnew="http://static.springsource.org/sts/nan/v351/NewAndNoteworthy.html">
+    <other name="Spring Tool Suite 3.5.1.RELEASE - based on Eclipse Kepler 4.3.2" whatsnew="https://docs.spring.io/sts/nan/v351/NewAndNoteworthy.html">
         <download os="windows" version="3.5.1.RELEASE" eclipse-version="4.3.2" size="361MB">
             <description>Windows</description>
             <file>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-win32-installer.exe</file>
             <md5>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.5.1.RELEASE" eclipse-version="4.3.2" size="360MB">
             <description>Windows</description>
             <file>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-win32.zip</file>
             <md5>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-win32.zip.md5</md5>
             <sha1>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.5.1.RELEASE" eclipse-version="4.3.2" size="361MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.5.1.RELEASE" eclipse-version="4.3.2" size="360MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-win32-x86_64.zip</file>
             <md5>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.1.RELEASE" eclipse-version="4.3.2" size="361MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.1.RELEASE" eclipse-version="4.3.2" size="357MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.1.RELEASE" eclipse-version="4.3.2" size="361MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.1.RELEASE" eclipse-version="4.3.2" size="357MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.1.RELEASE" eclipse-version="4.3.2" size="360MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-linux-gtk-installer.sh</file>
             <md5>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.1.RELEASE" eclipse-version="4.3.2" size="357MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-linux-gtk.tar.gz</file>
             <md5>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.1.RELEASE" eclipse-version="4.3.2" size="361MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.1.RELEASE" eclipse-version="4.3.2" size="357MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.5.1/dist/e4.3/spring-tool-suite-3.5.1.RELEASE-e4.3.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.1.RELEASE" eclipse-version="4.4" size="123MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.1.RELEASE/e4.4/springsource-tool-suite-3.5.1.RELEASE-e4.4-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.1.RELEASE/e4.4/springsource-tool-suite-3.5.1.RELEASE-e4.4-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.1.RELEASE/e4.4/springsource-tool-suite-3.5.1.RELEASE-e4.4-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.1.RELEASE" eclipse-version="4.3.2" size="141MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.1.RELEASE/e4.3/springsource-tool-suite-3.5.1.RELEASE-e4.3.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.1.RELEASE/e4.3/springsource-tool-suite-3.5.1.RELEASE-e4.3.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.1.RELEASE/e4.3/springsource-tool-suite-3.5.1.RELEASE-e4.3.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.1.RELEASE" eclipse-version="4.2.2" size="121MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.1.RELEASE/e4.2/springsource-tool-suite-3.5.1.RELEASE-e4.2.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.1.RELEASE/e4.2/springsource-tool-suite-3.5.1.RELEASE-e4.2.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.1.RELEASE/e4.2/springsource-tool-suite-3.5.1.RELEASE-e4.2.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.1.RELEASE" eclipse-version="3.8.2" size="121MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.1.RELEASE/e3.8/springsource-tool-suite-3.5.1.RELEASE-e3.8.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.1.RELEASE/e3.8/springsource-tool-suite-3.5.1.RELEASE-e3.8.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.1.RELEASE/e3.8/springsource-tool-suite-3.5.1.RELEASE-e3.8.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.1.RELEASE" eclipse-version="3.7.2" size="123MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.1.RELEASE/e3.7/springsource-tool-suite-3.5.1.RELEASE-e3.7.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.1.RELEASE/e3.7/springsource-tool-suite-3.5.1.RELEASE-e3.7.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.1.RELEASE/e3.7/springsource-tool-suite-3.5.1.RELEASE-e3.7.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Groovy/Grails Tool Suite 3.5.1.RELEASE - based on Eclipse Kepler 4.3.2" whatsnew="http://static.springsource.org/sts/nan/v351/NewAndNoteworthy.html">
+    <other name="Groovy/Grails Tool Suite 3.5.1.RELEASE - based on Eclipse Kepler 4.3.2" whatsnew="https://docs.spring.io/sts/nan/v351/NewAndNoteworthy.html">
         <download os="windows" version="3.5.1.RELEASE" eclipse-version="4.3.2" size="486MB">
             <description>Windows</description>
             <file>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-win32-installer.exe</file>
             <md5>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.5.1.RELEASE" eclipse-version="4.3.2" size="487MB">
             <description>Windows</description>
             <file>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-win32.zip</file>
             <md5>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-win32.zip.md5</md5>
             <sha1>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.5.1.RELEASE" eclipse-version="4.3.2" size="486MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.5.1.RELEASE" eclipse-version="4.3.2" size="487MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-win32-x86_64.zip</file>
             <md5>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.1.RELEASE" eclipse-version="4.3.2" size="486MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.1.RELEASE" eclipse-version="4.3.2" size="481MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.1.RELEASE" eclipse-version="4.3.2" size="486MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.1.RELEASE" eclipse-version="4.3.2" size="481MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.1.RELEASE" eclipse-version="4.3.2" size="486MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-linux-gtk-installer.sh</file>
             <md5>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.1.RELEASE" eclipse-version="4.3.2" size="481MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-linux-gtk.tar.gz</file>
             <md5>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.1.RELEASE" eclipse-version="4.3.2" size="486MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.1.RELEASE" eclipse-version="4.3.2" size="481MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.5.1/dist/e4.3/groovy-grails-tool-suite-3.5.1.RELEASE-e4.3.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.1.RELEASE" eclipse-version="4.4" size="123MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.1.RELEASE/e4.4/springsource-tool-suite-3.5.1.RELEASE-e4.4-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.1.RELEASE/e4.4/springsource-tool-suite-3.5.1.RELEASE-e4.4-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.1.RELEASE/e4.4/springsource-tool-suite-3.5.1.RELEASE-e4.4-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.1.RELEASE" eclipse-version="4.3.2" size="141MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.1.RELEASE/e4.3/springsource-tool-suite-3.5.1.RELEASE-e4.3.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.1.RELEASE/e4.3/springsource-tool-suite-3.5.1.RELEASE-e4.3.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.1.RELEASE/e4.3/springsource-tool-suite-3.5.1.RELEASE-e4.3.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.1.RELEASE" eclipse-version="4.2.2" size="121MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.1.RELEASE/e4.2/springsource-tool-suite-3.5.1.RELEASE-e4.2.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.1.RELEASE/e4.2/springsource-tool-suite-3.5.1.RELEASE-e4.2.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.1.RELEASE/e4.2/springsource-tool-suite-3.5.1.RELEASE-e4.2.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.1.RELEASE" eclipse-version="3.8.2" size="121MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.1.RELEASE/e3.8/springsource-tool-suite-3.5.1.RELEASE-e3.8.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.1.RELEASE/e3.8/springsource-tool-suite-3.5.1.RELEASE-e3.8.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.1.RELEASE/e3.8/springsource-tool-suite-3.5.1.RELEASE-e3.8.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.1.RELEASE" eclipse-version="3.7.2" size="123MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.1.RELEASE/e3.7/springsource-tool-suite-3.5.1.RELEASE-e3.7.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.1.RELEASE/e3.7/springsource-tool-suite-3.5.1.RELEASE-e3.7.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.1.RELEASE/e3.7/springsource-tool-suite-3.5.1.RELEASE-e3.7.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Spring Tool Suite 3.5.1.RELEASE - based on Eclipse Juno 3.8.2" whatsnew="http://static.springsource.org/sts/nan/v351/NewAndNoteworthy.html">
+    <other name="Spring Tool Suite 3.5.1.RELEASE - based on Eclipse Juno 3.8.2" whatsnew="https://docs.spring.io/sts/nan/v351/NewAndNoteworthy.html">
         <download os="windows" version="3.5.1.RELEASE" eclipse-version="3.8.2" size="349MB">
             <description>Windows</description>
             <file>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-win32-installer.exe</file>
             <md5>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.5.1.RELEASE" eclipse-version="3.8.2" size="348MB">
             <description>Windows</description>
             <file>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-win32.zip</file>
             <md5>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-win32.zip.md5</md5>
             <sha1>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.5.1.RELEASE" eclipse-version="3.8.2" size="349MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.5.1.RELEASE" eclipse-version="3.8.2" size="348MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-win32-x86_64.zip</file>
             <md5>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.1.RELEASE" eclipse-version="3.8.2" size="349MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.1.RELEASE" eclipse-version="3.8.2" size="345MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.1.RELEASE" eclipse-version="3.8.2" size="349MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.1.RELEASE" eclipse-version="3.8.2" size="345MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.1.RELEASE" eclipse-version="3.8.2" size="348MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-linux-gtk-installer.sh</file>
             <md5>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.1.RELEASE" eclipse-version="3.8.2" size="345MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-linux-gtk.tar.gz</file>
             <md5>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.1.RELEASE" eclipse-version="3.8.2" size="349MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.1.RELEASE" eclipse-version="3.8.2" size="346MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.5.1/dist/e3.8/spring-tool-suite-3.5.1.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.1.RELEASE" eclipse-version="4.4" size="123MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.1.RELEASE/e4.4/springsource-tool-suite-3.5.1.RELEASE-e4.4-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.1.RELEASE/e4.4/springsource-tool-suite-3.5.1.RELEASE-e4.4-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.1.RELEASE/e4.4/springsource-tool-suite-3.5.1.RELEASE-e4.4-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.1.RELEASE" eclipse-version="4.3.2" size="141MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.1.RELEASE/e4.3/springsource-tool-suite-3.5.1.RELEASE-e4.3.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.1.RELEASE/e4.3/springsource-tool-suite-3.5.1.RELEASE-e4.3.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.1.RELEASE/e4.3/springsource-tool-suite-3.5.1.RELEASE-e4.3.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.1.RELEASE" eclipse-version="4.2.2" size="121MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.1.RELEASE/e4.2/springsource-tool-suite-3.5.1.RELEASE-e4.2.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.1.RELEASE/e4.2/springsource-tool-suite-3.5.1.RELEASE-e4.2.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.1.RELEASE/e4.2/springsource-tool-suite-3.5.1.RELEASE-e4.2.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.1.RELEASE" eclipse-version="3.8.2" size="121MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.1.RELEASE/e3.8/springsource-tool-suite-3.5.1.RELEASE-e3.8.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.1.RELEASE/e3.8/springsource-tool-suite-3.5.1.RELEASE-e3.8.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.1.RELEASE/e3.8/springsource-tool-suite-3.5.1.RELEASE-e3.8.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.1.RELEASE" eclipse-version="3.7.2" size="123MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.1.RELEASE/e3.7/springsource-tool-suite-3.5.1.RELEASE-e3.7.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.1.RELEASE/e3.7/springsource-tool-suite-3.5.1.RELEASE-e3.7.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.1.RELEASE/e3.7/springsource-tool-suite-3.5.1.RELEASE-e3.7.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Groovy/Grails Tool Suite 3.5.1.RELEASE - based on Eclipse Juno 3.8.2" whatsnew="http://static.springsource.org/sts/nan/v351/NewAndNoteworthy.html">
+    <other name="Groovy/Grails Tool Suite 3.5.1.RELEASE - based on Eclipse Juno 3.8.2" whatsnew="https://docs.spring.io/sts/nan/v351/NewAndNoteworthy.html">
         <download os="windows" version="3.5.1.RELEASE" eclipse-version="3.8.2" size="474MB">
             <description>Windows</description>
             <file>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-win32-installer.exe</file>
             <md5>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.5.1.RELEASE" eclipse-version="3.8.2" size="475MB">
             <description>Windows</description>
             <file>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-win32.zip</file>
             <md5>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-win32.zip.md5</md5>
             <sha1>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.5.1.RELEASE" eclipse-version="3.8.2" size="474MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.5.1.RELEASE" eclipse-version="3.8.2" size="475MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-win32-x86_64.zip</file>
             <md5>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.1.RELEASE" eclipse-version="3.8.2" size="474MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.1.RELEASE" eclipse-version="3.8.2" size="469MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.1.RELEASE" eclipse-version="3.8.2" size="474MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.1.RELEASE" eclipse-version="3.8.2" size="469MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.1.RELEASE" eclipse-version="3.8.2" size="474MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-linux-gtk-installer.sh</file>
             <md5>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.1.RELEASE" eclipse-version="3.8.2" size="469MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-linux-gtk.tar.gz</file>
             <md5>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.1.RELEASE" eclipse-version="3.8.2" size="474MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.1.RELEASE" eclipse-version="3.8.2" size="469MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.5.1/dist/e3.8/groovy-grails-tool-suite-3.5.1.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.1.RELEASE" eclipse-version="4.4" size="123MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.1.RELEASE/e4.4/springsource-tool-suite-3.5.1.RELEASE-e4.4-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.1.RELEASE/e4.4/springsource-tool-suite-3.5.1.RELEASE-e4.4-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.1.RELEASE/e4.4/springsource-tool-suite-3.5.1.RELEASE-e4.4-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.1.RELEASE" eclipse-version="4.3.2" size="141MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.1.RELEASE/e4.3/springsource-tool-suite-3.5.1.RELEASE-e4.3.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.1.RELEASE/e4.3/springsource-tool-suite-3.5.1.RELEASE-e4.3.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.1.RELEASE/e4.3/springsource-tool-suite-3.5.1.RELEASE-e4.3.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.1.RELEASE" eclipse-version="4.2.2" size="121MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.1.RELEASE/e4.2/springsource-tool-suite-3.5.1.RELEASE-e4.2.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.1.RELEASE/e4.2/springsource-tool-suite-3.5.1.RELEASE-e4.2.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.1.RELEASE/e4.2/springsource-tool-suite-3.5.1.RELEASE-e4.2.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.1.RELEASE" eclipse-version="3.8.2" size="121MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.1.RELEASE/e3.8/springsource-tool-suite-3.5.1.RELEASE-e3.8.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.1.RELEASE/e3.8/springsource-tool-suite-3.5.1.RELEASE-e3.8.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.1.RELEASE/e3.8/springsource-tool-suite-3.5.1.RELEASE-e3.8.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.1.RELEASE" eclipse-version="3.7.2" size="123MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.1.RELEASE/e3.7/springsource-tool-suite-3.5.1.RELEASE-e3.7.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.1.RELEASE/e3.7/springsource-tool-suite-3.5.1.RELEASE-e3.7.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.1.RELEASE/e3.7/springsource-tool-suite-3.5.1.RELEASE-e3.7.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Spring Tool Suite 3.5.0.RELEASE - based on Eclipse Kepler 4.3.2" whatsnew="http://static.springsource.org/sts/nan/v350/NewAndNoteworthy.html">
+    <other name="Spring Tool Suite 3.5.0.RELEASE - based on Eclipse Kepler 4.3.2" whatsnew="https://docs.spring.io/sts/nan/v350/NewAndNoteworthy.html">
         <download os="windows" version="3.5.0.RELEASE" eclipse-version="4.3.2" size="361MB">
             <description>Windows</description>
             <file>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-win32-installer.exe</file>
             <md5>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.5.0.RELEASE" eclipse-version="4.3.2" size="360MB">
             <description>Windows</description>
             <file>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-win32.zip</file>
             <md5>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-win32.zip.md5</md5>
             <sha1>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.5.0.RELEASE" eclipse-version="4.3.2" size="361MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.5.0.RELEASE" eclipse-version="4.3.2" size="360MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-win32-x86_64.zip</file>
             <md5>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.0.RELEASE" eclipse-version="4.3.2" size="361MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.0.RELEASE" eclipse-version="4.3.2" size="358MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.0.RELEASE" eclipse-version="4.3.2" size="361MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.0.RELEASE" eclipse-version="4.3.2" size="358MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.0.RELEASE" eclipse-version="4.3.2" size="361MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-linux-gtk-installer.sh</file>
             <md5>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.0.RELEASE" eclipse-version="4.3.2" size="358MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-linux-gtk.tar.gz</file>
             <md5>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.0.RELEASE" eclipse-version="4.3.2" size="361MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.0.RELEASE" eclipse-version="4.3.2" size="358MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.5.0/dist/e4.3/spring-tool-suite-3.5.0.RELEASE-e4.3.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.0.RELEASE" eclipse-version="4.3.2" size="130MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.0.RELEASE/e4.3/springsource-tool-suite-3.5.0.RELEASE-e4.3.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.0.RELEASE/e4.3/springsource-tool-suite-3.5.0.RELEASE-e4.3.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.0.RELEASE/e4.3/springsource-tool-suite-3.5.0.RELEASE-e4.3.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.0.RELEASE" eclipse-version="4.2.2" size="110MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.0.RELEASE/e4.2/springsource-tool-suite-3.5.0.RELEASE-e4.2.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.0.RELEASE/e4.2/springsource-tool-suite-3.5.0.RELEASE-e4.2.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.0.RELEASE/e4.2/springsource-tool-suite-3.5.0.RELEASE-e4.2.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.0.RELEASE" eclipse-version="3.8.2" size="110MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.0.RELEASE/e3.8/springsource-tool-suite-3.5.0.RELEASE-e3.8.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.0.RELEASE/e3.8/springsource-tool-suite-3.5.0.RELEASE-e3.8.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.0.RELEASE/e3.8/springsource-tool-suite-3.5.0.RELEASE-e3.8.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.0.RELEASE" eclipse-version="3.7.2" size="112MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.0.RELEASE/e3.7/springsource-tool-suite-3.5.0.RELEASE-e3.7.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.0.RELEASE/e3.7/springsource-tool-suite-3.5.0.RELEASE-e3.7.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.0.RELEASE/e3.7/springsource-tool-suite-3.5.0.RELEASE-e3.7.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Groovy/Grails Tool Suite 3.5.0.RELEASE - based on Eclipse Kepler 4.3.2" whatsnew="http://static.springsource.org/sts/nan/v350/NewAndNoteworthy.html">
+    <other name="Groovy/Grails Tool Suite 3.5.0.RELEASE - based on Eclipse Kepler 4.3.2" whatsnew="https://docs.spring.io/sts/nan/v350/NewAndNoteworthy.html">
         <download os="windows" version="3.5.0.RELEASE" eclipse-version="4.3.2" size="488MB">
             <description>Windows</description>
             <file>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-win32-installer.exe</file>
             <md5>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.5.0.RELEASE" eclipse-version="4.3.2" size="489MB">
             <description>Windows</description>
             <file>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-win32.zip</file>
             <md5>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-win32.zip.md5</md5>
             <sha1>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.5.0.RELEASE" eclipse-version="4.3.2" size="488MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.5.0.RELEASE" eclipse-version="4.3.2" size="489MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-win32-x86_64.zip</file>
             <md5>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.0.RELEASE" eclipse-version="4.3.2" size="488MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.0.RELEASE" eclipse-version="4.3.2" size="482MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.0.RELEASE" eclipse-version="4.3.2" size="488MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.0.RELEASE" eclipse-version="4.3.2" size="482MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.0.RELEASE" eclipse-version="4.3.2" size="487MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-linux-gtk-installer.sh</file>
             <md5>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.0.RELEASE" eclipse-version="4.3.2" size="482MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-linux-gtk.tar.gz</file>
             <md5>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.0.RELEASE" eclipse-version="4.3.2" size="487MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.0.RELEASE" eclipse-version="4.3.2" size="482MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.5.0/dist/e4.3/groovy-grails-tool-suite-3.5.0.RELEASE-e4.3.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.0.RELEASE" eclipse-version="4.3.2" size="130MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.0.RELEASE/e4.3/springsource-tool-suite-3.5.0.RELEASE-e4.3.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.0.RELEASE/e4.3/springsource-tool-suite-3.5.0.RELEASE-e4.3.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.0.RELEASE/e4.3/springsource-tool-suite-3.5.0.RELEASE-e4.3.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.0.RELEASE" eclipse-version="4.2.2" size="110MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.0.RELEASE/e4.2/springsource-tool-suite-3.5.0.RELEASE-e4.2.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.0.RELEASE/e4.2/springsource-tool-suite-3.5.0.RELEASE-e4.2.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.0.RELEASE/e4.2/springsource-tool-suite-3.5.0.RELEASE-e4.2.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.0.RELEASE" eclipse-version="3.8.2" size="110MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.0.RELEASE/e3.8/springsource-tool-suite-3.5.0.RELEASE-e3.8.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.0.RELEASE/e3.8/springsource-tool-suite-3.5.0.RELEASE-e3.8.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.0.RELEASE/e3.8/springsource-tool-suite-3.5.0.RELEASE-e3.8.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.0.RELEASE" eclipse-version="3.7.2" size="112MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.0.RELEASE/e3.7/springsource-tool-suite-3.5.0.RELEASE-e3.7.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.0.RELEASE/e3.7/springsource-tool-suite-3.5.0.RELEASE-e3.7.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.0.RELEASE/e3.7/springsource-tool-suite-3.5.0.RELEASE-e3.7.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Spring Tool Suite 3.5.0.RELEASE - based on Eclipse Juno 3.8.2" whatsnew="http://static.springsource.org/sts/nan/v350/NewAndNoteworthy.html">
+    <other name="Spring Tool Suite 3.5.0.RELEASE - based on Eclipse Juno 3.8.2" whatsnew="https://docs.spring.io/sts/nan/v350/NewAndNoteworthy.html">
         <download os="windows" version="3.5.0.RELEASE" eclipse-version="3.8.2" size="349MB">
             <description>Windows</description>
             <file>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-win32-installer.exe</file>
             <md5>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.5.0.RELEASE" eclipse-version="3.8.2" size="348MB">
             <description>Windows</description>
             <file>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-win32.zip</file>
             <md5>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-win32.zip.md5</md5>
             <sha1>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.5.0.RELEASE" eclipse-version="3.8.2" size="349MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.5.0.RELEASE" eclipse-version="3.8.2" size="348MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-win32-x86_64.zip</file>
             <md5>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.0.RELEASE" eclipse-version="3.8.2" size="349MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.0.RELEASE" eclipse-version="3.8.2" size="345MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.0.RELEASE" eclipse-version="3.8.2" size="349MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.0.RELEASE" eclipse-version="3.8.2" size="345MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.0.RELEASE" eclipse-version="3.8.2" size="348MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-linux-gtk-installer.sh</file>
             <md5>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.0.RELEASE" eclipse-version="3.8.2" size="345MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-linux-gtk.tar.gz</file>
             <md5>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.0.RELEASE" eclipse-version="3.8.2" size="348MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.0.RELEASE" eclipse-version="3.8.2" size="345MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.5.0/dist/e3.8/spring-tool-suite-3.5.0.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.0.RELEASE" eclipse-version="4.3.2" size="130MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.0.RELEASE/e4.3/springsource-tool-suite-3.5.0.RELEASE-e4.3.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.0.RELEASE/e4.3/springsource-tool-suite-3.5.0.RELEASE-e4.3.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.0.RELEASE/e4.3/springsource-tool-suite-3.5.0.RELEASE-e4.3.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.0.RELEASE" eclipse-version="4.2.2" size="110MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.0.RELEASE/e4.2/springsource-tool-suite-3.5.0.RELEASE-e4.2.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.0.RELEASE/e4.2/springsource-tool-suite-3.5.0.RELEASE-e4.2.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.0.RELEASE/e4.2/springsource-tool-suite-3.5.0.RELEASE-e4.2.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.0.RELEASE" eclipse-version="3.8.2" size="110MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.0.RELEASE/e3.8/springsource-tool-suite-3.5.0.RELEASE-e3.8.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.0.RELEASE/e3.8/springsource-tool-suite-3.5.0.RELEASE-e3.8.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.0.RELEASE/e3.8/springsource-tool-suite-3.5.0.RELEASE-e3.8.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.0.RELEASE" eclipse-version="3.7.2" size="112MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.0.RELEASE/e3.7/springsource-tool-suite-3.5.0.RELEASE-e3.7.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.0.RELEASE/e3.7/springsource-tool-suite-3.5.0.RELEASE-e3.7.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.0.RELEASE/e3.7/springsource-tool-suite-3.5.0.RELEASE-e3.7.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Groovy/Grails Tool Suite 3.5.0.RELEASE - based on Eclipse Juno 3.8.2" whatsnew="http://static.springsource.org/sts/nan/v350/NewAndNoteworthy.html">
+    <other name="Groovy/Grails Tool Suite 3.5.0.RELEASE - based on Eclipse Juno 3.8.2" whatsnew="https://docs.spring.io/sts/nan/v350/NewAndNoteworthy.html">
         <download os="windows" version="3.5.0.RELEASE" eclipse-version="3.8.2" size="475MB">
             <description>Windows</description>
             <file>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-win32-installer.exe</file>
             <md5>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.5.0.RELEASE" eclipse-version="3.8.2" size="476MB">
             <description>Windows</description>
             <file>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-win32.zip</file>
             <md5>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-win32.zip.md5</md5>
             <sha1>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.5.0.RELEASE" eclipse-version="3.8.2" size="475MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.5.0.RELEASE" eclipse-version="3.8.2" size="476MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-win32-x86_64.zip</file>
             <md5>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.0.RELEASE" eclipse-version="3.8.2" size="475MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.0.RELEASE" eclipse-version="3.8.2" size="470MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.0.RELEASE" eclipse-version="3.8.2" size="475MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.5.0.RELEASE" eclipse-version="3.8.2" size="470MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.0.RELEASE" eclipse-version="3.8.2" size="475MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-linux-gtk-installer.sh</file>
             <md5>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.0.RELEASE" eclipse-version="3.8.2" size="470MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-linux-gtk.tar.gz</file>
             <md5>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.0.RELEASE" eclipse-version="3.8.2" size="475MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.5.0.RELEASE" eclipse-version="3.8.2" size="470MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.5.0/dist/e3.8/groovy-grails-tool-suite-3.5.0.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.0.RELEASE" eclipse-version="4.3.2" size="130MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.0.RELEASE/e4.3/springsource-tool-suite-3.5.0.RELEASE-e4.3.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.0.RELEASE/e4.3/springsource-tool-suite-3.5.0.RELEASE-e4.3.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.0.RELEASE/e4.3/springsource-tool-suite-3.5.0.RELEASE-e4.3.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.0.RELEASE" eclipse-version="4.2.2" size="110MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.0.RELEASE/e4.2/springsource-tool-suite-3.5.0.RELEASE-e4.2.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.0.RELEASE/e4.2/springsource-tool-suite-3.5.0.RELEASE-e4.2.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.0.RELEASE/e4.2/springsource-tool-suite-3.5.0.RELEASE-e4.2.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.0.RELEASE" eclipse-version="3.8.2" size="110MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.0.RELEASE/e3.8/springsource-tool-suite-3.5.0.RELEASE-e3.8.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.0.RELEASE/e3.8/springsource-tool-suite-3.5.0.RELEASE-e3.8.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.0.RELEASE/e3.8/springsource-tool-suite-3.5.0.RELEASE-e3.8.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.5.0.RELEASE" eclipse-version="3.7.2" size="112MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.5.0.RELEASE/e3.7/springsource-tool-suite-3.5.0.RELEASE-e3.7.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.5.0.RELEASE/e3.7/springsource-tool-suite-3.5.0.RELEASE-e3.7.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.5.0.RELEASE/e3.7/springsource-tool-suite-3.5.0.RELEASE-e3.7.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Spring Tool Suite 3.4.0.RELEASE - based on Eclipse Kepler 4.3.1" whatsnew="http://static.springsource.org/sts/nan/v340/NewAndNoteworthy.html">
+    <other name="Spring Tool Suite 3.4.0.RELEASE - based on Eclipse Kepler 4.3.1" whatsnew="https://docs.spring.io/sts/nan/v340/NewAndNoteworthy.html">
         <download os="windows" version="3.4.0.RELEASE" eclipse-version="4.3.1" size="380MB">
             <description>Windows</description>
             <file>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-win32-installer.exe</file>
             <md5>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-win32-installer.exe.md5</md5>
             <sha1>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.4.0.RELEASE" eclipse-version="4.3.1" size="379MB">
             <description>Windows</description>
             <file>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-win32.zip</file>
             <md5>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-win32.zip.md5</md5>
             <sha1>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.4.0.RELEASE" eclipse-version="4.3.1" size="380MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-win32-x86_64-installer.exe</file>
             <md5>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.4.0.RELEASE" eclipse-version="4.3.1" size="379MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-win32-x86_64.zip</file>
             <md5>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.4.0.RELEASE" eclipse-version="4.3.1" size="380MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.4.0.RELEASE" eclipse-version="4.3.1" size="376MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-macosx-cocoa.tar.gz</file>
             <md5>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.4.0.RELEASE" eclipse-version="4.3.1" size="379MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.4.0.RELEASE" eclipse-version="4.3.1" size="376MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.4.0.RELEASE" eclipse-version="4.3.1" size="379MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-linux-gtk-installer.sh</file>
             <md5>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.4.0.RELEASE" eclipse-version="4.3.1" size="376MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-linux-gtk.tar.gz</file>
             <md5>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.4.0.RELEASE" eclipse-version="4.3.1" size="379MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.4.0.RELEASE" eclipse-version="4.3.1" size="376MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.4.0/dist/e4.3/spring-tool-suite-3.4.0.RELEASE-e4.3.1-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.4.0.RELEASE" eclipse-version="4.3.1" size="167MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.4.0.RELEASE/e4.3/springsource-tool-suite-3.4.0.RELEASE-e4.3.1-updatesite.zip</file>
             <md5>release/TOOLS/update/3.4.0.RELEASE/e4.3/springsource-tool-suite-3.4.0.RELEASE-e4.3.1-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.4.0.RELEASE/e4.3/springsource-tool-suite-3.4.0.RELEASE-e4.3.1-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.4.0.RELEASE" eclipse-version="4.2.2" size="164MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.4.0.RELEASE/e4.2/springsource-tool-suite-3.4.0.RELEASE-e4.2.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.4.0.RELEASE/e4.2/springsource-tool-suite-3.4.0.RELEASE-e4.2.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.4.0.RELEASE/e4.2/springsource-tool-suite-3.4.0.RELEASE-e4.2.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.4.0.RELEASE" eclipse-version="3.8.2" size="161MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.4.0.RELEASE/e3.8/springsource-tool-suite-3.4.0.RELEASE-e3.8.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.4.0.RELEASE/e3.8/springsource-tool-suite-3.4.0.RELEASE-e3.8.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.4.0.RELEASE/e3.8/springsource-tool-suite-3.4.0.RELEASE-e3.8.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.4.0.RELEASE" eclipse-version="3.7.2" size="161MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.4.0.RELEASE/e3.7/springsource-tool-suite-3.4.0.RELEASE-e3.7.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.4.0.RELEASE/e3.7/springsource-tool-suite-3.4.0.RELEASE-e3.7.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.4.0.RELEASE/e3.7/springsource-tool-suite-3.4.0.RELEASE-e3.7.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Groovy/Grails Tool Suite 3.4.0.RELEASE - based on Eclipse Kepler 4.3.1" whatsnew="http://static.springsource.org/sts/nan/v340/NewAndNoteworthy.html">
+    <other name="Groovy/Grails Tool Suite 3.4.0.RELEASE - based on Eclipse Kepler 4.3.1" whatsnew="https://docs.spring.io/sts/nan/v340/NewAndNoteworthy.html">
         <download os="windows" version="3.4.0.RELEASE" eclipse-version="4.3.1" size="477MB">
             <description>Windows</description>
             <file>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-win32-installer.exe</file>
             <md5>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-win32-installer.exe.md5</md5>
             <sha1>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.4.0.RELEASE" eclipse-version="4.3.1" size="478MB">
             <description>Windows</description>
             <file>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-win32.zip</file>
             <md5>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-win32.zip.md5</md5>
             <sha1>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.4.0.RELEASE" eclipse-version="4.3.1" size="477MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-win32-x86_64-installer.exe</file>
             <md5>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.4.0.RELEASE" eclipse-version="4.3.1" size="478MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-win32-x86_64.zip</file>
             <md5>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.4.0.RELEASE" eclipse-version="4.3.1" size="477MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.4.0.RELEASE" eclipse-version="4.3.1" size="472MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-macosx-cocoa.tar.gz</file>
             <md5>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.4.0.RELEASE" eclipse-version="4.3.1" size="477MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.4.0.RELEASE" eclipse-version="4.3.1" size="472MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.4.0.RELEASE" eclipse-version="4.3.1" size="477MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-linux-gtk-installer.sh</file>
             <md5>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.4.0.RELEASE" eclipse-version="4.3.1" size="472MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-linux-gtk.tar.gz</file>
             <md5>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.4.0.RELEASE" eclipse-version="4.3.1" size="477MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.4.0.RELEASE" eclipse-version="4.3.1" size="472MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.4.0/dist/e4.3/groovy-grails-tool-suite-3.4.0.RELEASE-e4.3.1-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.4.0.RELEASE" eclipse-version="4.3.1" size="167MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.4.0.RELEASE/e4.3/springsource-tool-suite-3.4.0.RELEASE-e4.3.1-updatesite.zip</file>
             <md5>release/TOOLS/update/3.4.0.RELEASE/e4.3/springsource-tool-suite-3.4.0.RELEASE-e4.3.1-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.4.0.RELEASE/e4.3/springsource-tool-suite-3.4.0.RELEASE-e4.3.1-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.4.0.RELEASE" eclipse-version="4.2.2" size="164MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.4.0.RELEASE/e4.2/springsource-tool-suite-3.4.0.RELEASE-e4.2.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.4.0.RELEASE/e4.2/springsource-tool-suite-3.4.0.RELEASE-e4.2.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.4.0.RELEASE/e4.2/springsource-tool-suite-3.4.0.RELEASE-e4.2.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.4.0.RELEASE" eclipse-version="3.8.2" size="161MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.4.0.RELEASE/e3.8/springsource-tool-suite-3.4.0.RELEASE-e3.8.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.4.0.RELEASE/e3.8/springsource-tool-suite-3.4.0.RELEASE-e3.8.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.4.0.RELEASE/e3.8/springsource-tool-suite-3.4.0.RELEASE-e3.8.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.4.0.RELEASE" eclipse-version="3.7.2" size="161MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.4.0.RELEASE/e3.7/springsource-tool-suite-3.4.0.RELEASE-e3.7.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.4.0.RELEASE/e3.7/springsource-tool-suite-3.4.0.RELEASE-e3.7.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.4.0.RELEASE/e3.7/springsource-tool-suite-3.4.0.RELEASE-e3.7.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Spring Tool Suite 3.4.0.RELEASE - based on Eclipse Juno 3.8.2" whatsnew="http://static.springsource.org/sts/nan/v340/NewAndNoteworthy.html">
+    <other name="Spring Tool Suite 3.4.0.RELEASE - based on Eclipse Juno 3.8.2" whatsnew="https://docs.spring.io/sts/nan/v340/NewAndNoteworthy.html">
         <download os="windows" version="3.4.0.RELEASE" eclipse-version="3.8.2" size="372MB">
             <description>Windows</description>
             <file>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-win32-installer.exe</file>
             <md5>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.4.0.RELEASE" eclipse-version="3.8.2" size="371MB">
             <description>Windows</description>
             <file>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-win32.zip</file>
             <md5>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-win32.zip.md5</md5>
             <sha1>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.4.0.RELEASE" eclipse-version="3.8.2" size="372MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.4.0.RELEASE" eclipse-version="3.8.2" size="371MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-win32-x86_64.zip</file>
             <md5>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.4.0.RELEASE" eclipse-version="3.8.2" size="371MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.4.0.RELEASE" eclipse-version="3.8.2" size="368MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.4.0.RELEASE" eclipse-version="3.8.2" size="371MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.4.0.RELEASE" eclipse-version="3.8.2" size="368MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.4.0.RELEASE" eclipse-version="3.8.2" size="371MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-linux-gtk-installer.sh</file>
             <md5>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.4.0.RELEASE" eclipse-version="3.8.2" size="368MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-linux-gtk.tar.gz</file>
             <md5>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.4.0.RELEASE" eclipse-version="3.8.2" size="371MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.4.0.RELEASE" eclipse-version="3.8.2" size="368MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.4.0/dist/e3.8/spring-tool-suite-3.4.0.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.4.0.RELEASE" eclipse-version="4.3.1" size="167MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.4.0.RELEASE/e4.3/springsource-tool-suite-3.4.0.RELEASE-e4.3.1-updatesite.zip</file>
             <md5>release/TOOLS/update/3.4.0.RELEASE/e4.3/springsource-tool-suite-3.4.0.RELEASE-e4.3.1-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.4.0.RELEASE/e4.3/springsource-tool-suite-3.4.0.RELEASE-e4.3.1-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.4.0.RELEASE" eclipse-version="4.2.2" size="164MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.4.0.RELEASE/e4.2/springsource-tool-suite-3.4.0.RELEASE-e4.2.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.4.0.RELEASE/e4.2/springsource-tool-suite-3.4.0.RELEASE-e4.2.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.4.0.RELEASE/e4.2/springsource-tool-suite-3.4.0.RELEASE-e4.2.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.4.0.RELEASE" eclipse-version="3.8.2" size="161MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.4.0.RELEASE/e3.8/springsource-tool-suite-3.4.0.RELEASE-e3.8.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.4.0.RELEASE/e3.8/springsource-tool-suite-3.4.0.RELEASE-e3.8.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.4.0.RELEASE/e3.8/springsource-tool-suite-3.4.0.RELEASE-e3.8.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.4.0.RELEASE" eclipse-version="3.7.2" size="161MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.4.0.RELEASE/e3.7/springsource-tool-suite-3.4.0.RELEASE-e3.7.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.4.0.RELEASE/e3.7/springsource-tool-suite-3.4.0.RELEASE-e3.7.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.4.0.RELEASE/e3.7/springsource-tool-suite-3.4.0.RELEASE-e3.7.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Groovy/Grails Tool Suite 3.4.0.RELEASE - based on Eclipse Juno 3.8.2" whatsnew="http://static.springsource.org/sts/nan/v340/NewAndNoteworthy.html">
+    <other name="Groovy/Grails Tool Suite 3.4.0.RELEASE - based on Eclipse Juno 3.8.2" whatsnew="https://docs.spring.io/sts/nan/v340/NewAndNoteworthy.html">
         <download os="windows" version="3.4.0.RELEASE" eclipse-version="3.8.2" size="469MB">
             <description>Windows</description>
             <file>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-win32-installer.exe</file>
             <md5>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.4.0.RELEASE" eclipse-version="3.8.2" size="471MB">
             <description>Windows</description>
             <file>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-win32.zip</file>
             <md5>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-win32.zip.md5</md5>
             <sha1>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.4.0.RELEASE" eclipse-version="3.8.2" size="469MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.4.0.RELEASE" eclipse-version="3.8.2" size="471MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-win32-x86_64.zip</file>
             <md5>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.4.0.RELEASE" eclipse-version="3.8.2" size="469MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.4.0.RELEASE" eclipse-version="3.8.2" size="464MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.4.0.RELEASE" eclipse-version="3.8.2" size="469MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.4.0.RELEASE" eclipse-version="3.8.2" size="464MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.4.0.RELEASE" eclipse-version="3.8.2" size="469MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-linux-gtk-installer.sh</file>
             <md5>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.4.0.RELEASE" eclipse-version="3.8.2" size="465MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-linux-gtk.tar.gz</file>
             <md5>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.4.0.RELEASE" eclipse-version="3.8.2" size="469MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.4.0.RELEASE" eclipse-version="3.8.2" size="465MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.4.0/dist/e3.8/groovy-grails-tool-suite-3.4.0.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.4.0.RELEASE" eclipse-version="4.3.1" size="167MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.4.0.RELEASE/e4.3/springsource-tool-suite-3.4.0.RELEASE-e4.3.1-updatesite.zip</file>
             <md5>release/TOOLS/update/3.4.0.RELEASE/e4.3/springsource-tool-suite-3.4.0.RELEASE-e4.3.1-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.4.0.RELEASE/e4.3/springsource-tool-suite-3.4.0.RELEASE-e4.3.1-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.4.0.RELEASE" eclipse-version="4.2.2" size="164MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.4.0.RELEASE/e4.2/springsource-tool-suite-3.4.0.RELEASE-e4.2.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.4.0.RELEASE/e4.2/springsource-tool-suite-3.4.0.RELEASE-e4.2.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.4.0.RELEASE/e4.2/springsource-tool-suite-3.4.0.RELEASE-e4.2.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.4.0.RELEASE" eclipse-version="3.8.2" size="161MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.4.0.RELEASE/e3.8/springsource-tool-suite-3.4.0.RELEASE-e3.8.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.4.0.RELEASE/e3.8/springsource-tool-suite-3.4.0.RELEASE-e3.8.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.4.0.RELEASE/e3.8/springsource-tool-suite-3.4.0.RELEASE-e3.8.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.4.0.RELEASE" eclipse-version="3.7.2" size="161MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.4.0.RELEASE/e3.7/springsource-tool-suite-3.4.0.RELEASE-e3.7.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.4.0.RELEASE/e3.7/springsource-tool-suite-3.4.0.RELEASE-e3.7.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.4.0.RELEASE/e3.7/springsource-tool-suite-3.4.0.RELEASE-e3.7.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Spring Tool Suite 3.3.0.RELEASE - based on Eclipse Kepler 4.3" whatsnew="http://static.springsource.org/sts/nan/v330/NewAndNoteworthy.html">
+    <other name="Spring Tool Suite 3.3.0.RELEASE - based on Eclipse Kepler 4.3" whatsnew="https://docs.spring.io/sts/nan/v330/NewAndNoteworthy.html">
         <download os="windows" version="3.3.0.RELEASE" eclipse-version="4.3" size="373MB">
             <description>Windows</description>
             <file>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-win32-installer.exe</file>
             <md5>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-win32-installer.exe.md5</md5>
             <sha1>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.3.0.RELEASE" eclipse-version="4.3" size="372MB">
             <description>Windows</description>
             <file>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-win32.zip</file>
             <md5>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-win32.zip.md5</md5>
             <sha1>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.3.0.RELEASE" eclipse-version="4.3" size="373MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-win32-x86_64-installer.exe</file>
             <md5>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.3.0.RELEASE" eclipse-version="4.3" size="372MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-win32-x86_64.zip</file>
             <md5>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.3.0.RELEASE" eclipse-version="4.3" size="373MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.3.0.RELEASE" eclipse-version="4.3" size="369MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa.tar.gz</file>
             <md5>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.3.0.RELEASE" eclipse-version="4.3" size="373MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.3.0.RELEASE" eclipse-version="4.3" size="369MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.3.0.RELEASE" eclipse-version="4.3" size="372MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk-installer.sh</file>
             <md5>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.3.0.RELEASE" eclipse-version="4.3" size="369MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk.tar.gz</file>
             <md5>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.3.0.RELEASE" eclipse-version="4.3" size="372MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.3.0.RELEASE" eclipse-version="4.3" size="369MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.3.0/dist/e4.3/spring-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.3.0.RELEASE" eclipse-version="4.3" size="172MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.3.0.RELEASE/e4.3/springsource-tool-suite-3.3.0.RELEASE-e4.3-updatesite.zip</file>
             <md5>release/TOOLS/update/3.3.0.RELEASE/e4.3/springsource-tool-suite-3.3.0.RELEASE-e4.3-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.3.0.RELEASE/e4.3/springsource-tool-suite-3.3.0.RELEASE-e4.3-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.3.0.RELEASE" eclipse-version="4.2.2" size="169MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.3.0.RELEASE/e4.2/springsource-tool-suite-3.3.0.RELEASE-e4.2.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.3.0.RELEASE/e4.2/springsource-tool-suite-3.3.0.RELEASE-e4.2.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.3.0.RELEASE/e4.2/springsource-tool-suite-3.3.0.RELEASE-e4.2.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="166MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.3.0.RELEASE/e3.8/springsource-tool-suite-3.3.0.RELEASE-e3.8.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.3.0.RELEASE/e3.8/springsource-tool-suite-3.3.0.RELEASE-e3.8.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.3.0.RELEASE/e3.8/springsource-tool-suite-3.3.0.RELEASE-e3.8.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.3.0.RELEASE" eclipse-version="3.7.2" size="166MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.3.0.RELEASE/e3.7/springsource-tool-suite-3.3.0.RELEASE-e3.7.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.3.0.RELEASE/e3.7/springsource-tool-suite-3.3.0.RELEASE-e3.7.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.3.0.RELEASE/e3.7/springsource-tool-suite-3.3.0.RELEASE-e3.7.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Groovy/Grails Tool Suite 3.3.0.RELEASE - based on Eclipse Kepler 4.3" whatsnew="http://static.springsource.org/sts/nan/v330/NewAndNoteworthy.html">
+    <other name="Groovy/Grails Tool Suite 3.3.0.RELEASE - based on Eclipse Kepler 4.3" whatsnew="https://docs.spring.io/sts/nan/v330/NewAndNoteworthy.html">
         <download os="windows" version="3.3.0.RELEASE" eclipse-version="4.3" size="468MB">
             <description>Windows</description>
             <file>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-win32-installer.exe</file>
             <md5>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-win32-installer.exe.md5</md5>
             <sha1>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.3.0.RELEASE" eclipse-version="4.3" size="469MB">
             <description>Windows</description>
             <file>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-win32.zip</file>
             <md5>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-win32.zip.md5</md5>
             <sha1>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.3.0.RELEASE" eclipse-version="4.3" size="468MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-win32-x86_64-installer.exe</file>
             <md5>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.3.0.RELEASE" eclipse-version="4.3" size="469MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-win32-x86_64.zip</file>
             <md5>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.3.0.RELEASE" eclipse-version="4.3" size="468MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.3.0.RELEASE" eclipse-version="4.3" size="464MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa.tar.gz</file>
             <md5>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.3.0.RELEASE" eclipse-version="4.3" size="468MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.3.0.RELEASE" eclipse-version="4.3" size="463MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.3.0.RELEASE" eclipse-version="4.3" size="468MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk-installer.sh</file>
             <md5>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.3.0.RELEASE" eclipse-version="4.3" size="463MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk.tar.gz</file>
             <md5>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.3.0.RELEASE" eclipse-version="4.3" size="468MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.3.0.RELEASE" eclipse-version="4.3" size="463MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.3.0/dist/e4.3/groovy-grails-tool-suite-3.3.0.RELEASE-e4.3-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.3.0.RELEASE" eclipse-version="4.3" size="172MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.3.0.RELEASE/e4.3/springsource-tool-suite-3.3.0.RELEASE-e4.3-updatesite.zip</file>
             <md5>release/TOOLS/update/3.3.0.RELEASE/e4.3/springsource-tool-suite-3.3.0.RELEASE-e4.3-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.3.0.RELEASE/e4.3/springsource-tool-suite-3.3.0.RELEASE-e4.3-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.3.0.RELEASE" eclipse-version="4.2.2" size="169MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.3.0.RELEASE/e4.2/springsource-tool-suite-3.3.0.RELEASE-e4.2.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.3.0.RELEASE/e4.2/springsource-tool-suite-3.3.0.RELEASE-e4.2.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.3.0.RELEASE/e4.2/springsource-tool-suite-3.3.0.RELEASE-e4.2.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="166MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.3.0.RELEASE/e3.8/springsource-tool-suite-3.3.0.RELEASE-e3.8.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.3.0.RELEASE/e3.8/springsource-tool-suite-3.3.0.RELEASE-e3.8.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.3.0.RELEASE/e3.8/springsource-tool-suite-3.3.0.RELEASE-e3.8.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.3.0.RELEASE" eclipse-version="3.7.2" size="166MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.3.0.RELEASE/e3.7/springsource-tool-suite-3.3.0.RELEASE-e3.7.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.3.0.RELEASE/e3.7/springsource-tool-suite-3.3.0.RELEASE-e3.7.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.3.0.RELEASE/e3.7/springsource-tool-suite-3.3.0.RELEASE-e3.7.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Spring Tool Suite 3.3.0.RELEASE - based on Eclipse Juno 3.8.2" whatsnew="http://static.springsource.org/sts/nan/v330/NewAndNoteworthy.html">
+    <other name="Spring Tool Suite 3.3.0.RELEASE - based on Eclipse Juno 3.8.2" whatsnew="https://docs.spring.io/sts/nan/v330/NewAndNoteworthy.html">
         <download os="windows" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="368MB">
             <description>Windows</description>
             <file>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-win32-installer.exe</file>
             <md5>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="367MB">
             <description>Windows</description>
             <file>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-win32.zip</file>
             <md5>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-win32.zip.md5</md5>
             <sha1>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="368MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="367MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-win32-x86_64.zip</file>
             <md5>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="368MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="364MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="368MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="364MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="368MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk-installer.sh</file>
             <md5>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="364MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk.tar.gz</file>
             <md5>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="368MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="365MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.3.0/dist/e3.8/spring-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.3.0.RELEASE" eclipse-version="4.3" size="172MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.3.0.RELEASE/e4.3/springsource-tool-suite-3.3.0.RELEASE-e4.3-updatesite.zip</file>
             <md5>release/TOOLS/update/3.3.0.RELEASE/e4.3/springsource-tool-suite-3.3.0.RELEASE-e4.3-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.3.0.RELEASE/e4.3/springsource-tool-suite-3.3.0.RELEASE-e4.3-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.3.0.RELEASE" eclipse-version="4.2.2" size="169MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.3.0.RELEASE/e4.2/springsource-tool-suite-3.3.0.RELEASE-e4.2.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.3.0.RELEASE/e4.2/springsource-tool-suite-3.3.0.RELEASE-e4.2.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.3.0.RELEASE/e4.2/springsource-tool-suite-3.3.0.RELEASE-e4.2.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="166MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.3.0.RELEASE/e3.8/springsource-tool-suite-3.3.0.RELEASE-e3.8.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.3.0.RELEASE/e3.8/springsource-tool-suite-3.3.0.RELEASE-e3.8.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.3.0.RELEASE/e3.8/springsource-tool-suite-3.3.0.RELEASE-e3.8.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.3.0.RELEASE" eclipse-version="3.7.2" size="166MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.3.0.RELEASE/e3.7/springsource-tool-suite-3.3.0.RELEASE-e3.7.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.3.0.RELEASE/e3.7/springsource-tool-suite-3.3.0.RELEASE-e3.7.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.3.0.RELEASE/e3.7/springsource-tool-suite-3.3.0.RELEASE-e3.7.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Groovy/Grails Tool Suite 3.3.0.RELEASE - based on Eclipse Juno 3.8.2" whatsnew="http://static.springsource.org/sts/nan/v330/NewAndNoteworthy.html">
+    <other name="Groovy/Grails Tool Suite 3.3.0.RELEASE - based on Eclipse Juno 3.8.2" whatsnew="https://docs.spring.io/sts/nan/v330/NewAndNoteworthy.html">
         <download os="windows" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="464MB">
             <description>Windows</description>
             <file>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-win32-installer.exe</file>
             <md5>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="464MB">
             <description>Windows</description>
             <file>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-win32.zip</file>
             <md5>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-win32.zip.md5</md5>
             <sha1>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="464MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="464MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-win32-x86_64.zip</file>
             <md5>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="463MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="459MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="463MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="458MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="463MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk-installer.sh</file>
             <md5>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="459MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk.tar.gz</file>
             <md5>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="463MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="459MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.3.0/dist/e3.8/groovy-grails-tool-suite-3.3.0.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.3.0.RELEASE" eclipse-version="4.3" size="172MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.3.0.RELEASE/e4.3/springsource-tool-suite-3.3.0.RELEASE-e4.3-updatesite.zip</file>
             <md5>release/TOOLS/update/3.3.0.RELEASE/e4.3/springsource-tool-suite-3.3.0.RELEASE-e4.3-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.3.0.RELEASE/e4.3/springsource-tool-suite-3.3.0.RELEASE-e4.3-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.3.0.RELEASE" eclipse-version="4.2.2" size="169MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.3.0.RELEASE/e4.2/springsource-tool-suite-3.3.0.RELEASE-e4.2.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.3.0.RELEASE/e4.2/springsource-tool-suite-3.3.0.RELEASE-e4.2.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.3.0.RELEASE/e4.2/springsource-tool-suite-3.3.0.RELEASE-e4.2.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.3.0.RELEASE" eclipse-version="3.8.2" size="166MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.3.0.RELEASE/e3.8/springsource-tool-suite-3.3.0.RELEASE-e3.8.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.3.0.RELEASE/e3.8/springsource-tool-suite-3.3.0.RELEASE-e3.8.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.3.0.RELEASE/e3.8/springsource-tool-suite-3.3.0.RELEASE-e3.8.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.3.0.RELEASE" eclipse-version="3.7.2" size="166MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.3.0.RELEASE/e3.7/springsource-tool-suite-3.3.0.RELEASE-e3.7.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.3.0.RELEASE/e3.7/springsource-tool-suite-3.3.0.RELEASE-e3.7.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.3.0.RELEASE/e3.7/springsource-tool-suite-3.3.0.RELEASE-e3.7.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Spring Tool Suite 3.2.0.RELEASE - based on Eclipse Juno 3.8.2" whatsnew="http://static.springsource.org/sts/nan/v320/NewAndNoteworthy.html">
+    <other name="Spring Tool Suite 3.2.0.RELEASE - based on Eclipse Juno 3.8.2" whatsnew="https://docs.spring.io/sts/nan/v320/NewAndNoteworthy.html">
         <download os="windows" version="3.2.0.RELEASE" eclipse-version="3.8.2" size="364MB">
             <description>Windows</description>
             <file>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-win32-installer.exe</file>
             <md5>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.2.0.RELEASE" eclipse-version="3.8.2" size="363MB">
             <description>Windows</description>
             <file>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-win32.zip</file>
             <md5>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-win32.zip.md5</md5>
             <sha1>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.2.0.RELEASE" eclipse-version="3.8.2" size="364MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.2.0.RELEASE" eclipse-version="3.8.2" size="363MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-win32-x86_64.zip</file>
             <md5>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.2.0.RELEASE" eclipse-version="3.8.2" size="364MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.2.0.RELEASE" eclipse-version="3.8.2" size="360MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.2.0.RELEASE" eclipse-version="3.8.2" size="364MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.2.0.RELEASE" eclipse-version="3.8.2" size="360MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.2.0.RELEASE" eclipse-version="3.8.2" size="364MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-linux-gtk-installer.sh</file>
             <md5>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.2.0.RELEASE" eclipse-version="3.8.2" size="360MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-linux-gtk.tar.gz</file>
             <md5>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.2.0.RELEASE" eclipse-version="3.8.2" size="364MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.2.0.RELEASE" eclipse-version="3.8.2" size="361MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.2.0/dist/e3.8/spring-tool-suite-3.2.0.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.2.0.RELEASE" eclipse-version="4.3" size="185MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.2.0.RELEASE/e4.3/springsource-tool-suite-3.2.0.RELEASE-e4.3-updatesite.zip</file>
             <md5>release/TOOLS/update/3.2.0.RELEASE/e4.3/springsource-tool-suite-3.2.0.RELEASE-e4.3-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.2.0.RELEASE/e4.3/springsource-tool-suite-3.2.0.RELEASE-e4.3-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.2.0.RELEASE" eclipse-version="4.2.2" size="182MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.2.0.RELEASE/e4.2/springsource-tool-suite-3.2.0.RELEASE-e4.2.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.2.0.RELEASE/e4.2/springsource-tool-suite-3.2.0.RELEASE-e4.2.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.2.0.RELEASE/e4.2/springsource-tool-suite-3.2.0.RELEASE-e4.2.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.2.0.RELEASE" eclipse-version="3.8.2" size="179MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.2.0.RELEASE/e3.8/springsource-tool-suite-3.2.0.RELEASE-e3.8.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.2.0.RELEASE/e3.8/springsource-tool-suite-3.2.0.RELEASE-e3.8.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.2.0.RELEASE/e3.8/springsource-tool-suite-3.2.0.RELEASE-e3.8.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.2.0.RELEASE" eclipse-version="3.7.2" size="176MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.2.0.RELEASE/e3.7/springsource-tool-suite-3.2.0.RELEASE-e3.7.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.2.0.RELEASE/e3.7/springsource-tool-suite-3.2.0.RELEASE-e3.7.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.2.0.RELEASE/e3.7/springsource-tool-suite-3.2.0.RELEASE-e3.7.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Groovy/Grails Tool Suite 3.2.0.RELEASE - based on Eclipse Juno 3.8.2" whatsnew="http://static.springsource.org/sts/nan/v320/NewAndNoteworthy.html">
+    <other name="Groovy/Grails Tool Suite 3.2.0.RELEASE - based on Eclipse Juno 3.8.2" whatsnew="https://docs.spring.io/sts/nan/v320/NewAndNoteworthy.html">
         <download os="windows" version="3.2.0.RELEASE" eclipse-version="3.8.2" size="461MB">
             <description>Windows</description>
             <file>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-win32-installer.exe</file>
             <md5>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.2.0.RELEASE" eclipse-version="3.8.2" size="462MB">
             <description>Windows</description>
             <file>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-win32.zip</file>
             <md5>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-win32.zip.md5</md5>
             <sha1>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.2.0.RELEASE" eclipse-version="3.8.2" size="461MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.2.0.RELEASE" eclipse-version="3.8.2" size="462MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-win32-x86_64.zip</file>
             <md5>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.2.0.RELEASE" eclipse-version="3.8.2" size="461MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.2.0.RELEASE" eclipse-version="3.8.2" size="456MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.2.0.RELEASE" eclipse-version="3.8.2" size="460MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.2.0.RELEASE" eclipse-version="3.8.2" size="455MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.2.0.RELEASE" eclipse-version="3.8.2" size="460MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-linux-gtk-installer.sh</file>
             <md5>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.2.0.RELEASE" eclipse-version="3.8.2" size="456MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-linux-gtk.tar.gz</file>
             <md5>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.2.0.RELEASE" eclipse-version="3.8.2" size="461MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.2.0.RELEASE" eclipse-version="3.8.2" size="456MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.2.0/dist/e3.8/groovy-grails-tool-suite-3.2.0.RELEASE-e3.8.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.2.0.RELEASE" eclipse-version="4.3" size="185MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.2.0.RELEASE/e4.3/springsource-tool-suite-3.2.0.RELEASE-e4.3-updatesite.zip</file>
             <md5>release/TOOLS/update/3.2.0.RELEASE/e4.3/springsource-tool-suite-3.2.0.RELEASE-e4.3-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.2.0.RELEASE/e4.3/springsource-tool-suite-3.2.0.RELEASE-e4.3-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.2.0.RELEASE" eclipse-version="4.2.2" size="182MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.2.0.RELEASE/e4.2/springsource-tool-suite-3.2.0.RELEASE-e4.2.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.2.0.RELEASE/e4.2/springsource-tool-suite-3.2.0.RELEASE-e4.2.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.2.0.RELEASE/e4.2/springsource-tool-suite-3.2.0.RELEASE-e4.2.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.2.0.RELEASE" eclipse-version="3.8.2" size="179MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.2.0.RELEASE/e3.8/springsource-tool-suite-3.2.0.RELEASE-e3.8.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.2.0.RELEASE/e3.8/springsource-tool-suite-3.2.0.RELEASE-e3.8.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.2.0.RELEASE/e3.8/springsource-tool-suite-3.2.0.RELEASE-e3.8.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.2.0.RELEASE" eclipse-version="3.7.2" size="176MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.2.0.RELEASE/e3.7/springsource-tool-suite-3.2.0.RELEASE-e3.7.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.2.0.RELEASE/e3.7/springsource-tool-suite-3.2.0.RELEASE-e3.7.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.2.0.RELEASE/e3.7/springsource-tool-suite-3.2.0.RELEASE-e3.7.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Spring Tool Suite 3.2.0.RELEASE - based on Eclipse Juno 4.2.2" whatsnew="http://static.springsource.org/sts/nan/v320/NewAndNoteworthy.html">
+    <other name="Spring Tool Suite 3.2.0.RELEASE - based on Eclipse Juno 4.2.2" whatsnew="https://docs.spring.io/sts/nan/v320/NewAndNoteworthy.html">
         <download os="windows" version="3.2.0.RELEASE" eclipse-version="4.2.2" size="367MB">
             <description>Windows</description>
             <file>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-win32-installer.exe</file>
             <md5>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.2.0.RELEASE" eclipse-version="4.2.2" size="366MB">
             <description>Windows</description>
             <file>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-win32.zip</file>
             <md5>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-win32.zip.md5</md5>
             <sha1>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.2.0.RELEASE" eclipse-version="4.2.2" size="367MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.2.0.RELEASE" eclipse-version="4.2.2" size="366MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-win32-x86_64.zip</file>
             <md5>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.2.0.RELEASE" eclipse-version="4.2.2" size="366MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.2.0.RELEASE" eclipse-version="4.2.2" size="363MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.2.0.RELEASE" eclipse-version="4.2.2" size="366MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.2.0.RELEASE" eclipse-version="4.2.2" size="362MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.2.0.RELEASE" eclipse-version="4.2.2" size="366MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-linux-gtk-installer.sh</file>
             <md5>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.2.0.RELEASE" eclipse-version="4.2.2" size="363MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-linux-gtk.tar.gz</file>
             <md5>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.2.0.RELEASE" eclipse-version="4.2.2" size="366MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.2.0.RELEASE" eclipse-version="4.2.2" size="363MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.2.0/dist/e4.2/spring-tool-suite-3.2.0.RELEASE-e4.2.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.2.0.RELEASE" eclipse-version="4.3" size="185MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.2.0.RELEASE/e4.3/springsource-tool-suite-3.2.0.RELEASE-e4.3-updatesite.zip</file>
             <md5>release/TOOLS/update/3.2.0.RELEASE/e4.3/springsource-tool-suite-3.2.0.RELEASE-e4.3-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.2.0.RELEASE/e4.3/springsource-tool-suite-3.2.0.RELEASE-e4.3-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.2.0.RELEASE" eclipse-version="4.2.2" size="182MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.2.0.RELEASE/e4.2/springsource-tool-suite-3.2.0.RELEASE-e4.2.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.2.0.RELEASE/e4.2/springsource-tool-suite-3.2.0.RELEASE-e4.2.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.2.0.RELEASE/e4.2/springsource-tool-suite-3.2.0.RELEASE-e4.2.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.2.0.RELEASE" eclipse-version="3.8.2" size="179MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.2.0.RELEASE/e3.8/springsource-tool-suite-3.2.0.RELEASE-e3.8.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.2.0.RELEASE/e3.8/springsource-tool-suite-3.2.0.RELEASE-e3.8.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.2.0.RELEASE/e3.8/springsource-tool-suite-3.2.0.RELEASE-e3.8.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.2.0.RELEASE" eclipse-version="3.7.2" size="176MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.2.0.RELEASE/e3.7/springsource-tool-suite-3.2.0.RELEASE-e3.7.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.2.0.RELEASE/e3.7/springsource-tool-suite-3.2.0.RELEASE-e3.7.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.2.0.RELEASE/e3.7/springsource-tool-suite-3.2.0.RELEASE-e3.7.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Groovy/Grails Tool Suite 3.2.0.RELEASE - based on Eclipse Juno 4.2.2" whatsnew="http://static.springsource.org/sts/nan/v320/NewAndNoteworthy.html">
+    <other name="Groovy/Grails Tool Suite 3.2.0.RELEASE - based on Eclipse Juno 4.2.2" whatsnew="https://docs.spring.io/sts/nan/v320/NewAndNoteworthy.html">
         <download os="windows" version="3.2.0.RELEASE" eclipse-version="4.2.2" size="463MB">
             <description>Windows</description>
             <file>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-win32-installer.exe</file>
             <md5>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.2.0.RELEASE" eclipse-version="4.2.2" size="464MB">
             <description>Windows</description>
             <file>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-win32.zip</file>
             <md5>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-win32.zip.md5</md5>
             <sha1>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.2.0.RELEASE" eclipse-version="4.2.2" size="463MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.2.0.RELEASE" eclipse-version="4.2.2" size="464MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-win32-x86_64.zip</file>
             <md5>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.2.0.RELEASE" eclipse-version="4.2.2" size="463MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.2.0.RELEASE" eclipse-version="4.2.2" size="458MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.2.0.RELEASE" eclipse-version="4.2.2" size="463MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.2.0.RELEASE" eclipse-version="4.2.2" size="458MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.2.0.RELEASE" eclipse-version="4.2.2" size="463MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-linux-gtk-installer.sh</file>
             <md5>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.2.0.RELEASE" eclipse-version="4.2.2" size="458MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-linux-gtk.tar.gz</file>
             <md5>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.2.0.RELEASE" eclipse-version="4.2.2" size="463MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.2.0.RELEASE" eclipse-version="4.2.2" size="458MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.2.0/dist/e4.2/groovy-grails-tool-suite-3.2.0.RELEASE-e4.2.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.2.0.RELEASE" eclipse-version="4.3" size="185MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.2.0.RELEASE/e4.3/springsource-tool-suite-3.2.0.RELEASE-e4.3-updatesite.zip</file>
             <md5>release/TOOLS/update/3.2.0.RELEASE/e4.3/springsource-tool-suite-3.2.0.RELEASE-e4.3-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.2.0.RELEASE/e4.3/springsource-tool-suite-3.2.0.RELEASE-e4.3-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.2.0.RELEASE" eclipse-version="4.2.2" size="182MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.2.0.RELEASE/e4.2/springsource-tool-suite-3.2.0.RELEASE-e4.2.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.2.0.RELEASE/e4.2/springsource-tool-suite-3.2.0.RELEASE-e4.2.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.2.0.RELEASE/e4.2/springsource-tool-suite-3.2.0.RELEASE-e4.2.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.2.0.RELEASE" eclipse-version="3.8.2" size="179MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.2.0.RELEASE/e3.8/springsource-tool-suite-3.2.0.RELEASE-e3.8.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.2.0.RELEASE/e3.8/springsource-tool-suite-3.2.0.RELEASE-e3.8.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.2.0.RELEASE/e3.8/springsource-tool-suite-3.2.0.RELEASE-e3.8.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.2.0.RELEASE" eclipse-version="3.7.2" size="176MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.2.0.RELEASE/e3.7/springsource-tool-suite-3.2.0.RELEASE-e3.7.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.2.0.RELEASE/e3.7/springsource-tool-suite-3.2.0.RELEASE-e3.7.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.2.0.RELEASE/e3.7/springsource-tool-suite-3.2.0.RELEASE-e3.7.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Spring Tool Suite 3.1.0.RELEASE - based on Eclipse Juno 3.8.1" whatsnew="http://static.springsource.org/sts/nan/v310/NewAndNoteworthy.html">
+    <other name="Spring Tool Suite 3.1.0.RELEASE - based on Eclipse Juno 3.8.1" whatsnew="https://docs.spring.io/sts/nan/v310/NewAndNoteworthy.html">
         <download os="windows" version="3.1.0.RELEASE" eclipse-version="3.8" size="358MB">
             <description>Windows</description>
             <file>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-win32-installer.exe</file>
             <md5>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-win32-installer.exe.md5</md5>
             <sha1>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.1.0.RELEASE" eclipse-version="3.8" size="357MB">
             <description>Windows</description>
             <file>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-win32.zip</file>
             <md5>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-win32.zip.md5</md5>
             <sha1>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.1.0.RELEASE" eclipse-version="3.8" size="358MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-win32-x86_64-installer.exe</file>
             <md5>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.1.0.RELEASE" eclipse-version="3.8" size="357MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-win32-x86_64.zip</file>
             <md5>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.1.0.RELEASE" eclipse-version="3.8" size="358MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.1.0.RELEASE" eclipse-version="3.8" size="353MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-macosx-cocoa.tar.gz</file>
             <md5>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.1.0.RELEASE" eclipse-version="3.8" size="357MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.1.0.RELEASE" eclipse-version="3.8" size="353MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.1.0.RELEASE" eclipse-version="3.8" size="357MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-linux-gtk-installer.sh</file>
             <md5>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.1.0.RELEASE" eclipse-version="3.8" size="354MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-linux-gtk.tar.gz</file>
             <md5>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.1.0.RELEASE" eclipse-version="3.8" size="357MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.1.0.RELEASE" eclipse-version="3.8" size="354MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.1.0/dist/e3.8/spring-tool-suite-3.1.0.RELEASE-e3.8-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.1.0.RELEASE" eclipse-version="4.2" size="180MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.1.0.RELEASE/e4.2/springsource-tool-suite-3.1.0.RELEASE-e4.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.1.0.RELEASE/e4.2/springsource-tool-suite-3.1.0.RELEASE-e4.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.1.0.RELEASE/e4.2/springsource-tool-suite-3.1.0.RELEASE-e4.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.1.0.RELEASE" eclipse-version="3.8" size="178MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.1.0.RELEASE/e3.8/springsource-tool-suite-3.1.0.RELEASE-e3.8-updatesite.zip</file>
             <md5>release/TOOLS/update/3.1.0.RELEASE/e3.8/springsource-tool-suite-3.1.0.RELEASE-e3.8-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.1.0.RELEASE/e3.8/springsource-tool-suite-3.1.0.RELEASE-e3.8-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.1.0.RELEASE" eclipse-version="3.7" size="175MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.1.0.RELEASE/e3.7/springsource-tool-suite-3.1.0.RELEASE-e3.7-updatesite.zip</file>
             <md5>release/TOOLS/update/3.1.0.RELEASE/e3.7/springsource-tool-suite-3.1.0.RELEASE-e3.7-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.1.0.RELEASE/e3.7/springsource-tool-suite-3.1.0.RELEASE-e3.7-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Groovy/Grails Tool Suite 3.1.0.RELEASE - based on Eclipse Juno 3.8.1" whatsnew="http://static.springsource.org/sts/nan/v310/NewAndNoteworthy.html">
+    <other name="Groovy/Grails Tool Suite 3.1.0.RELEASE - based on Eclipse Juno 3.8.1" whatsnew="https://docs.spring.io/sts/nan/v310/NewAndNoteworthy.html">
         <download os="windows" version="3.1.0.RELEASE" eclipse-version="3.8" size="400MB">
             <description>Windows</description>
             <file>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-win32-installer.exe</file>
             <md5>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-win32-installer.exe.md5</md5>
             <sha1>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.1.0.RELEASE" eclipse-version="3.8" size="401MB">
             <description>Windows</description>
             <file>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-win32.zip</file>
             <md5>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-win32.zip.md5</md5>
             <sha1>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.1.0.RELEASE" eclipse-version="3.8" size="400MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-win32-x86_64-installer.exe</file>
             <md5>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.1.0.RELEASE" eclipse-version="3.8" size="401MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-win32-x86_64.zip</file>
             <md5>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.1.0.RELEASE" eclipse-version="3.8" size="399MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.1.0.RELEASE" eclipse-version="3.8" size="395MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-macosx-cocoa.tar.gz</file>
             <md5>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.1.0.RELEASE" eclipse-version="3.8" size="400MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.1.0.RELEASE" eclipse-version="3.8" size="395MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.1.0.RELEASE" eclipse-version="3.8" size="399MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-linux-gtk-installer.sh</file>
             <md5>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.1.0.RELEASE" eclipse-version="3.8" size="395MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-linux-gtk.tar.gz</file>
             <md5>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.1.0.RELEASE" eclipse-version="3.8" size="399MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.1.0.RELEASE" eclipse-version="3.8" size="395MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.1.0/dist/e3.8/groovy-grails-tool-suite-3.1.0.RELEASE-e3.8-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.1.0.RELEASE" eclipse-version="4.2" size="180MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.1.0.RELEASE/e4.2/springsource-tool-suite-3.1.0.RELEASE-e4.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.1.0.RELEASE/e4.2/springsource-tool-suite-3.1.0.RELEASE-e4.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.1.0.RELEASE/e4.2/springsource-tool-suite-3.1.0.RELEASE-e4.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.1.0.RELEASE" eclipse-version="3.8" size="178MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.1.0.RELEASE/e3.8/springsource-tool-suite-3.1.0.RELEASE-e3.8-updatesite.zip</file>
             <md5>release/TOOLS/update/3.1.0.RELEASE/e3.8/springsource-tool-suite-3.1.0.RELEASE-e3.8-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.1.0.RELEASE/e3.8/springsource-tool-suite-3.1.0.RELEASE-e3.8-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.1.0.RELEASE" eclipse-version="3.7" size="175MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.1.0.RELEASE/e3.7/springsource-tool-suite-3.1.0.RELEASE-e3.7-updatesite.zip</file>
             <md5>release/TOOLS/update/3.1.0.RELEASE/e3.7/springsource-tool-suite-3.1.0.RELEASE-e3.7-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.1.0.RELEASE/e3.7/springsource-tool-suite-3.1.0.RELEASE-e3.7-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Spring Tool Suite 3.1.0.RELEASE - based on Eclipse Juno 4.2.1" whatsnew="http://static.springsource.org/sts/nan/v310/NewAndNoteworthy.html">
+    <other name="Spring Tool Suite 3.1.0.RELEASE - based on Eclipse Juno 4.2.1" whatsnew="https://docs.spring.io/sts/nan/v310/NewAndNoteworthy.html">
         <download os="windows" version="3.1.0.RELEASE" eclipse-version="4.2" size="361MB">
             <description>Windows</description>
             <file>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-win32-installer.exe</file>
             <md5>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.1.0.RELEASE" eclipse-version="4.2" size="359MB">
             <description>Windows</description>
             <file>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-win32.zip</file>
             <md5>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-win32.zip.md5</md5>
             <sha1>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.1.0.RELEASE" eclipse-version="4.2" size="361MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.1.0.RELEASE" eclipse-version="4.2" size="359MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-win32-x86_64.zip</file>
             <md5>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.1.0.RELEASE" eclipse-version="4.2" size="360MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.1.0.RELEASE" eclipse-version="4.2" size="356MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.1.0.RELEASE" eclipse-version="4.2" size="360MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.1.0.RELEASE" eclipse-version="4.2" size="356MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.1.0.RELEASE" eclipse-version="4.2" size="360MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-linux-gtk-installer.sh</file>
             <md5>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.1.0.RELEASE" eclipse-version="4.2" size="356MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-linux-gtk.tar.gz</file>
             <md5>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.1.0.RELEASE" eclipse-version="4.2" size="360MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.1.0.RELEASE" eclipse-version="4.2" size="357MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.1.0/dist/e4.2/spring-tool-suite-3.1.0.RELEASE-e4.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.1.0.RELEASE" eclipse-version="4.2" size="180MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.1.0.RELEASE/e4.2/springsource-tool-suite-3.1.0.RELEASE-e4.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.1.0.RELEASE/e4.2/springsource-tool-suite-3.1.0.RELEASE-e4.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.1.0.RELEASE/e4.2/springsource-tool-suite-3.1.0.RELEASE-e4.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.1.0.RELEASE" eclipse-version="3.8" size="178MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.1.0.RELEASE/e3.8/springsource-tool-suite-3.1.0.RELEASE-e3.8-updatesite.zip</file>
             <md5>release/TOOLS/update/3.1.0.RELEASE/e3.8/springsource-tool-suite-3.1.0.RELEASE-e3.8-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.1.0.RELEASE/e3.8/springsource-tool-suite-3.1.0.RELEASE-e3.8-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.1.0.RELEASE" eclipse-version="3.7" size="175MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.1.0.RELEASE/e3.7/springsource-tool-suite-3.1.0.RELEASE-e3.7-updatesite.zip</file>
             <md5>release/TOOLS/update/3.1.0.RELEASE/e3.7/springsource-tool-suite-3.1.0.RELEASE-e3.7-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.1.0.RELEASE/e3.7/springsource-tool-suite-3.1.0.RELEASE-e3.7-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Groovy/Grails Tool Suite 3.1.0.RELEASE - based on Eclipse Juno 4.2.1" whatsnew="http://static.springsource.org/sts/nan/v310/NewAndNoteworthy.html">
+    <other name="Groovy/Grails Tool Suite 3.1.0.RELEASE - based on Eclipse Juno 4.2.1" whatsnew="https://docs.spring.io/sts/nan/v310/NewAndNoteworthy.html">
         <download os="windows" version="3.1.0.RELEASE" eclipse-version="4.2" size="403MB">
             <description>Windows</description>
             <file>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-win32-installer.exe</file>
             <md5>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.1.0.RELEASE" eclipse-version="4.2" size="403MB">
             <description>Windows</description>
             <file>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-win32.zip</file>
             <md5>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-win32.zip.md5</md5>
             <sha1>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.1.0.RELEASE" eclipse-version="4.2" size="403MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.1.0.RELEASE" eclipse-version="4.2" size="403MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-win32-x86_64.zip</file>
             <md5>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.1.0.RELEASE" eclipse-version="4.2" size="403MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.1.0.RELEASE" eclipse-version="4.2" size="398MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.1.0.RELEASE" eclipse-version="4.2" size="402MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.1.0.RELEASE" eclipse-version="4.2" size="397MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.1.0.RELEASE" eclipse-version="4.2" size="402MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-linux-gtk-installer.sh</file>
             <md5>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.1.0.RELEASE" eclipse-version="4.2" size="398MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-linux-gtk.tar.gz</file>
             <md5>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.1.0.RELEASE" eclipse-version="4.2" size="402MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.1.0.RELEASE" eclipse-version="4.2" size="398MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.1.0/dist/e4.2/groovy-grails-tool-suite-3.1.0.RELEASE-e4.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.1.0.RELEASE" eclipse-version="4.2" size="180MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.1.0.RELEASE/e4.2/springsource-tool-suite-3.1.0.RELEASE-e4.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.1.0.RELEASE/e4.2/springsource-tool-suite-3.1.0.RELEASE-e4.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.1.0.RELEASE/e4.2/springsource-tool-suite-3.1.0.RELEASE-e4.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.1.0.RELEASE" eclipse-version="3.8" size="178MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.1.0.RELEASE/e3.8/springsource-tool-suite-3.1.0.RELEASE-e3.8-updatesite.zip</file>
             <md5>release/TOOLS/update/3.1.0.RELEASE/e3.8/springsource-tool-suite-3.1.0.RELEASE-e3.8-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.1.0.RELEASE/e3.8/springsource-tool-suite-3.1.0.RELEASE-e3.8-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.1.0.RELEASE" eclipse-version="3.7" size="175MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.1.0.RELEASE/e3.7/springsource-tool-suite-3.1.0.RELEASE-e3.7-updatesite.zip</file>
             <md5>release/TOOLS/update/3.1.0.RELEASE/e3.7/springsource-tool-suite-3.1.0.RELEASE-e3.7-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.1.0.RELEASE/e3.7/springsource-tool-suite-3.1.0.RELEASE-e3.7-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Previous Version - Spring Tool Suite 3.0.0.RELEASE" whatsnew="http://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-3.0.0.RELEASE.pdf">
+    <other name="Previous Version - Spring Tool Suite 3.0.0.RELEASE" whatsnew="https://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-3.0.0.RELEASE.pdf">
         <download os="windows" version="3.0.0.RELEASE" eclipse-version="4.2" size="359MB">
             <description>Windows</description>
             <file>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-win32-installer.exe</file>
             <md5>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.0.0.RELEASE" eclipse-version="4.2" size="358MB">
             <description>Windows</description>
             <file>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-win32.zip</file>
             <md5>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-win32.zip.md5</md5>
             <sha1>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.0.0.RELEASE" eclipse-version="4.2" size="359MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.0.0.RELEASE" eclipse-version="4.2" size="358MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-win32-x86_64.zip</file>
             <md5>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.0.0.RELEASE" eclipse-version="4.2" size="359MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.0.0.RELEASE" eclipse-version="4.2" size="355MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.0.0.RELEASE" eclipse-version="4.2" size="359MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.0.0.RELEASE" eclipse-version="4.2" size="355MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.0.0.RELEASE" eclipse-version="4.2" size="359MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-linux-gtk-installer.sh</file>
             <md5>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.0.0.RELEASE" eclipse-version="4.2" size="356MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-linux-gtk.tar.gz</file>
             <md5>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.0.0.RELEASE" eclipse-version="4.2" size="359MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.0.0.RELEASE" eclipse-version="4.2" size="356MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.0.0/dist/e4.2/spring-tool-suite-3.0.0.RELEASE-e4.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.0.0.RELEASE" eclipse-version="4.2" size="182MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.0.0.RELEASE/e4.2/springsource-tool-suite-3.0.0.RELEASE-e4.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.0.0.RELEASE/e4.2/springsource-tool-suite-3.0.0.RELEASE-e4.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.0.0.RELEASE/e4.2/springsource-tool-suite-3.0.0.RELEASE-e4.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.0.0.RELEASE" eclipse-version="3.7" size="177MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.0.0.RELEASE/e3.7/springsource-tool-suite-3.0.0.RELEASE-e3.7-updatesite.zip</file>
             <md5>release/TOOLS/update/3.0.0.RELEASE/e3.7/springsource-tool-suite-3.0.0.RELEASE-e3.7-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.0.0.RELEASE/e3.7/springsource-tool-suite-3.0.0.RELEASE-e3.7-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Previous Version - Groovy/Grails Tool Suite 3.0.0.RELEASE" whatsnew="http://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-3.0.0.RELEASE.pdf">
+    <other name="Previous Version - Groovy/Grails Tool Suite 3.0.0.RELEASE" whatsnew="https://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-3.0.0.RELEASE.pdf">
         <download os="windows" version="3.0.0.RELEASE" eclipse-version="4.2" size="401MB">
             <description>Windows</description>
             <file>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-win32-installer.exe</file>
             <md5>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.0.0.RELEASE" eclipse-version="4.2" size="401MB">
             <description>Windows</description>
             <file>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-win32.zip</file>
             <md5>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-win32.zip.md5</md5>
             <sha1>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.0.0.RELEASE" eclipse-version="4.2" size="400MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="3.0.0.RELEASE" eclipse-version="4.2" size="401MB">
             <description>Windows (64bit)</description>
             <file>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-win32-x86_64.zip</file>
             <md5>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.0.0.RELEASE" eclipse-version="4.2" size="400MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.0.0.RELEASE" eclipse-version="4.2" size="396MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.0.0.RELEASE" eclipse-version="4.2" size="400MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="3.0.0.RELEASE" eclipse-version="4.2" size="396MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.0.0.RELEASE" eclipse-version="4.2" size="400MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-linux-gtk-installer.sh</file>
             <md5>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.0.0.RELEASE" eclipse-version="4.2" size="396MB">
             <description>Linux (GTK)</description>
             <file>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-linux-gtk.tar.gz</file>
             <md5>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.0.0.RELEASE" eclipse-version="4.2" size="400MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="3.0.0.RELEASE" eclipse-version="4.2" size="396MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/3.0.0/dist/e4.2/groovy-grails-tool-suite-3.0.0.RELEASE-e4.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.0.0.RELEASE" eclipse-version="4.2" size="182MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.0.0.RELEASE/e4.2/springsource-tool-suite-3.0.0.RELEASE-e4.2-updatesite.zip</file>
             <md5>release/TOOLS/update/3.0.0.RELEASE/e4.2/springsource-tool-suite-3.0.0.RELEASE-e4.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.0.0.RELEASE/e4.2/springsource-tool-suite-3.0.0.RELEASE-e4.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="3.0.0.RELEASE" eclipse-version="3.7" size="177MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/3.0.0.RELEASE/e3.7/springsource-tool-suite-3.0.0.RELEASE-e3.7-updatesite.zip</file>
             <md5>release/TOOLS/update/3.0.0.RELEASE/e3.7/springsource-tool-suite-3.0.0.RELEASE-e3.7-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/3.0.0.RELEASE/e3.7/springsource-tool-suite-3.0.0.RELEASE-e3.7-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Previous Version - 2.9.2.RELEASE" whatsnew="http://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.9.2.RELEASE.pdf">
+    <other name="Previous Version - 2.9.2.RELEASE" whatsnew="https://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.9.2.RELEASE.pdf">
         <download os="windows" version="2.9.2.RELEASE" eclipse-version="3.7.2" size="352MB">
             <description>Windows</description>
             <file>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-win32-installer.exe</file>
             <md5>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.9.2.RELEASE" eclipse-version="3.7.2" size="351MB">
             <description>Windows</description>
             <file>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-win32.zip</file>
             <md5>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-win32.zip.md5</md5>
             <sha1>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.9.2.RELEASE" eclipse-version="3.7.2" size="352MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.9.2.RELEASE" eclipse-version="3.7.2" size="351MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-win32-x86_64.zip</file>
             <md5>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.9.2.RELEASE" eclipse-version="3.7.2" size="352MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-macosx-carbon-installer.dmg</file>
             <md5>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-macosx-carbon-installer.dmg.md5</md5>
             <sha1>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-macosx-carbon-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.9.2.RELEASE" eclipse-version="3.7.2" size="348MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-macosx-carbon.tar.gz</file>
             <md5>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-macosx-carbon.tar.gz.md5</md5>
             <sha1>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-macosx-carbon.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.9.2.RELEASE" eclipse-version="3.7.2" size="352MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.9.2.RELEASE" eclipse-version="3.7.2" size="348MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.9.2.RELEASE" eclipse-version="3.7.2" size="352MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.9.2.RELEASE" eclipse-version="3.7.2" size="348MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.9.2.RELEASE" eclipse-version="3.7.2" size="352MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-linux-gtk-installer.sh</file>
             <md5>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.9.2.RELEASE" eclipse-version="3.7.2" size="348MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-linux-gtk.tar.gz</file>
             <md5>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.9.2.RELEASE" eclipse-version="3.7.2" size="352MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.9.2.RELEASE" eclipse-version="3.7.2" size="348MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.9.2/dist/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.9.2.RELEASE" eclipse-version="3.7.2" size="252MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.9.2.RELEASE/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-updatesite.zip</file>
             <md5>release/TOOLS/update/2.9.2.RELEASE/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.9.2.RELEASE/e3.7/springsource-tool-suite-2.9.2.RELEASE-e3.7.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.9.2.RELEASE" eclipse-version="3.6" size="206MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.9.2.RELEASE/e3.6/springsource-tool-suite-2.9.2.RELEASE-e3.6-updatesite.zip</file>
             <md5>release/TOOLS/update/2.9.2.RELEASE/e3.6/springsource-tool-suite-2.9.2.RELEASE-e3.6-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.9.2.RELEASE/e3.6/springsource-tool-suite-2.9.2.RELEASE-e3.6-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Previous Version - 2.9.1.RELEASE" whatsnew="http://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.9.2.RELEASE.pdf">
+    <other name="Previous Version - 2.9.1.RELEASE" whatsnew="https://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.9.2.RELEASE.pdf">
         <download os="windows" version="2.9.1.RELEASE" eclipse-version="3.7.2" size="347MB">
             <description>Windows</description>
             <file>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-win32-installer.exe</file>
             <md5>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.9.1.RELEASE" eclipse-version="3.7.2" size="346MB">
             <description>Windows</description>
             <file>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-win32.zip</file>
             <md5>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-win32.zip.md5</md5>
             <sha1>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.9.1.RELEASE" eclipse-version="3.7.2" size="347MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.9.1.RELEASE" eclipse-version="3.7.2" size="346MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-win32-x86_64.zip</file>
             <md5>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.9.1.RELEASE" eclipse-version="3.7.2" size="347MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-macosx-carbon-installer.dmg</file>
             <md5>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-macosx-carbon-installer.dmg.md5</md5>
             <sha1>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-macosx-carbon-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.9.1.RELEASE" eclipse-version="3.7.2" size="343MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-macosx-carbon.tar.gz</file>
             <md5>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-macosx-carbon.tar.gz.md5</md5>
             <sha1>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-macosx-carbon.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.9.1.RELEASE" eclipse-version="3.7.2" size="347MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.9.1.RELEASE" eclipse-version="3.7.2" size="343MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.9.1.RELEASE" eclipse-version="3.7.2" size="347MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.9.1.RELEASE" eclipse-version="3.7.2" size="343MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.9.1.RELEASE" eclipse-version="3.7.2" size="346MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-linux-gtk-installer.sh</file>
             <md5>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.9.1.RELEASE" eclipse-version="3.7.2" size="343MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-linux-gtk.tar.gz</file>
             <md5>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.9.1.RELEASE" eclipse-version="3.7.2" size="347MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.9.1.RELEASE" eclipse-version="3.7.2" size="343MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.9.1/dist/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.9.1.RELEASE" eclipse-version="3.7.2" size="252MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.9.1.RELEASE/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-updatesite.zip</file>
             <md5>release/TOOLS/update/2.9.1.RELEASE/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.9.1.RELEASE/e3.7/springsource-tool-suite-2.9.1.RELEASE-e3.7.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.9.1.RELEASE" eclipse-version="3.6" size="206MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.9.1.RELEASE/e3.6/springsource-tool-suite-2.9.1.RELEASE-e3.6-updatesite.zip</file>
             <md5>release/TOOLS/update/2.9.1.RELEASE/e3.6/springsource-tool-suite-2.9.1.RELEASE-e3.6-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.9.1.RELEASE/e3.6/springsource-tool-suite-2.9.1.RELEASE-e3.6-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Previous Version - 2.9.0.RELEASE" whatsnew="http://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.9.2.RELEASE.pdf">
+    <other name="Previous Version - 2.9.0.RELEASE" whatsnew="https://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.9.2.RELEASE.pdf">
         <download os="windows" version="2.9.0.RELEASE" eclipse-version="3.7.2" size="347MB">
             <description>Windows</description>
             <file>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-win32-installer.exe</file>
             <md5>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.9.0.RELEASE" eclipse-version="3.7.2" size="346MB">
             <description>Windows</description>
             <file>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-win32.zip</file>
             <md5>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-win32.zip.md5</md5>
             <sha1>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.9.0.RELEASE" eclipse-version="3.7.2" size="347MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.9.0.RELEASE" eclipse-version="3.7.2" size="346MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-win32-x86_64.zip</file>
             <md5>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.9.0.RELEASE" eclipse-version="3.7.2" size="347MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-macosx-carbon-installer.dmg</file>
             <md5>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-macosx-carbon-installer.dmg.md5</md5>
             <sha1>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-macosx-carbon-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.9.0.RELEASE" eclipse-version="3.7.2" size="343MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-macosx-carbon.tar.gz</file>
             <md5>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-macosx-carbon.tar.gz.md5</md5>
             <sha1>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-macosx-carbon.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.9.0.RELEASE" eclipse-version="3.7.2" size="347MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.9.0.RELEASE" eclipse-version="3.7.2" size="343MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.9.0.RELEASE" eclipse-version="3.7.2" size="347MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.9.0.RELEASE" eclipse-version="3.7.2" size="343MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.9.0.RELEASE" eclipse-version="3.7.2" size="346MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-linux-gtk-installer.sh</file>
             <md5>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.9.0.RELEASE" eclipse-version="3.7.2" size="343MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-linux-gtk.tar.gz</file>
             <md5>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.9.0.RELEASE" eclipse-version="3.7.2" size="347MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.9.0.RELEASE" eclipse-version="3.7.2" size="343MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.9.0/dist/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.9.0.RELEASE" eclipse-version="3.7.2" size="252MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.9.0.RELEASE/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-updatesite.zip</file>
             <md5>release/TOOLS/update/2.9.0.RELEASE/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.9.0.RELEASE/e3.7/springsource-tool-suite-2.9.0.RELEASE-e3.7.2-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.9.0.RELEASE" eclipse-version="3.6" size="206MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.9.0.RELEASE/e3.6/springsource-tool-suite-2.9.0.RELEASE-e3.6-updatesite.zip</file>
             <md5>release/TOOLS/update/2.9.0.RELEASE/e3.6/springsource-tool-suite-2.9.0.RELEASE-e3.6-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.9.0.RELEASE/e3.6/springsource-tool-suite-2.9.0.RELEASE-e3.6-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Previous Version - 2.8.1.RELEASE" whatsnew="http://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.8.1.RELEASE.pdf">
+    <other name="Previous Version - 2.8.1.RELEASE" whatsnew="https://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.8.1.RELEASE.pdf">
         <download os="windows" version="2.8.1.RELEASE" eclipse-version="3.7.1" size="358MB">
             <description>Windows</description>
             <file>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-win32-installer.exe</file>
             <md5>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-win32-installer.exe.md5</md5>
             <sha1>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.8.1.RELEASE" eclipse-version="3.7.1" size="357MB">
             <description>Windows</description>
             <file>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-win32.zip</file>
             <md5>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-win32.zip.md5</md5>
             <sha1>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.8.1.RELEASE" eclipse-version="3.7.1" size="358MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-win32-x86_64-installer.exe</file>
             <md5>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.8.1.RELEASE" eclipse-version="3.7.1" size="357MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-win32-x86_64.zip</file>
             <md5>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.8.1.RELEASE" eclipse-version="3.7.1" size="358MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-macosx-carbon-installer.dmg</file>
             <md5>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-macosx-carbon-installer.dmg.md5</md5>
             <sha1>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-macosx-carbon-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.8.1.RELEASE" eclipse-version="3.7.1" size="354MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-macosx-carbon.tar.gz</file>
             <md5>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-macosx-carbon.tar.gz.md5</md5>
             <sha1>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-macosx-carbon.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.8.1.RELEASE" eclipse-version="3.7.1" size="358MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.8.1.RELEASE" eclipse-version="3.7.1" size="355MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-macosx-cocoa.tar.gz</file>
             <md5>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.8.1.RELEASE" eclipse-version="3.7.1" size="358MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.8.1.RELEASE" eclipse-version="3.7.1" size="355MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.8.1.RELEASE" eclipse-version="3.7.1" size="358MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-linux-gtk-installer.sh</file>
             <md5>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.8.1.RELEASE" eclipse-version="3.7.1" size="355MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-linux-gtk.tar.gz</file>
             <md5>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.8.1.RELEASE" eclipse-version="3.7.1" size="358MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.8.1.RELEASE" eclipse-version="3.7.1" size="355MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.8.1/dist/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.8.1.RELEASE" eclipse-version="3.7.1" size="183MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.8.1.RELEASE/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-updatesite.zip</file>
             <md5>release/TOOLS/update/2.8.1.RELEASE/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.8.1.RELEASE/e3.7/springsource-tool-suite-2.8.1.RELEASE-e3.7.1-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.8.1.RELEASE" eclipse-version="3.6" size="205MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.8.1.RELEASE/e3.6/springsource-tool-suite-2.8.1.RELEASE-e3.6-updatesite.zip</file>
             <md5>release/TOOLS/update/2.8.1.RELEASE/e3.6/springsource-tool-suite-2.8.1.RELEASE-e3.6-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.8.1.RELEASE/e3.6/springsource-tool-suite-2.8.1.RELEASE-e3.6-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Previous Version - 2.8.0.RELEASE" whatsnew="http://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.8.1.RELEASE.pdf">
+    <other name="Previous Version - 2.8.0.RELEASE" whatsnew="https://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.8.1.RELEASE.pdf">
         <download os="windows" version="2.8.0.RELEASE" eclipse-version="3.7.1" size="358MB">
             <description>Windows</description>
             <file>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-win32-installer.exe</file>
             <md5>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-win32-installer.exe.md5</md5>
             <sha1>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.8.0.RELEASE" eclipse-version="3.7.1" size="357MB">
             <description>Windows</description>
             <file>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-win32.zip</file>
             <md5>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-win32.zip.md5</md5>
             <sha1>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.8.0.RELEASE" eclipse-version="3.7.1" size="358MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-win32-x86_64-installer.exe</file>
             <md5>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.8.0.RELEASE" eclipse-version="3.7.1" size="357MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-win32-x86_64.zip</file>
             <md5>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.8.0.RELEASE" eclipse-version="3.7.1" size="358MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-macosx-carbon-installer.dmg</file>
             <md5>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-macosx-carbon-installer.dmg.md5</md5>
             <sha1>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-macosx-carbon-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.8.0.RELEASE" eclipse-version="3.7.1" size="354MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-macosx-carbon.tar.gz</file>
             <md5>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-macosx-carbon.tar.gz.md5</md5>
             <sha1>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-macosx-carbon.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.8.0.RELEASE" eclipse-version="3.7.1" size="358MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.8.0.RELEASE" eclipse-version="3.7.1" size="354MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-macosx-cocoa.tar.gz</file>
             <md5>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.8.0.RELEASE" eclipse-version="3.7.1" size="358MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.8.0.RELEASE" eclipse-version="3.7.1" size="354MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.8.0.RELEASE" eclipse-version="3.7.1" size="358MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-linux-gtk-installer.sh</file>
             <md5>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.8.0.RELEASE" eclipse-version="3.7.1" size="354MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-linux-gtk.tar.gz</file>
             <md5>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.8.0.RELEASE" eclipse-version="3.7.1" size="358MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.8.0.RELEASE" eclipse-version="3.7.1" size="355MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.8.0/dist/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.8.0.RELEASE" eclipse-version="3.7.1" size="183MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.8.0.RELEASE/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-updatesite.zip</file>
             <md5>release/TOOLS/update/2.8.0.RELEASE/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.8.0.RELEASE/e3.7/springsource-tool-suite-2.8.0.RELEASE-e3.7.1-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.8.0.RELEASE" eclipse-version="3.6" size="205MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.8.0.RELEASE/e3.6/springsource-tool-suite-2.8.0.RELEASE-e3.6-updatesite.zip</file>
             <md5>release/TOOLS/update/2.8.0.RELEASE/e3.6/springsource-tool-suite-2.8.0.RELEASE-e3.6-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.8.0.RELEASE/e3.6/springsource-tool-suite-2.8.0.RELEASE-e3.6-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Previous Version - 2.7.2.RELEASE" whatsnew="http://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.7.2.RELEASE.pdf">
+    <other name="Previous Version - 2.7.2.RELEASE" whatsnew="https://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.7.2.RELEASE.pdf">
         <download os="windows" version="2.7.2.RELEASE" eclipse-version="3.7" size="360MB">
             <description>Windows</description>
             <file>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-win32-installer.exe</file>
             <md5>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-win32-installer.exe.md5</md5>
             <sha1>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.7.2.RELEASE" eclipse-version="3.7" size="359MB">
             <description>Windows</description>
             <file>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-win32.zip</file>
             <md5>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-win32.zip.md5</md5>
             <sha1>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.7.2.RELEASE" eclipse-version="3.7" size="360MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-win32-x86_64-installer.exe</file>
             <md5>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.7.2.RELEASE" eclipse-version="3.7" size="359MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-win32-x86_64.zip</file>
             <md5>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.7.2.RELEASE" eclipse-version="3.7" size="360MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-macosx-carbon-installer.dmg</file>
             <md5>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-macosx-carbon-installer.dmg.md5</md5>
             <sha1>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-macosx-carbon-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.7.2.RELEASE" eclipse-version="3.7" size="357MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-macosx-carbon.tar.gz</file>
             <md5>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-macosx-carbon.tar.gz.md5</md5>
             <sha1>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-macosx-carbon.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.7.2.RELEASE" eclipse-version="3.7" size="361MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.7.2.RELEASE" eclipse-version="3.7" size="357MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-macosx-cocoa.tar.gz</file>
             <md5>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.7.2.RELEASE" eclipse-version="3.7" size="361MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.7.2.RELEASE" eclipse-version="3.7" size="357MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.7.2.RELEASE" eclipse-version="3.7" size="360MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-linux-gtk-installer.sh</file>
             <md5>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.7.2.RELEASE" eclipse-version="3.7" size="357MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-linux-gtk.tar.gz</file>
             <md5>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.7.2.RELEASE" eclipse-version="3.7" size="360MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.7.2.RELEASE" eclipse-version="3.7" size="357MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.7.2/dist/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.7.2.RELEASE" eclipse-version="3.7" size="160MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.7.2.RELEASE/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-updatesite.zip</file>
             <md5>release/TOOLS/update/2.7.2.RELEASE/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.7.2.RELEASE/e3.7/springsource-tool-suite-2.7.2.RELEASE-e3.7-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.7.2.RELEASE" eclipse-version="3.6" size="223MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.7.2.RELEASE/e3.6/springsource-tool-suite-2.7.2.RELEASE-e3.6-updatesite.zip</file>
             <md5>release/TOOLS/update/2.7.2.RELEASE/e3.6/springsource-tool-suite-2.7.2.RELEASE-e3.6-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.7.2.RELEASE/e3.6/springsource-tool-suite-2.7.2.RELEASE-e3.6-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Previous Version - 2.7.1.RELEASE" whatsnew="http://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.7.2.RELEASE.pdf">
+    <other name="Previous Version - 2.7.1.RELEASE" whatsnew="https://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.7.2.RELEASE.pdf">
         <download os="windows" version="2.7.1.RELEASE" eclipse-version="3.7" size="361MB">
             <description>Windows</description>
             <file>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-win32-installer.exe</file>
             <md5>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-win32-installer.exe.md5</md5>
             <sha1>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.7.1.RELEASE" eclipse-version="3.7" size="360MB">
             <description>Windows</description>
             <file>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-win32.zip</file>
             <md5>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-win32.zip.md5</md5>
             <sha1>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.7.1.RELEASE" eclipse-version="3.7" size="361MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-win32-x86_64-installer.exe</file>
             <md5>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.7.1.RELEASE" eclipse-version="3.7" size="359MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-win32-x86_64.zip</file>
             <md5>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.7.1.RELEASE" eclipse-version="3.7" size="361MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-macosx-carbon-installer.dmg</file>
             <md5>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-macosx-carbon-installer.dmg.md5</md5>
             <sha1>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-macosx-carbon-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.7.1.RELEASE" eclipse-version="3.7" size="357MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-macosx-carbon.tar.gz</file>
             <md5>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-macosx-carbon.tar.gz.md5</md5>
             <sha1>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-macosx-carbon.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.7.1.RELEASE" eclipse-version="3.7" size="361MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.7.1.RELEASE" eclipse-version="3.7" size="357MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-macosx-cocoa.tar.gz</file>
             <md5>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.7.1.RELEASE" eclipse-version="3.7" size="361MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.7.1.RELEASE" eclipse-version="3.7" size="357MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.7.1.RELEASE" eclipse-version="3.7" size="360MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-linux-gtk-installer.sh</file>
             <md5>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.7.1.RELEASE" eclipse-version="3.7" size="357MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-linux-gtk.tar.gz</file>
             <md5>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.7.1.RELEASE" eclipse-version="3.7" size="360MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.7.1.RELEASE" eclipse-version="3.7" size="357MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.7.1/dist/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.7.1.RELEASE" eclipse-version="3.7" size="160MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.7.1.RELEASE/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-updatesite.zip</file>
             <md5>release/TOOLS/update/2.7.1.RELEASE/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.7.1.RELEASE/e3.7/springsource-tool-suite-2.7.1.RELEASE-e3.7-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.7.1.RELEASE" eclipse-version="3.6" size="223MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.7.1.RELEASE/e3.6/springsource-tool-suite-2.7.1.RELEASE-e3.6-updatesite.zip</file>
             <md5>release/TOOLS/update/2.7.1.RELEASE/e3.6/springsource-tool-suite-2.7.1.RELEASE-e3.6-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.7.1.RELEASE/e3.6/springsource-tool-suite-2.7.1.RELEASE-e3.6-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Previous Version - 2.7.0.RELEASE" whatsnew="http://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.7.2.RELEASE.pdf">
+    <other name="Previous Version - 2.7.0.RELEASE" whatsnew="https://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.7.2.RELEASE.pdf">
         <download os="windows" version="2.7.0.RELEASE" eclipse-version="3.7" size="361MB">
             <description>Windows</description>
             <file>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-win32-installer.exe</file>
             <md5>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-win32-installer.exe.md5</md5>
             <sha1>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.7.0.RELEASE" eclipse-version="3.7" size="360MB">
             <description>Windows</description>
             <file>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-win32.zip</file>
             <md5>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-win32.zip.md5</md5>
             <sha1>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.7.0.RELEASE" eclipse-version="3.7" size="361MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-win32-x86_64-installer.exe</file>
             <md5>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.7.0.RELEASE" eclipse-version="3.7" size="359MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-win32-x86_64.zip</file>
             <md5>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.7.0.RELEASE" eclipse-version="3.7" size="360MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-macosx-carbon-installer.dmg</file>
             <md5>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-macosx-carbon-installer.dmg.md5</md5>
             <sha1>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-macosx-carbon-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.7.0.RELEASE" eclipse-version="3.7" size="357MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-macosx-carbon.tar.gz</file>
             <md5>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-macosx-carbon.tar.gz.md5</md5>
             <sha1>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-macosx-carbon.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.7.0.RELEASE" eclipse-version="3.7" size="361MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.7.0.RELEASE" eclipse-version="3.7" size="357MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-macosx-cocoa.tar.gz</file>
             <md5>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.7.0.RELEASE" eclipse-version="3.7" size="361MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.7.0.RELEASE" eclipse-version="3.7" size="357MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.7.0.RELEASE" eclipse-version="3.7" size="360MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-linux-gtk-installer.sh</file>
             <md5>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.7.0.RELEASE" eclipse-version="3.7" size="357MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-linux-gtk.tar.gz</file>
             <md5>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.7.0.RELEASE" eclipse-version="3.7" size="360MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.7.0.RELEASE" eclipse-version="3.7" size="357MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.7.0/dist/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.7.0.RELEASE" eclipse-version="3.7" size="160MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.7.0.RELEASE/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-updatesite.zip</file>
             <md5>release/TOOLS/update/2.7.0.RELEASE/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.7.0.RELEASE/e3.7/springsource-tool-suite-2.7.0.RELEASE-e3.7-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.7.0.RELEASE" eclipse-version="3.6" size="223MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.7.0.RELEASE/e3.6/springsource-tool-suite-2.7.0.RELEASE-e3.6-updatesite.zip</file>
             <md5>release/TOOLS/update/2.7.0.RELEASE/e3.6/springsource-tool-suite-2.7.0.RELEASE-e3.6-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.7.0.RELEASE/e3.6/springsource-tool-suite-2.7.0.RELEASE-e3.6-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Previous Version - 2.6.1.SR1" whatsnew="http://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.6.1.SR1.pdf">
+    <other name="Previous Version - 2.6.1.SR1" whatsnew="https://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.6.1.SR1.pdf">
         <download os="windows" version="2.6.1.SR1" eclipse-version="3.6.2" size="347MB">
             <description>Windows</description>
             <file>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-win32-installer.exe</file>
             <md5>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.6.1.SR1" eclipse-version="3.6.2" size="346MB">
             <description>Windows</description>
             <file>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-win32.zip</file>
             <md5>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-win32.zip.md5</md5>
             <sha1>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.6.1.SR1" eclipse-version="3.6.2" size="347MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.6.1.SR1" eclipse-version="3.6.2" size="346MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-win32-x86_64.zip</file>
             <md5>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.6.1.SR1" eclipse-version="3.6.2" size="347MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-macosx-carbon-installer.dmg</file>
             <md5>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-macosx-carbon-installer.dmg.md5</md5>
             <sha1>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-macosx-carbon-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.6.1.SR1" eclipse-version="3.6.2" size="344MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-macosx-carbon.tar.gz</file>
             <md5>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-macosx-carbon.tar.gz.md5</md5>
             <sha1>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-macosx-carbon.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.6.1.SR1" eclipse-version="3.6.2" size="348MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.6.1.SR1" eclipse-version="3.6.2" size="344MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.6.1.SR1" eclipse-version="3.6.2" size="348MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.6.1.SR1" eclipse-version="3.6.2" size="344MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.6.1.SR1" eclipse-version="3.6.2" size="347MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-linux-gtk-installer.sh</file>
             <md5>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.6.1.SR1" eclipse-version="3.6.2" size="344MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-linux-gtk.tar.gz</file>
             <md5>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.6.1.SR1" eclipse-version="3.6.2" size="347MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.6.1.SR1" eclipse-version="3.6.2" size="344MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.6.1.SR1/dist/e3.6/springsource-tool-suite-2.6.1.SR1-e3.6.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.6.1.RELEASE" eclipse-version="3.6" size="241MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.6.1.RELEASE/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6-updatesite.zip</file>
             <md5>release/TOOLS/update/2.6.1.RELEASE/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.6.1.RELEASE/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.6.1.RELEASE" eclipse-version="3.5" size="175MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.6.1.RELEASE/e3.5/springsource-tool-suite-2.6.1.RELEASE-e3.5-updatesite.zip</file>
             <md5>release/TOOLS/update/2.6.1.RELEASE/e3.5/springsource-tool-suite-2.6.1.RELEASE-e3.5-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.6.1.RELEASE/e3.5/springsource-tool-suite-2.6.1.RELEASE-e3.5-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Previous Version - 2.6.1" whatsnew="http://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.6.1.SR1.pdf">
+    <other name="Previous Version - 2.6.1" whatsnew="https://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.6.1.SR1.pdf">
         <download os="windows" version="2.6.1.RELEASE" eclipse-version="3.6.2" size="346MB">
             <description>Windows</description>
             <file>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-win32-installer.exe</file>
             <md5>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.6.1.RELEASE" eclipse-version="3.6.2" size="345MB">
             <description>Windows</description>
             <file>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-win32.zip</file>
             <md5>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-win32.zip.md5</md5>
             <sha1>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.6.1.RELEASE" eclipse-version="3.6.2" size="346MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.6.1.RELEASE" eclipse-version="3.6.2" size="345MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-win32-x86_64.zip</file>
             <md5>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.6.1.RELEASE" eclipse-version="3.6.2" size="347MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-macosx-carbon-installer.dmg</file>
             <md5>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-macosx-carbon-installer.dmg.md5</md5>
             <sha1>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-macosx-carbon-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.6.1.RELEASE" eclipse-version="3.6.2" size="343MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-macosx-carbon.tar.gz</file>
             <md5>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-macosx-carbon.tar.gz.md5</md5>
             <sha1>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-macosx-carbon.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.6.1.RELEASE" eclipse-version="3.6.2" size="347MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.6.1.RELEASE" eclipse-version="3.6.2" size="343MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.6.1.RELEASE" eclipse-version="3.6.2" size="346MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.6.1.RELEASE" eclipse-version="3.6.2" size="343MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.6.1.RELEASE" eclipse-version="3.6.2" size="346MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-linux-gtk-installer.sh</file>
             <md5>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.6.1.RELEASE" eclipse-version="3.6.2" size="343MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-linux-gtk.tar.gz</file>
             <md5>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.6.1.RELEASE" eclipse-version="3.6.2" size="346MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.6.1.RELEASE" eclipse-version="3.6.2" size="343MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.6.1/dist/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.6.1.RELEASE" eclipse-version="3.6" size="241MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.6.1.RELEASE/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6-updatesite.zip</file>
             <md5>release/TOOLS/update/2.6.1.RELEASE/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.6.1.RELEASE/e3.6/springsource-tool-suite-2.6.1.RELEASE-e3.6-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.6.1.RELEASE" eclipse-version="3.5" size="175MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.6.1.RELEASE/e3.5/springsource-tool-suite-2.6.1.RELEASE-e3.5-updatesite.zip</file>
             <md5>release/TOOLS/update/2.6.1.RELEASE/e3.5/springsource-tool-suite-2.6.1.RELEASE-e3.5-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.6.1.RELEASE/e3.5/springsource-tool-suite-2.6.1.RELEASE-e3.5-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Previous Version - 2.6.0.SR1" whatsnew="http://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.6.1.SR1.pdf">
+    <other name="Previous Version - 2.6.0.SR1" whatsnew="https://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.6.1.SR1.pdf">
         <download os="windows" version="2.6.0.SR1" eclipse-version="3.6.2" size="339MB">
             <description>Windows</description>
             <file>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-win32-installer.exe</file>
             <md5>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.6.0.SR1" eclipse-version="3.6.2" size="338MB">
             <description>Windows</description>
             <file>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-win32.zip</file>
             <md5>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-win32.zip.md5</md5>
             <sha1>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.6.0.SR1" eclipse-version="3.6.2" size="339MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.6.0.SR1" eclipse-version="3.6.2" size="338MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-win32-x86_64.zip</file>
             <md5>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.6.0.SR1" eclipse-version="3.6.2" size="339MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-macosx-carbon-installer.dmg</file>
             <md5>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-macosx-carbon-installer.dmg.md5</md5>
             <sha1>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-macosx-carbon-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.6.0.SR1" eclipse-version="3.6.2" size="335MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-macosx-carbon.tar.gz</file>
             <md5>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-macosx-carbon.tar.gz.md5</md5>
             <sha1>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-macosx-carbon.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.6.0.SR1" eclipse-version="3.6.2" size="339MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.6.0.SR1" eclipse-version="3.6.2" size="336MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.6.0.SR1" eclipse-version="3.6.2" size="339MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.6.0.SR1" eclipse-version="3.6.2" size="336MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.6.0.SR1" eclipse-version="3.6.2" size="339MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-linux-gtk-installer.sh</file>
             <md5>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.6.0.SR1" eclipse-version="3.6.2" size="336MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-linux-gtk.tar.gz</file>
             <md5>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.6.0.SR1" eclipse-version="3.6.2" size="339MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.6.0.SR1" eclipse-version="3.6.2" size="336MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.6.0.SR1/dist/e3.6/springsource-tool-suite-2.6.0.SR1-e3.6.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Previous Version - 2.6.0.RELEASE" whatsnew="http://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.6.1.SR1.pdf">
+    <other name="Previous Version - 2.6.0.RELEASE" whatsnew="https://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.6.1.SR1.pdf">
         <download os="windows" version="2.6.0.RELEASE" eclipse-version="3.6.2" size="186MB">
             <description>Windows</description>
             <file>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-win32-installer.exe</file>
             <md5>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.6.0.RELEASE" eclipse-version="3.6.2" size="336MB">
             <description>Windows</description>
             <file>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-win32.zip</file>
             <md5>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-win32.zip.md5</md5>
             <sha1>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.6.0.RELEASE" eclipse-version="3.6.2" size="186MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.6.0.RELEASE" eclipse-version="3.6.2" size="336MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-win32-x86_64.zip</file>
             <md5>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.6.0.RELEASE" eclipse-version="3.6.2" size="186MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-macosx-carbon-installer.dmg</file>
             <md5>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-macosx-carbon-installer.dmg.md5</md5>
             <sha1>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-macosx-carbon-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.6.0.RELEASE" eclipse-version="3.6.2" size="334MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-macosx-carbon.tar.gz</file>
             <md5>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-macosx-carbon.tar.gz.md5</md5>
             <sha1>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-macosx-carbon.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.6.0.RELEASE" eclipse-version="3.6.2" size="186MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.6.0.RELEASE" eclipse-version="3.6.2" size="334MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.6.0.RELEASE" eclipse-version="3.6.2" size="186MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.6.0.RELEASE" eclipse-version="3.6.2" size="334MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.6.0.RELEASE" eclipse-version="3.6.2" size="185MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-linux-gtk-installer.sh</file>
             <md5>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.6.0.RELEASE" eclipse-version="3.6.2" size="334MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-linux-gtk.tar.gz</file>
             <md5>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.6.0.RELEASE" eclipse-version="3.6.2" size="186MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.6.0.RELEASE" eclipse-version="3.6.2" size="334MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.6.0/dist/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.6.0.RELEASE" eclipse-version="3.6" size="253MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.6.0.RELEASE/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6-updatesite.zip</file>
             <md5>release/TOOLS/update/2.6.0.RELEASE/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.6.0.RELEASE/e3.6/springsource-tool-suite-2.6.0.RELEASE-e3.6-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.6.0.RELEASE" eclipse-version="3.5" size="187MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.6.0.RELEASE/e3.5/springsource-tool-suite-2.6.0.RELEASE-e3.5-updatesite.zip</file>
             <md5>release/TOOLS/update/2.6.0.RELEASE/e3.5/springsource-tool-suite-2.6.0.RELEASE-e3.5-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.6.0.RELEASE/e3.5/springsource-tool-suite-2.6.0.RELEASE-e3.5-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Previous Version - 2.5.2.SR1" whatsnew="http://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.5.2.SR1.pdf">
+    <other name="Previous Version - 2.5.2.SR1" whatsnew="https://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.5.2.SR1.pdf">
         <download os="windows" version="2.5.2.SR1" eclipse-version="3.6.2" size="192MB">
             <description>Windows</description>
             <file>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-win32-installer.exe</file>
             <md5>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.5.2.SR1" eclipse-version="3.6.2" size="349MB">
             <description>Windows</description>
             <file>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-win32.zip</file>
             <md5>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-win32.zip.md5</md5>
             <sha1>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.5.2.SR1" eclipse-version="3.6.2" size="192MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.5.2.SR1" eclipse-version="3.6.2" size="349MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-win32-x86_64.zip</file>
             <md5>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.5.2.SR1" eclipse-version="3.6.2" size="192MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-macosx-carbon-installer.dmg</file>
             <md5>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-macosx-carbon-installer.dmg.md5</md5>
             <sha1>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-macosx-carbon-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.5.2.SR1" eclipse-version="3.6.2" size="346MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-macosx-carbon.tar.gz</file>
             <md5>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-macosx-carbon.tar.gz.md5</md5>
             <sha1>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-macosx-carbon.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.5.2.SR1" eclipse-version="3.6.2" size="192MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.5.2.SR1" eclipse-version="3.6.2" size="346MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.5.2.SR1" eclipse-version="3.6.2" size="192MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.5.2.SR1" eclipse-version="3.6.2" size="346MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.5.2.SR1" eclipse-version="3.6.2" size="191MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-linux-gtk-installer.sh</file>
             <md5>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.5.2.SR1" eclipse-version="3.6.2" size="346MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-linux-gtk.tar.gz</file>
             <md5>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.5.2.SR1" eclipse-version="3.6.2" size="191MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.5.2.SR1" eclipse-version="3.6.2" size="347MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.5.2.SR1/dist/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.5.2.SR1" eclipse-version="3.6" size="252MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.5.2.SR1/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6-updatesite.zip</file>
             <md5>release/TOOLS/update/2.5.2.SR1/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.5.2.SR1/e3.6/springsource-tool-suite-2.5.2.SR1-e3.6-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.5.2.SR1" eclipse-version="3.5" size="186MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.5.2.SR1/e3.5/springsource-tool-suite-2.5.2.SR1-e3.5-updatesite.zip</file>
             <md5>release/TOOLS/update/2.5.2.SR1/e3.5/springsource-tool-suite-2.5.2.SR1-e3.5-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.5.2.SR1/e3.5/springsource-tool-suite-2.5.2.SR1-e3.5-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Previous Version - 2.5.2.RELEASE" whatsnew="http://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.5.2.SR1.pdf">
+    <other name="Previous Version - 2.5.2.RELEASE" whatsnew="https://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.5.2.SR1.pdf">
         <download os="windows" version="2.5.2.RELEASE" eclipse-version="3.6.1" size="190MB">
             <description>Windows</description>
             <file>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-win32-installer.exe</file>
             <md5>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-win32-installer.exe.md5</md5>
             <sha1>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.5.2.RELEASE" eclipse-version="3.6.1" size="346MB">
             <description>Windows</description>
             <file>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-win32.zip</file>
             <md5>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-win32.zip.md5</md5>
             <sha1>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.5.2.RELEASE" eclipse-version="3.6.1" size="190MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-win32-x86_64-installer.exe</file>
             <md5>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.5.2.RELEASE" eclipse-version="3.6.1" size="345MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-win32-x86_64.zip</file>
             <md5>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.5.2.RELEASE" eclipse-version="3.6.1" size="190MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-macosx-carbon-installer.dmg</file>
             <md5>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-macosx-carbon-installer.dmg.md5</md5>
             <sha1>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-macosx-carbon-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.5.2.RELEASE" eclipse-version="3.6.1" size="343MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-macosx-carbon.tar.gz</file>
             <md5>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-macosx-carbon.tar.gz.md5</md5>
             <sha1>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-macosx-carbon.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.5.2.RELEASE" eclipse-version="3.6.1" size="190MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.5.2.RELEASE" eclipse-version="3.6.1" size="343MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-macosx-cocoa.tar.gz</file>
             <md5>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.5.2.RELEASE" eclipse-version="3.6.1" size="190MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.5.2.RELEASE" eclipse-version="3.6.1" size="343MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.5.2.RELEASE" eclipse-version="3.6.1" size="190MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-linux-gtk-installer.sh</file>
             <md5>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.5.2.RELEASE" eclipse-version="3.6.1" size="343MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-linux-gtk.tar.gz</file>
             <md5>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.5.2.RELEASE" eclipse-version="3.6.1" size="190MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.5.2.RELEASE" eclipse-version="3.6.1" size="343MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.5.2/dist/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6.1-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.5.2.RELEASE" eclipse-version="3.6" size="169MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.5.2.RELEASE/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6-updatesite.zip</file>
             <md5>release/TOOLS/update/2.5.2.RELEASE/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.5.2.RELEASE/e3.6/springsource-tool-suite-2.5.2.RELEASE-e3.6-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.5.2.RELEASE" eclipse-version="3.5" size="165MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.5.2.RELEASE/e3.5/springsource-tool-suite-2.5.2.RELEASE-e3.5-updatesite.zip</file>
             <md5>release/TOOLS/update/2.5.2.RELEASE/e3.5/springsource-tool-suite-2.5.2.RELEASE-e3.5-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.5.2.RELEASE/e3.5/springsource-tool-suite-2.5.2.RELEASE-e3.5-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Previous Version - 2.5.1.RELEASE" whatsnew="http://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.5.2.SR1.pdf">
+    <other name="Previous Version - 2.5.1.RELEASE" whatsnew="https://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.5.2.SR1.pdf">
         <download os="windows" version="2.5.1.RELEASE" eclipse-version="3.6.1" size="193MB">
             <description>Windows</description>
             <file>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-win32-installer.exe</file>
             <md5>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-win32-installer.exe.md5</md5>
             <sha1>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.5.1.RELEASE" eclipse-version="3.6.1" size="350MB">
             <description>Windows</description>
             <file>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-win32.zip</file>
             <md5>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-win32.zip.md5</md5>
             <sha1>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.5.1.RELEASE" eclipse-version="3.6.1" size="193MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-win32-x86_64-installer.exe</file>
             <md5>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.5.1.RELEASE" eclipse-version="3.6.1" size="350MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-win32-x86_64.zip</file>
             <md5>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.5.1.RELEASE" eclipse-version="3.6.1" size="194MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-macosx-carbon-installer.dmg</file>
             <md5>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-macosx-carbon-installer.dmg.md5</md5>
             <sha1>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-macosx-carbon-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.5.1.RELEASE" eclipse-version="3.6.1" size="348MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-macosx-carbon.tar.gz</file>
             <md5>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-macosx-carbon.tar.gz.md5</md5>
             <sha1>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-macosx-carbon.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.5.1.RELEASE" eclipse-version="3.6.1" size="194MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.5.1.RELEASE" eclipse-version="3.6.1" size="348MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-macosx-cocoa.tar.gz</file>
             <md5>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.5.1.RELEASE" eclipse-version="3.6.1" size="193MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.5.1.RELEASE" eclipse-version="3.6.1" size="348MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.5.1.RELEASE" eclipse-version="3.6.1" size="193MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-linux-gtk-installer.sh</file>
             <md5>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.5.1.RELEASE" eclipse-version="3.6.1" size="348MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-linux-gtk.tar.gz</file>
             <md5>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.5.1.RELEASE" eclipse-version="3.6.1" size="193MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.5.1.RELEASE" eclipse-version="3.6.1" size="348MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.5.1/dist/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6.1-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.5.1.RELEASE" eclipse-version="3.6" size="171MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.5.1.RELEASE/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6-updatesite.zip</file>
             <md5>release/TOOLS/update/2.5.1.RELEASE/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.5.1.RELEASE/e3.6/springsource-tool-suite-2.5.1.RELEASE-e3.6-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.5.1.RELEASE" eclipse-version="3.5" size="167MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.5.1.RELEASE/e3.5/springsource-tool-suite-2.5.1.RELEASE-e3.5-updatesite.zip</file>
             <md5>release/TOOLS/update/2.5.1.RELEASE/e3.5/springsource-tool-suite-2.5.1.RELEASE-e3.5-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.5.1.RELEASE/e3.5/springsource-tool-suite-2.5.1.RELEASE-e3.5-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Previous Version - 2.5.0.RELEASE" whatsnew="http://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.5.2.SR1.pdf">
+    <other name="Previous Version - 2.5.0.RELEASE" whatsnew="https://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.5.2.SR1.pdf">
         <download os="windows" version="2.5.0.RELEASE" eclipse-version="3.6.1" size="194MB">
             <description>Windows</description>
             <file>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-win32-installer.exe</file>
             <md5>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-win32-installer.exe.md5</md5>
             <sha1>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.5.0.RELEASE" eclipse-version="3.6.1" size="355MB">
             <description>Windows</description>
             <file>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-win32.zip</file>
             <md5>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-win32.zip.md5</md5>
             <sha1>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.5.0.RELEASE" eclipse-version="3.6.1" size="194MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-win32-x86_64-installer.exe</file>
             <md5>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.5.0.RELEASE" eclipse-version="3.6.1" size="355MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-win32-x86_64.zip</file>
             <md5>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.5.0.RELEASE" eclipse-version="3.6.1" size="194MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-macosx-carbon-installer.dmg</file>
             <md5>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-macosx-carbon-installer.dmg.md5</md5>
             <sha1>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-macosx-carbon-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.5.0.RELEASE" eclipse-version="3.6.1" size="352MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-macosx-carbon.tar.gz</file>
             <md5>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-macosx-carbon.tar.gz.md5</md5>
             <sha1>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-macosx-carbon.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.5.0.RELEASE" eclipse-version="3.6.1" size="194MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.5.0.RELEASE" eclipse-version="3.6.1" size="353MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-macosx-cocoa.tar.gz</file>
             <md5>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.5.0.RELEASE" eclipse-version="3.6.1" size="194MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.5.0.RELEASE" eclipse-version="3.6.1" size="352MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.5.0.RELEASE" eclipse-version="3.6.1" size="194MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-linux-gtk-installer.sh</file>
             <md5>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.5.0.RELEASE" eclipse-version="3.6.1" size="352MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-linux-gtk.tar.gz</file>
             <md5>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.5.0.RELEASE" eclipse-version="3.6.1" size="194MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.5.0.RELEASE" eclipse-version="3.6.1" size="353MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.5.0/dist/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6.1-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.5.0.RELEASE" eclipse-version="3.6" size="174MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.5.0.RELEASE/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6-updatesite.zip</file>
             <md5>release/TOOLS/update/2.5.0.RELEASE/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.5.0.RELEASE/e3.6/springsource-tool-suite-2.5.0.RELEASE-e3.6-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="all" version="2.5.0.RELEASE" eclipse-version="3.5" size="170MB">
             <description>Update Site</description>
             <file>release/TOOLS/update/2.5.0.RELEASE/e3.5/springsource-tool-suite-2.5.0.RELEASE-e3.5-updatesite.zip</file>
             <md5>release/TOOLS/update/2.5.0.RELEASE/e3.5/springsource-tool-suite-2.5.0.RELEASE-e3.5-updatesite.zip.md5</md5>
             <sha1>release/TOOLS/update/2.5.0.RELEASE/e3.5/springsource-tool-suite-2.5.0.RELEASE-e3.5-updatesite.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
-    <other name="Previous Version - 2.3.2.RELEASE" whatsnew="http://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.3.2.RELEASE.pdf">
+    <other name="Previous Version - 2.3.2.RELEASE" whatsnew="https://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.3.2.RELEASE.pdf">
         <download os="windows" version="2.3.2.RELEASE" eclipse-version="3.5.2" size="174MB">
             <description>Windows</description>
             <file>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-win32-installer.exe</file>
             <md5>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-win32-installer.exe.md5</md5>
             <sha1>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-win32-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.3.2.RELEASE" eclipse-version="3.5.2" size="318MB">
             <description>Windows</description>
             <file>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-win32.zip</file>
             <md5>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-win32.zip.md5</md5>
             <sha1>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-win32.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.3.2.RELEASE" eclipse-version="3.5.2" size="174MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-win32-x86_64-installer.exe</file>
             <md5>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-win32-x86_64-installer.exe.md5</md5>
             <sha1>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-win32-x86_64-installer.exe.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="windows" version="2.3.2.RELEASE" eclipse-version="3.5.2" size="318MB">
             <description>Windows (64bit)</description>
             <file>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-win32-x86_64.zip</file>
             <md5>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-win32-x86_64.zip.md5</md5>
             <sha1>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-win32-x86_64.zip.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.3.2.RELEASE" eclipse-version="3.5.2" size="174MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-macosx-carbon-installer.dmg</file>
             <md5>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-macosx-carbon-installer.dmg.md5</md5>
             <sha1>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-macosx-carbon-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.3.2.RELEASE" eclipse-version="3.5.2" size="315MB">
             <description>Mac OS X (Carbon)</description>
             <file>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-macosx-carbon.tar.gz</file>
             <md5>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-macosx-carbon.tar.gz.md5</md5>
             <sha1>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-macosx-carbon.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.3.2.RELEASE" eclipse-version="3.5.2" size="174MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-macosx-cocoa-installer.dmg</file>
             <md5>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-macosx-cocoa-installer.dmg.md5</md5>
             <sha1>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-macosx-cocoa-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.3.2.RELEASE" eclipse-version="3.5.2" size="315MB">
             <description>Mac OS X (Cocoa)</description>
             <file>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-macosx-cocoa.tar.gz</file>
             <md5>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-macosx-cocoa.tar.gz.md5</md5>
             <sha1>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-macosx-cocoa.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.3.2.RELEASE" eclipse-version="3.5.2" size="174MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-macosx-cocoa-x86_64-installer.dmg</file>
             <md5>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-macosx-cocoa-x86_64-installer.dmg.md5</md5>
             <sha1>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-macosx-cocoa-x86_64-installer.dmg.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="mac" version="2.3.2.RELEASE" eclipse-version="3.5.2" size="315MB">
             <description>Mac OS X (Cocoa, 64bit)</description>
             <file>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-macosx-cocoa-x86_64.tar.gz</file>
             <md5>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-macosx-cocoa-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-macosx-cocoa-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.3.2.RELEASE" eclipse-version="3.5.2" size="173MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-linux-gtk-installer.sh</file>
             <md5>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-linux-gtk-installer.sh.md5</md5>
             <sha1>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-linux-gtk-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.3.2.RELEASE" eclipse-version="3.5.2" size="315MB">
             <description>Linux (GTK)</description>
             <file>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-linux-gtk.tar.gz</file>
             <md5>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-linux-gtk.tar.gz.md5</md5>
             <sha1>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-linux-gtk.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.3.2.RELEASE" eclipse-version="3.5.2" size="173MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-linux-gtk-x86_64-installer.sh</file>
             <md5>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-linux-gtk-x86_64-installer.sh.md5</md5>
             <sha1>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-linux-gtk-x86_64-installer.sh.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
         <download os="linux" version="2.3.2.RELEASE" eclipse-version="3.5.2" size="315MB">
             <description>Linux (GTK, 64bit)</description>
             <file>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-linux-gtk-x86_64.tar.gz</file>
             <md5>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-linux-gtk-x86_64.tar.gz.md5</md5>
             <sha1>release/STS/2.3.2/dist/e3.5/springsource-tool-suite-2.3.2.RELEASE-e3.5.2-linux-gtk-x86_64.tar.gz.sha1</sha1>
-            <bucket>http://download.springsource.com/</bucket>
+            <bucket>https://download.springsource.com/</bucket>
         </download>
     </other>
 </downloads>

--- a/sagan-site/src/main/resources/urlrewrite.xml
+++ b/sagan-site/src/main/resources/urlrewrite.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!DOCTYPE urlrewrite PUBLIC "-//tuckey.org//DTD UrlRewrite 4.0//EN"
-        "http://www.tuckey.org/res/dtds/urlrewrite4.0.dtd">
+        "https://www.tuckey.org/res/dtds/urlrewrite4.0.dtd">
 <!--
     Configuration file for UrlRewriteFilter. See:
-    http://www.tuckey.org/urlrewrite/
-    http://urlrewritefilter.googlecode.com/svn/trunk/src/doc/manual/4.0/guide.html
-    http://urlrewritefilter.googlecode.com/svn/trunk/src/doc/manual/4.0/index.html
+    https://www.tuckey.org/urlrewrite/
+    https://urlrewritefilter.googlecode.com/svn/trunk/src/doc/manual/4.0/guide.html
+    https://urlrewritefilter.googlecode.com/svn/trunk/src/doc/manual/4.0/index.html
     http://localhost:8080/rewrite-status (only works when running locally)
 -->
 <urlrewrite use-query-string="true">
@@ -42,7 +42,7 @@
     <rule>
         <name>Rossen's WebSocket blog post</name>
         <from>^.*/2013/07/24/spring-framework-4-0-m2-websocket-messaging-architectures/?</from>
-        <to type="temporary-redirect" last="true">http://assets.spring.io/wp/WebSocketBlogPost.html</to>
+        <to type="temporary-redirect" last="true">https://assets.spring.io/wp/WebSocketBlogPost.html</to>
     </rule>
     <rule>
         <name>YouTube</name>
@@ -51,7 +51,7 @@
         name of our youtube channel.
         </note>
         <from>/videos?</from>
-        <to type="temporary-redirect" last="true">http://www.youtube.com/springsourcedev</to>
+        <to type="temporary-redirect" last="true">https://www.youtube.com/springsourcedev</to>
     </rule>
     <rule>
         <name>GSG listing</name>
@@ -101,7 +101,7 @@
         <name>Linkedin</name>
         <note>https://github.com/spring-io/sagan/issues/222</note>
         <from>^/linkedin$</from>
-        <to type="temporary-redirect" last="true">http://www.linkedin.com/groups/46964</to>
+        <to type="temporary-redirect" last="true">https://www.linkedin.com/groups/46964</to>
     </rule>
 	<rule>
 		<name>Tools4</name>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://download.springsource.com/ (403) with 1565 occurrences migrated to:  
  https://download.springsource.com/ ([https](https://download.springsource.com/) result 403).
* http://urlrewritefilter.googlecode.com/svn/trunk/src/doc/manual/4.0/guide.html (404) with 1 occurrences migrated to:  
  https://urlrewritefilter.googlecode.com/svn/trunk/src/doc/manual/4.0/guide.html ([https](https://urlrewritefilter.googlecode.com/svn/trunk/src/doc/manual/4.0/guide.html) result 404).
* http://urlrewritefilter.googlecode.com/svn/trunk/src/doc/manual/4.0/index.html (404) with 1 occurrences migrated to:  
  https://urlrewritefilter.googlecode.com/svn/trunk/src/doc/manual/4.0/index.html ([https](https://urlrewritefilter.googlecode.com/svn/trunk/src/doc/manual/4.0/index.html) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://assets.spring.io/wp/WebSocketBlogPost.html with 1 occurrences migrated to:  
  https://assets.spring.io/wp/WebSocketBlogPost.html ([https](https://assets.spring.io/wp/WebSocketBlogPost.html) result 200).
* http://static.springsource.org/sts/nan/v310/NewAndNoteworthy.html (301) with 8 occurrences migrated to:  
  https://docs.spring.io/sts/nan/v310/NewAndNoteworthy.html ([https](https://static.springsource.org/sts/nan/v310/NewAndNoteworthy.html) result 200).
* http://static.springsource.org/sts/nan/v320/NewAndNoteworthy.html (301) with 8 occurrences migrated to:  
  https://docs.spring.io/sts/nan/v320/NewAndNoteworthy.html ([https](https://static.springsource.org/sts/nan/v320/NewAndNoteworthy.html) result 200).
* http://static.springsource.org/sts/nan/v330/NewAndNoteworthy.html (301) with 8 occurrences migrated to:  
  https://docs.spring.io/sts/nan/v330/NewAndNoteworthy.html ([https](https://static.springsource.org/sts/nan/v330/NewAndNoteworthy.html) result 200).
* http://static.springsource.org/sts/nan/v340/NewAndNoteworthy.html (301) with 8 occurrences migrated to:  
  https://docs.spring.io/sts/nan/v340/NewAndNoteworthy.html ([https](https://static.springsource.org/sts/nan/v340/NewAndNoteworthy.html) result 200).
* http://static.springsource.org/sts/nan/v350/NewAndNoteworthy.html (301) with 8 occurrences migrated to:  
  https://docs.spring.io/sts/nan/v350/NewAndNoteworthy.html ([https](https://static.springsource.org/sts/nan/v350/NewAndNoteworthy.html) result 200).
* http://static.springsource.org/sts/nan/v351/NewAndNoteworthy.html (301) with 8 occurrences migrated to:  
  https://docs.spring.io/sts/nan/v351/NewAndNoteworthy.html ([https](https://static.springsource.org/sts/nan/v351/NewAndNoteworthy.html) result 200).
* http://static.springsource.org/sts/nan/v360/NewAndNoteworthy.html (301) with 4 occurrences migrated to:  
  https://docs.spring.io/sts/nan/v360/NewAndNoteworthy.html ([https](https://static.springsource.org/sts/nan/v360/NewAndNoteworthy.html) result 200).
* http://static.springsource.org/sts/nan/v370/NewAndNoteworthy.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/sts/nan/v370/NewAndNoteworthy.html ([https](https://static.springsource.org/sts/nan/v370/NewAndNoteworthy.html) result 200).
* http://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.3.2.RELEASE.pdf with 2 occurrences migrated to:  
  https://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.3.2.RELEASE.pdf ([https](https://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.3.2.RELEASE.pdf) result 200).
* http://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.5.2.SR1.pdf with 8 occurrences migrated to:  
  https://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.5.2.SR1.pdf ([https](https://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.5.2.SR1.pdf) result 200).
* http://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.6.1.SR1.pdf with 8 occurrences migrated to:  
  https://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.6.1.SR1.pdf ([https](https://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.6.1.SR1.pdf) result 200).
* http://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.7.2.RELEASE.pdf with 6 occurrences migrated to:  
  https://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.7.2.RELEASE.pdf ([https](https://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.7.2.RELEASE.pdf) result 200).
* http://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.8.1.RELEASE.pdf with 4 occurrences migrated to:  
  https://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.8.1.RELEASE.pdf ([https](https://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.8.1.RELEASE.pdf) result 200).
* http://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.9.2.RELEASE.pdf with 6 occurrences migrated to:  
  https://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.9.2.RELEASE.pdf ([https](https://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-2.9.2.RELEASE.pdf) result 200).
* http://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-3.0.0.RELEASE.pdf with 4 occurrences migrated to:  
  https://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-3.0.0.RELEASE.pdf ([https](https://download.springsource.com/release/STS/doc/STS-new_and_noteworthy-3.0.0.RELEASE.pdf) result 200).
* http://www.linkedin.com/groups/46964 with 1 occurrences migrated to:  
  https://www.linkedin.com/groups/46964 ([https](https://www.linkedin.com/groups/46964) result 200).
* http://www.tuckey.org/res/dtds/urlrewrite4.0.dtd with 1 occurrences migrated to:  
  https://www.tuckey.org/res/dtds/urlrewrite4.0.dtd ([https](https://www.tuckey.org/res/dtds/urlrewrite4.0.dtd) result 200).
* http://www.tuckey.org/urlrewrite/ with 1 occurrences migrated to:  
  https://www.tuckey.org/urlrewrite/ ([https](https://www.tuckey.org/urlrewrite/) result 200).
* http://www.youtube.com/springsourcedev with 1 occurrences migrated to:  
  https://www.youtube.com/springsourcedev ([https](https://www.youtube.com/springsourcedev) result 301).
* http://www.springsource.org/files/uploads/all/images/icons/GG_ICO_48x48.png with 2 occurrences migrated to:  
  https://www.springsource.org/files/uploads/all/images/icons/GG_ICO_48x48.png ([https](https://www.springsource.org/files/uploads/all/images/icons/GG_ICO_48x48.png) result 302).
* http://www.springsource.org/files/uploads/all/images/icons/Spring_ICO_48x48.png with 2 occurrences migrated to:  
  https://www.springsource.org/files/uploads/all/images/icons/Spring_ICO_48x48.png ([https](https://www.springsource.org/files/uploads/all/images/icons/Spring_ICO_48x48.png) result 302).
* http://www.springsource.org/files/uploads/all/images/product/classic2-nobg.png with 5 occurrences migrated to:  
  https://www.springsource.org/files/uploads/all/images/product/classic2-nobg.png ([https](https://www.springsource.org/files/uploads/all/images/product/classic2-nobg.png) result 302).
* http://www.springsource.org/files/uploads/all/images/product/java-nobg.png with 5 occurrences migrated to:  
  https://www.springsource.org/files/uploads/all/images/product/java-nobg.png ([https](https://www.springsource.org/files/uploads/all/images/product/java-nobg.png) result 302).
* http://www.springsource.org/files/uploads/all/images/product/jee-nobg.png with 5 occurrences migrated to:  
  https://www.springsource.org/files/uploads/all/images/product/jee-nobg.png ([https](https://www.springsource.org/files/uploads/all/images/product/jee-nobg.png) result 302).
* http://www.springsource.org/files/uploads/all/images/product/rcp-nobg.png with 5 occurrences migrated to:  
  https://www.springsource.org/files/uploads/all/images/product/rcp-nobg.png ([https](https://www.springsource.org/files/uploads/all/images/product/rcp-nobg.png) result 302).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8080/rewrite-status with 1 occurrences