### PR TITLE
Update the security policy redirection and security.txt

### DIFF
--- a/sagan-site/src/main/resources/public/.well-known/security.txt
+++ b/sagan-site/src/main/resources/public/.well-known/security.txt
@@ -1,2 +1,6 @@
+Contact: mailto:security@vmware.com
 Contact: https://spring.io/security-policy
+Contact: https://tanzu.vmware.com/security
+Expires: 2023-08-31T22:00:00.000Z
+Encryption: https://kb.vmware.com/s/article/1055
 Policy: https://spring.io/security-policy

--- a/sagan-site/src/main/resources/urlrewrite.xml
+++ b/sagan-site/src/main/resources/urlrewrite.xml
@@ -13,7 +13,7 @@
 		<name>Security page</name>
 		<note>https://github.com/spring-io/sagan/issues/1015</note>
 		<from>^/security-policy$</from>
-		<to type="temporary-redirect" last="true">https://tanzu.vmware.com/security</to>
+		<to type="temporary-redirect" last="true">https://www.vmware.com/support/policies/security_response.html</to>
 	</rule>
     <rule>
         <name>Support renamed mongodb GS guide</name>

--- a/sagan-site/src/test/java/sagan/site/support/rewrite/RewriteTests.java
+++ b/sagan-site/src/test/java/sagan/site/support/rewrite/RewriteTests.java
@@ -156,7 +156,7 @@ public class RewriteTests {
 
 	@Test
 	void tanzuSecurityPolicy() throws Exception {
-		validateTemporaryRedirect("https://spring.io/security-policy", "https://tanzu.vmware.com/security");
+		validateTemporaryRedirect("https://spring.io/security-policy", "https://www.vmware.com/support/policies/security_response.html");
 	}
 
 	@Test


### PR DESCRIPTION
The redirection now points directly to a page describing the security
policy of VMware, rather than a page listing CVEs.

The security.txt is updated to:
 1. put the vmware security email as the primary mean of disclosure
 2. link to spring.io's (temporary) redirection as an alternative
 3. link to the old redirection as a third alternative
 4. add a link to a KB page containing PGP public key for secure email
 communications when disclosing
 5. add an Expires entry to conform to the latest update to the spec
