### PR TITLE
Enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  # For dependencies declared with Gradle
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  # For dependencies declared with npm
+  - package-ecosystem: "npm"
+    directory: "/sagan-client/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
There are quite a few outdated dependencies in this project which should be upgraded. Generally it is a good practice to let a tool like Dependabot do a lot of the work for you.

This PR adds a config that will upgrade dependencies defined via Gradle or npm.

I know this will trigger quite a few PRs initially but I'm happy to assist with working through them.