### PR TITLE
bug fix of Webpack module build failed (MiniCssExtractPlugin)

### DIFF
--- a/sagan-client/package.json
+++ b/sagan-client/package.json
@@ -21,6 +21,7 @@
     "copy-webpack-plugin": "^5.0.5",
     "css-loader": "^3.2.1",
     "file-loader": "^5.0.2",
+    "url-loader": "^4.0.0",
     "mini-css-extract-plugin": "^0.8.0",
     "optimize-css-assets-webpack-plugin": "^5.0.3",
     "robotstxt-webpack-plugin": "^7.0.0",

--- a/sagan-client/webpack.config.js
+++ b/sagan-client/webpack.config.js
@@ -104,6 +104,16 @@ module.exports = {
                 options: {
                     name: '[path][name].[ext]',
                 },
+            },
+            {
+                test: /\.(jpg|png|gif|woff|eot|ttf|svg)/,
+                use: {
+                    loader: 'url-loader',
+                    options: {
+                        limit: 50000
+
+                    }
+                }
             }
         ]
     },


### PR DESCRIPTION
**url-loader** package is needed for font-face and also svg files used as url inside main.css and other files