### PR TITLE
Update flyway to 4.2.0

### DIFF
--- a/sagan-common/build.gradle
+++ b/sagan-common/build.gradle
@@ -59,7 +59,7 @@ dependencies {
     runtime 'com.h2database:h2'
 
     // for use in on-the-fly database setup and migrations
-    compile 'org.flywaydb:flyway-core'
+    compile 'org.flywaydb:flyway-core:4.2.0'
 
     // jackson, for JSON and XML serialization
     compile "com.fasterxml.jackson.dataformat:jackson-dataformat-xml"


### PR DESCRIPTION
This is necessary *before* Spring Boot is upgraded so that the
Flyway checksums for the migrations are recalculated.