### PR TITLE
Update link to Spring certification

### DIFF
--- a/sagan-site/src/main/resources/templates/pages/training.html
+++ b/sagan-site/src/main/resources/templates/pages/training.html
@@ -61,13 +61,13 @@
                 <h2 class='h2 antialiased'>Certification</h2>
                 <div class='course border-dark rad-5 border-box mb-2 bg-white'>
                     <div class='course-title flex ai-center'>
-                        <a class='h3 link-darken blue antialiased' href='https://tanzu.vmware.com/training/certification/spring-professional-certification'>Spring Professional Certification</a>
+                        <a class='h3 link-darken blue antialiased' href='https://www.vmware.com/learning/certification/vcp-am-dev.html'>Spring Professional Certification</a>
                     </div>
                     <div class='course-details flex jc-between'>
                         <div class='course-description'>
                             <p class='m-0'>The Spring Professional certification exam is designed to test and validate your understanding of and familiarity with core aspects of Spring such as:</p><ul><li>Container basics</li><li>Aspect Oriented Programming (AOP)</li><li>Data access and transactions</li><li>Spring model-view-controller (MVC)</li></ul>
                         </div>
-                        <a href='https://tanzu.vmware.com/training/certification/spring-professional-certification' target='_blank' class='as-fs button uppercase transparent animate'>Learn more <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><polyline points="15 10.94 15 15 1 15 1 1 5.06 1" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="2"/><polyline points="8.93 1 15 1 15 7.07" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="2"/><line x1="15" y1="1" x2="8" y2="8" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="2"/></svg></a>
+                        <a href='https://www.vmware.com/learning/certification/vcp-am-dev.html' target='_blank' class='as-fs button uppercase transparent animate'>Learn more <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><polyline points="15 10.94 15 15 1 15 1 1 5.06 1" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="2"/><polyline points="8.93 1 15 1 15 7.07" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="2"/><line x1="15" y1="1" x2="8" y2="8" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="2"/></svg></a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
The current Spring certification link redirects to the main VMware certification page.

As part of the VMware rebranding, the link was moved to https://www.vmware.com/learning/certification/vcp-am-dev.html.