### PR TITLE
issue#1054 - fix for turning Github box dark highlighted background i…

### DIFF
--- a/sagan-client/src/css/dark.scss
+++ b/sagan-client/src/css/dark.scss
@@ -463,7 +463,7 @@ body.dark {
     color: $dark-background;
   }
 
-  .admonitionblock, &.guide main .right-pane-widget--container {
+  .admonitionblock, &#guide main .right-pane-widget--container {
     background: $dark-highlight-background;
   }
 


### PR DESCRIPTION
This is the fix for issue #1054 - which will turn the Github repository box on the right dark highlighted background. It will make the Github repository box as follows. 

<img width="1225" alt="sagan-screenshot" src="https://user-images.githubusercontent.com/102477169/161156874-d75476dd-448a-45c9-a22a-e663e80e7916.png">
