### PR TITLE
Code snippets with tab size 4 by default

### DIFF
--- a/sagan-client/src/css/asciidoctor.css
+++ b/sagan-client/src/css/asciidoctor.css
@@ -111,3 +111,7 @@ table.tableblock {
 .tableblock tr:nth-child(even) > td {
     background-color: #f9f9f9
 }
+
+pre.prettyprint {
+  tab-size: 4;
+}


### PR DESCRIPTION
Came out as the result of the conversation here: https://pivotal.slack.com/archives/C064D3HPZ/p1574414987039400