### PR TITLE
Consistent line height between standard paragraphs and bullet lists

### DIFF
--- a/sagan-client/src/css/blog.css
+++ b/sagan-client/src/css/blog.css
@@ -209,6 +209,7 @@ article:last-child {
 
 .blog--post ul li {
     margin: 12px 0;
+    line-height: 1.7em;
 }
 
 .blog--post pre.prettyprint {


### PR DESCRIPTION
Prior to this change the line height in a blog post's bullet list was smaller than in standard paragraphs.

Before:
![Screenshot 2022-03-22 at 13 56 10](https://user-images.githubusercontent.com/128577/159487502-c328fad3-cf19-4ae6-a360-f7fcc75febe6.png)
After:
![Screenshot 2022-03-22 at 13 56 21](https://user-images.githubusercontent.com/128577/159487529-f416d40f-eb12-454e-b857-9fbf44a9fc07.png)

