### PR TITLE
de-hyphenated

### DIFF
--- a/sagan-site/src/main/resources/templates/pages/event-driven.html
+++ b/sagan-site/src/main/resources/templates/pages/event-driven.html
@@ -3,8 +3,8 @@
       layout:decorator="layout">
 <head>
     <title>Spring | Event Driven</title>
-    <meta property='og:title' content='Event-driven architectures'/>
-    <meta property='og:description' content='Event-driven systems reflect how modern businesses actually work–thousands of small changes happening all day, every day. Spring’s ability to handle events and easily build applications around them, allows your apps to stay in sync with your business.'/>
+    <meta property='og:title' content='Event driven architectures'/>
+    <meta property='og:description' content='Event driven systems reflect how modern businesses actually work–thousands of small changes happening all day, every day. Spring’s ability to handle events and easily build applications around them, allows your apps to stay in sync with your business.'/>
 </head>
 <body id='event-driven'>
 <div layout:fragment="~{content}">
@@ -16,7 +16,7 @@
             <h1 class='h1'>Event Driven</h1>
             <div class='flex jc-between topic-hero'>
                 <div class='left m-0 topic-info'>
-                    <p class='big'>Event-driven systems reflect how modern businesses actually work–thousands of small changes happening all day, every day. Spring’s ability to handle events and enable developers to build applications around them, means your apps will stay in sync with your business. Spring has a number of event-driven options to choose from, from integration and streaming all the way to cloud functions and data flows.</p>
+                    <p class='big'>Event driven systems reflect how modern businesses actually work–thousands of small changes happening all day, every day. Spring’s ability to handle events and enable developers to build applications around them, means your apps will stay in sync with your business. Spring has a number of event driven options to choose from, from integration and streaming all the way to cloud functions and data flows.</p>
                 </div>
                 <img class='as-fs topic-icon' th:src="@{/images/streams.svg}" alt=''>
             </div>
@@ -24,8 +24,8 @@
         <section class='container'>
             <div id='trio' class='flex jc-between py-50'>
                 <div class='third'>
-                    <h3 class='h3'>Event-driven microservices</h3>
-                        <p>When combined with microservices, event streaming opens up exciting opportunities&mdash;event-driven architecture being one common example. Spring simplifies the production, processing, and consumption of events, providing several useful abstractions.</p>
+                    <h3 class='h3'>Event driven microservices</h3>
+                        <p>When combined with microservices, event streaming opens up exciting opportunities&mdash;event driven architecture being one common example. Spring simplifies the production, processing, and consumption of events, providing several useful abstractions.</p>
                 </div>
                 <div class='third'>
                     <h3 class='h3'>Streaming data</h3>
@@ -33,7 +33,7 @@
                 </div>
                 <div class='third'>
                     <h3 class='h3'>Integration</h3>
-                        <p>The bedrock of any event-driven system is  message handling. Connecting to message platforms, routing messages, transforming messages, processing messages. With  Spring you can solve these integration challenges quickly.</p>
+                        <p>The bedrock of any event driven system is message handling. Connecting to message platforms, routing messages, transforming messages, processing messages. With  Spring you can solve these integration challenges quickly.</p>
                 </div>
             </div>
         </section>


### PR DESCRIPTION
I de-hyphenated the use of event-driven here in order to be consistent with the rest of the site. Generally, hyphenation would apply to verb-noun combinations, so it needn't be applied to 'event driven'.