### PR TITLE
Fix bug - Find a guide should filter all the guides

### DIFF
--- a/sagan-site/src/main/resources/templates/guides/index.html
+++ b/sagan-site/src/main/resources/templates/guides/index.html
@@ -64,7 +64,7 @@
                     <p class='guide-description m-0'>Designed to be read and comprehended in an hour or less, providing more wide-ranging or subjective content than a getting started guide.</p>
                 </div>
                 <section id='topical-guides-list' class='flex jc-between flex-wrap'>
-                    <div data-th-each="topical : ${topicals}" class='guide half border-box flex' data-th-attr="data-filterable=${topical.title}+' '+${topical.description}">
+                    <div data-th-each="topical : ${topicals}" class='guide guide-search half border-box flex' data-th-attr="data-filterable=${topical.title}+' '+${topical.description}">
                         <div class="guide-icon" data-th-insert="~{svg/_icons :: icon-guides-topic}"></div>
                         <div class='text'>
                             <a class='guide-link bold blue link-darken antialiased' data-th-href="@{'/guides/topicals/'+${topical.name}+'/'}" data-th-text="${topical.title}">Spring Security Architecture</a>
@@ -81,7 +81,7 @@
                     <p class='guide-description m-0'>Designed to be completed in 2-3 hours, these guides provide deeper, in-context explorations of enterprise application development topics, leaving you ready to implement real-world solutions.</p>
                 </div>
                 <section id='tutorials-list' class='flex jc-between flex-wrap'>
-                    <div data-th-each="tutorial : ${tutorials}" class='guide half border-box flex' data-th-attr="data-filterable=${tutorial.title}+' '+${tutorial.description}">
+                    <div data-th-each="tutorial : ${tutorials}" class='guide guide-search half border-box flex' data-th-attr="data-filterable=${tutorial.title}+' '+${tutorial.description}">
                         <div class="guide-icon" data-th-insert="~{svg/_icons :: icon-guides-tutorial}"></div>
                         <div class='text'>
                             <a class='guide-link bold blue link-darken antialiased' data-th-href="@{'/guides/tutorials/'+${tutorial.name}+'/'}" data-th-text="${tutorial.title}">Building REST services with Spring</a>


### PR DESCRIPTION
- Added `guide-search` class to all the guides `div`
  and as javascript code is written in a way that it will start considering
  these new `div` as well for filtering

Fixes gh-1001

After these changes it filters guides in all three sections, and on filtering it looks something like this
@bclozel is this good ?

![screenshot.png](https://user-images.githubusercontent.com/4180238/123466344-dbc4ee00-d60c-11eb-881a-d03d78e65958.png)

