### PR TITLE
Matching disqus link styling to the blog posts

### DIFF
--- a/sagan-client/src/css/blog.css
+++ b/sagan-client/src/css/blog.css
@@ -165,10 +165,10 @@ article:last-child {
         display: block;
     }
 }
-.blog--post a {
+.blog--post a, #disqus_thread a {
     color: #086dc3;
 }
-.blog--post a:hover {
+.blog--post a:hover, #disqus_thread a:hover {
     color: #333;
 }
 .blog--wrapper {


### PR DESCRIPTION
In response to [Issue 984](https://github.com/spring-io/sagan/issues/984), I've edited the rules for blog post link styles to apply to links in disqus comments as well.
Targeted the `#disqus_thread` element on advice from the [disqus docs](https://help.disqus.com/en/articles/1717201-disqus-appearance-customizations#link-color)