### PR TITLE
fix verbose stack Error: sagan@ build: `webpack`

### DIFF
--- a/sagan-client/package.json
+++ b/sagan-client/package.json
@@ -19,6 +19,7 @@
     "copy-webpack-plugin": "^5.0.5",
     "css-loader": "^3.2.1",
     "file-loader": "^5.0.2",
+    "url-loader": "3.0.0",
     "mini-css-extract-plugin": "^0.8.0",
     "optimize-css-assets-webpack-plugin": "^5.0.3",
     "robotstxt-webpack-plugin": "^7.0.0",

--- a/sagan-client/webpack.config.js
+++ b/sagan-client/webpack.config.js
@@ -104,7 +104,11 @@ module.exports = {
                 options: {
                     name: '[path][name].[ext]',
                 },
-            }
+            },
+            {
+                test: /\.(png|woff|woff2|eot|ttf|svg)$/,
+                loader: 'url-loader?limit=100000'
+             }
         ]
     },
     optimization: {


### PR DESCRIPTION
fixing verbose stack Error: sagan@ build: `webpack` issue 
node version v13.9.0
npm version 6.13.7 (also works and for node version 13.2.0)